### PR TITLE
Mat-176 development tools. Adding command line property to allow alternative location for config file and then native libraries to load from system locations.

### DIFF
--- a/src/java/src/main/java/com/opengamma/longdog/nativeloader/NativeLibraries.java
+++ b/src/java/src/main/java/com/opengamma/longdog/nativeloader/NativeLibraries.java
@@ -114,14 +114,14 @@ public final class NativeLibraries {
     InputStream propsFile = null;
 
     // Is the config file location overridden?
-    String commandLineConfigLoc = System.getProperty("configfileloc");
+    String commandLineConfig = System.getProperty("configFile");
 
-    if (commandLineConfigLoc != null) { // yes we are using a config file specified on the command line
+    if (commandLineConfig != null) { // yes we are using a config file specified on the command line
       s_commandlineconfig = true;
       if (s_debug) {
         System.out.println("Using command line supplied configfileloc information");
       }
-      s_configFileLocation = commandLineConfigLoc;
+      s_configFileLocation = commandLineConfig;
       try {
         if (s_debug) {
           System.out.println("Attempting load from " + s_configFileLocation);

--- a/src/java/src/main/java/com/opengamma/longdog/nativeloader/NativeLibraries.java
+++ b/src/java/src/main/java/com/opengamma/longdog/nativeloader/NativeLibraries.java
@@ -5,10 +5,17 @@
  */
 package com.opengamma.longdog.nativeloader;
 
+import static java.nio.file.Files.createTempDirectory;
+
+import java.io.BufferedOutputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.URL;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -17,17 +24,17 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.nio.file.Path;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.BufferedOutputStream;
+
 import com.opengamma.longdog.exceptions.LongdogInitializationException;
 import com.opengamma.longdog.exceptions.LongdogUnsupportedPlatformException;
 
-import static java.nio.file.Files.createTempDirectory;
-
 /**
- * Used for extracting and loading native libraries from the JAR file.
+ * Used for extracting and loading native libraries.
+ * 
+ * Default behaviour is to extract and load libraries from the JAR file. 
+ * Optionally, the location of the config file that specifies the libraries to be loaded can
+ * be given on the command line as -Dconfigfileloc="location/file" in which case the
+ * libraries are loaded from system specific library path based locations.
  *
  * The correct libraries are extracted and loaded depending on the architecture
  * that we are running on.
@@ -42,6 +49,10 @@ public final class NativeLibraries {
   private static boolean s_debug = true;
   private static List<String> s_libsToExtract = new ArrayList<String>();
   private static List<String> s_libsToLoad = new ArrayList<String>();
+  /* properties file location, defaults to jar, can be overridden on command line */
+  private static String s_configFileLocation = "/config/NativeLibraries.properties";
+  /* true if config was supplied on the command line */
+  private static boolean s_commandlineconfig;
 
   /**
    * Check whether the current platform is supported.
@@ -101,11 +112,30 @@ public final class NativeLibraries {
     Properties nativeLibrariesProperties = new Properties();
 
     InputStream propsFile = null;
-    propsFile = NativeLibraries.class.getResourceAsStream("/config/NativeLibraries.properties");
-    if (propsFile == null) {
-      throw new LongdogInitializationException("Cannot find NativeLibraries properties file");
-    }
 
+    // Is the config file location overridden?
+    String commandLineConfigLoc = System.getProperty("configfileloc");
+
+    if (!commandLineConfigLoc.isEmpty()) { // yes we are using a config file specified on the command line
+      s_commandlineconfig = true;
+      if (s_debug) {
+        System.out.println("Using command line supplied configfileloc information");
+      }
+      s_configFileLocation = commandLineConfigLoc;
+      try {
+        if (s_debug) {
+          System.out.println("Attempting load from " + s_configFileLocation);
+        }
+        propsFile = new FileInputStream(s_configFileLocation);
+      } catch (IOException ex) {
+        throw new LongdogInitializationException("Cannot find NativeLibraries properties file in command line specified location: " + s_configFileLocation);
+      }
+    } else { // we are using the default config file location in the JAR
+      propsFile = NativeLibraries.class.getResourceAsStream(s_configFileLocation);
+      if (propsFile == null) {
+        throw new LongdogInitializationException("Cannot find NativeLibraries properties file in location: " + s_configFileLocation);
+      }
+    }
     try {
       nativeLibrariesProperties.load(propsFile);
     } catch (IOException e) {
@@ -166,75 +196,77 @@ public final class NativeLibraries {
     checkPlatformSupported();
     getConfigFromProperties();
 
-    Path libDir;
-    try {
-      libDir = createTempDirectory("og-mathswrappers-");
-      libDir.toFile().deleteOnExit();
-    } catch (IOException e) {
-      throw new LongdogInitializationException("Could not create temp directory for native libaries", e);
-    }
-    s_tmpDir = libDir.toString();
+    if (!s_commandlineconfig) {
+      Path libDir;
+      try {
+        libDir = createTempDirectory("og-mathswrappers-");
+        libDir.toFile().deleteOnExit();
+      } catch (IOException e) {
+        throw new LongdogInitializationException("Could not create temp directory for native libaries", e);
+      }
+      s_tmpDir = libDir.toString();
 
-    String url = "/lib";
+      String url = "/lib";
 
-    Class<?> c = NativeLibraries.class;
-    for (String name : s_libsToExtract) {
+      Class<?> c = NativeLibraries.class;
+      for (String name : s_libsToExtract) {
+        if (s_debug) {
+          System.out.println("Extracting " + name);
+        }
+        String fsPath = libDir + "/" + name;
+        String jarPath = url + "/" + getShortPlatform() + "/" + name;
+
+        URL jarURL = c.getResource(jarPath);
+        if (jarURL == null) {
+          throw new LongdogInitializationException("Resource " + jarPath + " not found in jar file");
+        }
+
+        InputStream source = null;
+        OutputStream destination = null;
+        try {
+          source = c.getResourceAsStream(jarPath);
+          destination = new BufferedOutputStream(new FileOutputStream(fsPath));
+          byte[] buffer = new byte[1024 * 1024];
+          int len;
+          boolean haveReadBytes = false;
+          while ((len = source.read(buffer)) != -1) {
+            if (!haveReadBytes && (len == 0)) {
+              throw new LongdogInitializationException("0 bytes read for resource" + name);
+            }
+            haveReadBytes = true;
+            destination.write(buffer, 0, len);
+          }
+        } catch (Exception e) {
+          throw new LongdogInitializationException("Error extracting resource " + name, e);
+        } finally {
+          if (source != null) {
+            try {
+              source.close();
+            } catch (IOException e) {
+              throw new LongdogInitializationException("Error closing source stream for " + name, e);
+            }
+          }
+          if (destination != null) {
+            try {
+              destination.close();
+            } catch (IOException e) {
+              throw new LongdogInitializationException("Error closing destination stream for " + name, e);
+            }
+          }
+        }
+
+        File file = new File(fsPath);
+
+        try {
+          file.deleteOnExit();
+        } catch (SecurityException e) {
+          throw new LongdogInitializationException("Security settings prevent deletion of native libraries on exit", e);
+        }
+      }
       if (s_debug) {
-        System.out.println("Extracting " + name);
+        System.out.println("Native libraries extracted");
       }
-      String fsPath = libDir + "/" + name;
-      String jarPath = url + "/" + getShortPlatform() + "/" + name;
-
-      URL jarURL = c.getResource(jarPath);
-      if (jarURL == null) {
-        throw new LongdogInitializationException("Resource " + jarPath + " not found in jar file");
-      }
-
-      InputStream source = null;
-      OutputStream destination = null;
-      try {
-        source = c.getResourceAsStream(jarPath);
-        destination = new BufferedOutputStream(new FileOutputStream(fsPath));
-        byte[] buffer = new byte[1024 * 1024];
-        int len;
-        boolean haveReadBytes = false;
-        while ((len = source.read(buffer)) != -1) {
-          if (!haveReadBytes && (len == 0)) {
-            throw new LongdogInitializationException("0 bytes read for resource" + name);
-          }
-          haveReadBytes = true;
-          destination.write(buffer, 0, len);
-        }
-      } catch (Exception e) {
-        throw new LongdogInitializationException("Error extracting resource " + name, e);
-      } finally {
-        if (source != null) {
-          try {
-            source.close();
-          } catch (IOException e) {
-            throw new LongdogInitializationException("Error closing source stream for " + name, e);
-          }
-        }
-        if (destination != null) {
-          try {
-            destination.close();
-          } catch (IOException e) {
-            throw new LongdogInitializationException("Error closing destination stream for " + name, e);
-          }
-        }
-      }
-
-      File file = new File(fsPath);
-
-      try {
-        file.deleteOnExit();
-      } catch (SecurityException e) {
-        throw new LongdogInitializationException("Security settings prevent deletion of native libraries on exit", e);
-      }
-    }
-    if (s_debug) {
-      System.out.println("Native libraries extracted");
-    }
+    } // end if(!s_commandlineconfig)
 
     for (String name : s_libsToLoad) {
       load(name);
@@ -251,16 +283,37 @@ public final class NativeLibraries {
    */
   private static synchronized void load(String lib) {
 
-    String libPath = s_tmpDir + File.separatorChar + lib;
-
-    try {
-      if (s_debug) {
-        System.out.println("Loading " + lib + " from " + libPath);
+    if (!s_commandlineconfig) { // we are using the config from the file in the jar
+      String libPath = s_tmpDir + File.separatorChar + lib;
+      try {
+        if (s_debug) {
+          System.out.println("Loading " + lib + " from " + libPath);
+        }
+        System.load(libPath);
+      } catch (Exception e) {
+        throw new LongdogInitializationException("Cannot load " + lib + " as " + libPath, e);
       }
-      System.load(libPath);
-    } catch (Exception e) {
-      throw new LongdogInitializationException("Cannot load " + lib + " as " + libPath, e);
+    } else { // we are using a command line specified config location
+      Pattern pat = Pattern.compile("lib(\\w+)..*"); // compile pattern to strip lib and .* from library name
+      Matcher m = pat.matcher(lib);
+      if (!m.matches()) {
+        throw new LongdogInitializationException("Could not extract library name from lib string.");
+      }
+      String libsimplename = m.group(1); // single group
+      if (libsimplename == null) {
+        throw new LongdogInitializationException("Could not extract system invariant library name from library name string.");
+      }
+      try {
+        if (s_debug) {
+          System.out.println("Loading " + libsimplename + " from native library locations.");
+        }
+        System.loadLibrary(libsimplename);
+      } catch (Exception e) {
+        throw new LongdogInitializationException("Cannot load " + libsimplename + " from native library locations", e);
+      }
+
     }
+
   }
 
   private NativeLibraries() {

--- a/src/java/src/main/java/com/opengamma/longdog/nativeloader/NativeLibraries.java
+++ b/src/java/src/main/java/com/opengamma/longdog/nativeloader/NativeLibraries.java
@@ -116,7 +116,7 @@ public final class NativeLibraries {
     // Is the config file location overridden?
     String commandLineConfigLoc = System.getProperty("configfileloc");
 
-    if (!commandLineConfigLoc.isEmpty()) { // yes we are using a config file specified on the command line
+    if (commandLineConfigLoc != null) { // yes we are using a config file specified on the command line
       s_commandlineconfig = true;
       if (s_debug) {
         System.out.println("Using command line supplied configfileloc information");


### PR DESCRIPTION
##### This is a development tooling fix.

Added code that reads a `-DconfigFile="foo"` property from the command line to specify the config file from which libraries shall be read. Adding this option also means the code will look in native library locations for native libraries opposed to within the jar build.

Test pass: [http://devmaths-lx-1:8011/builders/nyqwk2-testing/builds/17](http://devmaths-lx-1:8011/builders/nyqwk2-testing/builds/17)
