### PR TITLE
Compile with warnings/errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,15 +37,15 @@ set(longdog_VERSION
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules ${CMAKE_MODULE_PATH})
 
 # tweak flags
-set(CMAKE_C_FLAGS "-ffast-math -O2 -march=core2 -funroll-loops ${CMAKE_C_FLAGS}")
-set(CMAKE_C_FLAGS_DEBUG "-ffast-math -O2 -march=core2 -funroll-loops ${CMAKE_C_FLAGS_DEBUG}")
-set(CMAKE_C_FLAGS_RELEASE "-ffast-math -O2 -march=core2 -funroll-loops ${CMAKE_C_FLAGS_RELEASE}")
-set(CMAKE_C_FLAGS_RELWITHDEBINFO "-ffast-math -O2 -march=core2 -funroll-loops ${CMAKE_C_FLAGS_RELWITHDEBINFO}")
+set(CMAKE_C_FLAGS "-std=c99 -Wall -Werror -Wextra -pedantic ${CMAKE_C_FLAGS}")
+set(CMAKE_C_FLAGS_DEBUG "-DDEBUG ${CMAKE_C_FLAGS_DEBUG}")
+set(CMAKE_C_FLAGS_RELEASE "-ffast-math -O2 -march=core2 -funroll-loops -DNDEBUG")
+set(CMAKE_C_FLAGS_RELWITHDEBINFO "-ffast-math -march=core2 -funroll-loops ${CMAKE_C_FLAGS_RELWITHDEBINFO}")
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -ffast-math -O2 -march=core2 -funroll-loops ${CMAKE_CXX_FLAGS}")
-set(CMAKE_CXX_FLAGS_DEBUG "-std=c++11 -ffast-math -O2 -march=core2 -funroll-loops ${CMAKE_CXX_FLAGS_DEBUG}")
-set(CMAKE_CXX_FLAGS_RELEASE "-std=c++11 -ffast-math -O2 -march=core2 -funroll-loops ${CMAKE_CXX_FLAGS_RELEASE}")
-set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-std=c++11 -ffast-math -O2 -march=core2 -funroll-loops ${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+set(CMAKE_CXX_FLAGS "-std=c++11 -Wall -Werror -Wextra -pedantic ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS_DEBUG "-DDEBUG ${CMAKE_CXX_FLAGS_DEBUG}")
+set(CMAKE_CXX_FLAGS_RELEASE "-ffast-math -O2 -march=core2 -funroll-loops -DNDEBUG")
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-ffast-math -march=core2 -funroll-loops ${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
 
 
 # Add Java
@@ -86,15 +86,21 @@ message("Build type: " ${CMAKE_BUILD_TYPE})
 
 message("
   Package " ${CMAKE_PROJECT_NAME} " version " ${OGMW_VERSION} "
-  Prefix...................: " ${CMAKE_INSTALL_PREFIX} "
-  C Compiler...............: " ${CMAKE_C_COMPILER} "
-  C Flags..................: " ${CMAKE_C_FLAGS} "
-  C Flags (release)........: " ${CMAKE_C_FLAGS_RELEASE} "
-  C Flags (debug)..........: " ${CMAKE_C_FLAGS_DEBUG} "
-  Java Compiler............: " ${Java_JAVAC_EXECUTABLE} "
-  Java Compiler flags......: " ${CMAKE_Java_COMPILE_FLAGS} "
-  JavaH Tool...............: " ${Java_JAVAH_EXECUTABLE} "
-  Jar Tool.................: " ${Java_JAR_EXECUTABLE} "
-  Python executable........: " ${PYTHON_EXECUTABLE} "
+  Prefix.....................: " ${CMAKE_INSTALL_PREFIX} "
+  C Compiler.................: " ${CMAKE_C_COMPILER} "
+  C Flags....................: " ${CMAKE_C_FLAGS} "
+  C Flags (release)..........: " ${CMAKE_C_FLAGS_RELEASE} "
+  C Flags (debug)............: " ${CMAKE_C_FLAGS_DEBUG} "
+  C Flags (relwithdebinfo)...: " ${CMAKE_C_FLAGS_RELWITHDEBINFO} "
+  C++ Compiler...............: " ${CMAKE_CXX_COMPILER} "
+  C++ Flags..................: " ${CMAKE_CXX_FLAGS} "
+  C++ Flags (release)........: " ${CMAKE_CXX_FLAGS_RELEASE} "
+  C++ Flags (debug)..........: " ${CMAKE_CXX_FLAGS_DEBUG} "
+  C++ Flags (relwithdebinfo).: " ${CMAKE_CXX_FLAGS_RELWITHDEBINFO} "
+  Java Compiler..............: " ${Java_JAVAC_EXECUTABLE} "
+  Java Compiler flags........: " ${CMAKE_Java_COMPILE_FLAGS} "
+  JavaH Tool.................: " ${Java_JAVAH_EXECUTABLE} "
+  Jar Tool...................: " ${Java_JAR_EXECUTABLE} "
+  Python executable..........: " ${PYTHON_EXECUTABLE} "
   ")
 

--- a/include/bindings.hh
+++ b/include/bindings.hh
@@ -187,7 +187,7 @@ template <class T> class OGScalar: public OGNumeric
     OGScalar() {};
     OGScalar(T data)
     {
-      this._value=data;
+      this->_value=data;
     };
     void accept(Visitor &v)
     {
@@ -275,7 +275,7 @@ template <typename T> class OGMatrix: public OGArray<T>
     OGMatrix(T * data, int rows, int cols)
     {
       this->_datalen = rows*cols;
-      T * tmpdata =new T [this.getDatalen()];
+      T * tmpdata =new T [this->getDatalen()];
       memcpy(tmpdata, data, sizeof(T)*this->_datalen);
       this->_data=tmpdata;
       this->_rows=rows;

--- a/include/expression.hh
+++ b/include/expression.hh
@@ -1,45 +1,31 @@
+/**
+ * Copyright (C) 2012 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+#ifndef _EXPRESSION_HH
+#define _EXPRESSION_HH
+
 // bindings
 #include <iostream>
 #include <cstring>
 #include <cstdlib>
-#include <complex>
 #include <vector>
 #include <memory>
 
+#include "numerictypes.hh"
+#include "visitor.hh"
+
 using namespace std;
 
-typedef complex<double> complex16;
-typedef complex<float> complex8;
-typedef double real16;
-typedef float real8;
+
 
 /*
- * The namespace for the
+ * The namespace for the DAG library
  */
 namespace librdag
 {
-
-/*
- * Forward declare types for visitor class
- */
-class OGExpr;
-template  <typename T> class OGArray;
-template  <typename T> class OGMatrix;
-template  <typename T> class OGScalar;
-
-/*
- * Pure function visitor class to access all fundamental types
- */
-class Visitor
-{
-  public:
-    virtual void visit(OGExpr *thing) = 0;
-    virtual void visit(OGArray<real16> *thing) = 0;
-    virtual void visit(OGArray<complex16> *thing) = 0;
-    virtual void visit(OGMatrix<real16> *thing) = 0;
-    virtual void visit(OGScalar<real16> *thing) = 0;
-    virtual void visit(OGScalar<complex16> *thing) = 0;
-};
 
 /*
  * Base class for absolutely everything!
@@ -47,144 +33,91 @@ class Visitor
 class OGNumeric
 {
   public:
-    OGNumeric() {};
-    ~OGNumeric()
-    {
-      printf("in OGNumeric destructor\n");
-    };
-    virtual void debug_print()
-    {
-      printf("Abstract OGNumeric type\n");
-    }
+    OGNumeric();
+    virtual ~OGNumeric();
+    virtual void debug_print();
     virtual void accept(Visitor &v)=0;
 };
 
 /**
- *  expr type
+ *  Expr type
  */
 class OGExpr: public OGNumeric
 {
   public:
-    OGExpr() {};
-    explicit OGExpr(OGExpr& copy)
-    {
-      this->_args = new std::vector<OGNumeric *>(*copy.getArgs());
-    }
-    OGExpr& operator=(OGExpr& rhs)
-    {
-      rhs.setArgs(this->getArgs());
-      return *this;
-    }
-    OGExpr(const librdag::OGNumeric * const args, const int nargs)
-    {
-      for(size_t i = 0; i < nargs; i++)
-      {
-        this->_args->push_back(const_cast<OGNumeric *> (&args[i]));
-      }
-    };
-    virtual ~OGExpr()
-    {
-      for (std::vector<OGNumeric *>::iterator it = this->_args->begin() ; it != this->_args->end(); it++)
-      {
-        delete &it;
-      }
-      delete this->_args;
-    };
-    std::vector<OGNumeric *> * getArgs()
-    {
-      return this->_args;
-    };
-    // should replace this with a construct from vector
-    void setArgs(std::vector<OGNumeric *> * args)
-    {
-      _args = args;
-    };
-    size_t getNArgs()
-    {
-      return this->_args->size();
-    };
-    void debug_print()
-    {
-      printf("OGExpr base class\n");
-    }
-    void accept(Visitor &v)
-    {
-      v.visit(this);
-    };
+    OGExpr();
+    explicit OGExpr(OGExpr& copy);
+    OGExpr(const librdag::OGNumeric * const args, const int nargs);
+    virtual ~OGExpr();
+
+    OGExpr& operator=(OGExpr& rhs);
+
+    std::vector<OGNumeric *> * getArgs();
+    // FIXME: should replace this with a construct from vector
+    void setArgs(std::vector<OGNumeric *> * args);
+    size_t getNArgs();
+    virtual void debug_print();
+    void accept(Visitor &v);
   private:
     std::vector<OGNumeric *> * _args = NULL;
 };
 
 /**
- * Things what extend OGExpr
+ * Things that extend OGExpr
  */
 
 class COPY: virtual public OGExpr
 {
   public:
-    COPY()
-    {
-    };
-    void debug_print()
-    {
-      printf("COPY base class\n");
-    }
+    COPY();
+    void debug_print();
 };
 
 
 class PLUS: virtual public OGExpr
 {
   public:
-    PLUS() {};
-    void debug_print()
-    {
-      printf("PLUS base class\n");
-    }
+    PLUS();
+    void debug_print();
 };
 
 
 class MINUS: virtual public OGExpr
 {
   public:
-    MINUS() {};
-    void debug_print()
-    {
-      printf("MINUS base class\n");
-    }
+    MINUS();
+    void debug_print();
 };
 
 class SVD: virtual public OGExpr
 {
   public:
-    SVD() {};
-    void debug_print()
-    {
-      printf("SVD base class\n");
-    }
+    SVD();
+    void debug_print();
 };
 
 class SELECTRESULT: virtual public OGExpr
 {
   public:
-    SELECTRESULT() {};
-    void debug_print()
-    {
-      printf("SELECTRESULT base class\n");
-    }
+    SELECTRESULT();
+    void debug_print();
 };
 
 /**
- * Things what extend OGScalar
+ * Things that extend OGScalar
  */
 template <class T> class OGScalar: public OGNumeric
 {
+  private:
     T _value;
   public:
+    OGScalar() {};
+
     OGScalar(const OGScalar& copy)
     {
-      copy._value=_value;
+      copy._value= this->_value;
     }
-    OGScalar() {};
+
     OGScalar(T data)
     {
       this->_value=data;
@@ -561,3 +494,5 @@ class OGComplexSparseMatrix: public OGSparseMatrix<complex16>
 };
 
 }
+
+#endif

--- a/include/expression.hh
+++ b/include/expression.hh
@@ -162,7 +162,7 @@ template <typename T> class OGArray: public OGNumeric
     {
       return _rows;
     }
-    int setRows(int rows)
+    void setRows(int rows)
     {
       _rows = rows;
     }
@@ -170,7 +170,7 @@ template <typename T> class OGArray: public OGNumeric
     {
       return _cols;
     }
-    int setCols(int cols)
+    void setCols(int cols)
     {
       _cols = cols;
     }
@@ -178,7 +178,7 @@ template <typename T> class OGArray: public OGNumeric
     {
       return _datalen;
     }
-    int setDatalen(int datalen)
+    void setDatalen(int datalen)
     {
       _datalen = datalen;
     }
@@ -243,9 +243,9 @@ class OGRealMatrix: public OGMatrix<real16>
     {
       size_t ptr=0;
       printf("\n");
-      for(size_t i = 0 ; i < this->getRows(); i++)
+      for(int i = 0 ; i < this->getRows(); i++)
       {
-        for(size_t j = 0 ; j < this->getCols()-1; j++)
+        for(int j = 0 ; j < this->getCols()-1; j++)
         {
           printf("%6.4f, ",this->getData()[ptr++]);
         }
@@ -262,9 +262,9 @@ class OGComplexMatrix: public OGMatrix<complex16>
     {
       size_t ptr=0;
       printf("\n");
-      for(size_t i = 0 ; i < this->getRows(); i++)
+      for(int i = 0 ; i < this->getRows(); i++)
       {
-        for(size_t j = 0 ; j < this->getCols()-1; j++)
+        for(int j = 0 ; j < this->getCols()-1; j++)
         {
           printf("%6.4f + %6.4fi, ",this->getData()[ptr].real(),this->getData()[ptr].imag());
           ptr++;
@@ -332,9 +332,9 @@ class OGRealDiagonalMatrix: public OGDiagonalMatrix<real16>
     {
       size_t ptr=0;
       printf("\n");
-      for(size_t i = 0 ; i < this->getRows(); i++)
+      for(int i = 0 ; i < this->getRows(); i++)
       {
-        for(size_t j = 0 ; j < this->getCols()-1; j++)
+        for(int j = 0 ; j < this->getCols()-1; j++)
         {
           if(i==j)
           {
@@ -356,9 +356,9 @@ class OGComplexDiagonalMatrix: public OGDiagonalMatrix<complex16>
     {
       size_t ptr=0;
       printf("\n");
-      for(size_t i = 0 ; i < this->getRows(); i++)
+      for(int i = 0 ; i < this->getRows(); i++)
       {
-        for(size_t j = 0 ; j < this->getCols()-1; j++)
+        for(int j = 0 ; j < this->getCols()-1; j++)
         {
           if(i==j)
           {
@@ -462,11 +462,11 @@ class OGRealSparseMatrix: public OGSparseMatrix<real16>
     {
       double nnz = 100.e0 * this->getDatalen() / (this->getRows() * this->getCols());
       printf("\nOGRealSparseMatrix\n");
-      printf("[nnz density = %4.2f\%. rows = %d, columns = %d]\n", nnz, this->getRows(), this->getCols());
+      printf("[nnz density = %4.2f. rows = %d, columns = %d]\n", nnz, this->getRows(), this->getCols());
       int * colPtr = this->getColPtr();
-      for (size_t ir = 0; ir < this->getCols(); ir++)
+      for (int ir = 0; ir < this->getCols(); ir++)
       {
-        for (size_t i = colPtr[ir]; i < colPtr[ir + 1]; i++)
+        for (int i = colPtr[ir]; i < colPtr[ir + 1]; i++)
         {
           printf("(%d,%d) = %6.4f\n",this->getRowIdx()[i],ir,this->getData()[i]);
         }
@@ -481,11 +481,11 @@ class OGComplexSparseMatrix: public OGSparseMatrix<complex16>
     {
       double nnz = 100.e0 * this->getDatalen() / (double)(this->getRows() * this->getCols());
       printf("\nOGComplexSparseMatrix\n");
-      printf("[nnz density = %4.2f\%. rows = %d, columns = %d]\n", nnz, this->getRows(), this->getCols());
+      printf("[nnz density = %4.2f. rows = %d, columns = %d]\n", nnz, this->getRows(), this->getCols());
       int * colPtr = this->getColPtr();
-      for (size_t ir = 0; ir < this->getCols(); ir++)
+      for (int ir = 0; ir < this->getCols(); ir++)
       {
-        for (size_t i = colPtr[ir]; i < colPtr[ir + 1]; i++)
+        for (int i = colPtr[ir]; i < colPtr[ir + 1]; i++)
         {
           printf("(%d,%d) = %6.4f + %6.4fi \n",this->getRowIdx()[i],ir,this->getData()[i].real(),this->getData()[i].imag());
         }

--- a/include/numerictypes.hh
+++ b/include/numerictypes.hh
@@ -1,0 +1,20 @@
+/**
+ * Copyright (C) 2012 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+#ifndef _NUMERICTYPES_HH
+#define _NUMERICTYPES_HH
+
+#include <complex>
+
+using namespace std;
+
+typedef complex<double> complex16;
+typedef complex<float> complex8;
+typedef double real16;
+typedef float real8;
+
+
+#endif /* NUMERICTYPES_HH_ */

--- a/include/visitor.hh
+++ b/include/visitor.hh
@@ -25,6 +25,8 @@ template  <typename T> class OGScalar;
 class Visitor
 {
   public:
+	  Visitor();
+	  virtual ~Visitor();
     virtual void visit(OGExpr *thing) = 0;
     virtual void visit(OGArray<real16> *thing) = 0;
     virtual void visit(OGArray<complex16> *thing) = 0;

--- a/include/visitor.hh
+++ b/include/visitor.hh
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) 2012 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+#ifndef _VISITOR_HH
+#define _VISITOR_HH
+
+#include "numerictypes.hh"
+
+namespace librdag {
+
+/*
+ * Forward declare types for visitor class
+ */
+class OGExpr;
+template  <typename T> class OGArray;
+template  <typename T> class OGMatrix;
+template  <typename T> class OGScalar;
+
+/*
+ * Pure function visitor class to access all fundamental types
+ */
+class Visitor
+{
+  public:
+    virtual void visit(OGExpr *thing) = 0;
+    virtual void visit(OGArray<real16> *thing) = 0;
+    virtual void visit(OGArray<complex16> *thing) = 0;
+    virtual void visit(OGMatrix<real16> *thing) = 0;
+    virtual void visit(OGScalar<real16> *thing) = 0;
+    virtual void visit(OGScalar<complex16> *thing) = 0;
+};
+
+}
+
+#endif /* VISITOR_HH_ */

--- a/include/warningmacros.h
+++ b/include/warningmacros.h
@@ -1,0 +1,12 @@
+/**
+ * Copyright (C) 2012 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+#ifndef _WARNINGMACROS_H
+#define _WARNINGMACROS_H
+
+#define SUPPRESS_UNUSED __attribute__ ((unused))
+
+#endif

--- a/include/winprint64.h
+++ b/include/winprint64.h
@@ -1,0 +1,14 @@
+/**
+ * Copyright (C) 2012 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+#ifndef _WINPRINT64_H
+#define _WINPRINT64_H
+
+#define INT64HIGHLOW(val,high,low) \
+    low = (long long unsigned int)val & 0x00000000FFFFFFFFULL; \
+    high = ((long long unsigned int)val & 0xFFFFFFFF00000000ULL) >> 32
+
+#endif

--- a/src/jshim/jshim.cc
+++ b/src/jshim/jshim.cc
@@ -1,7 +1,7 @@
 #include "com_opengamma_longdog_materialisers_Materialisers.h"
 #include "entrypt.h"
 #include "jshim.h"
-#include "bindings.hh"
+#include "expression.hh"
 #include "exprtypeenum.h"
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/jshim/jshim.cc
+++ b/src/jshim/jshim.cc
@@ -3,6 +3,7 @@
 #include "jshim.h"
 #include "expression.hh"
 #include "exprtypeenum.h"
+#include "warningmacros.h"
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -83,9 +84,9 @@ class JOGRealMatrix: public OGRealMatrix
       printf("\nJava bound OGRealMatrix\n");
       size_t ptr=0;
       printf("\n");
-      for(size_t i = 0 ; i < this->getRows(); i++)
+      for(int i = 0 ; i < this->getRows(); i++)
       {
-        for(size_t j = 0 ; j < this->getCols()-1; j++)
+        for(int j = 0 ; j < this->getCols()-1; j++)
         {
           printf("%6.4f, ",this->getData()[ptr++]);
         }
@@ -117,9 +118,9 @@ class JOGComplexMatrix: public OGComplexMatrix
       printf("\nJava bound OGComplexMatrix\n");
       size_t ptr=0;
       printf("\n");
-      for(size_t i = 0 ; i < this->getRows(); i++)
+      for(int i = 0 ; i < this->getRows(); i++)
       {
-        for(size_t j = 0 ; j < this->getCols()-1; j++)
+        for(int j = 0 ; j < this->getCols()-1; j++)
         {
           ptr++;
           printf("%6.4f + %6.4fi, ",this->getData()[ptr].real(),this->getData()[ptr].imag());
@@ -157,11 +158,11 @@ class JOGRealSparseMatrix: public OGRealSparseMatrix
       double nnz = 100.e0 * this->getDatalen() / (this->getRows() * this->getCols());
       printf("\nJava bound OGRealSparseMatrix\n");
       printf("\ndata len = %d\n",this->getDatalen());
-      printf("[nnz density = %4.2f\%. rows = %d, columns = %d]\n", nnz, this->getRows(), this->getCols());
+      printf("[nnz density = %4.2f. rows = %d, columns = %d]\n", nnz, this->getRows(), this->getCols());
       int * colPtr = this->getColPtr();
-      for (size_t ir = 0; ir < this->getCols(); ir++)
+      for (int ir = 0; ir < this->getCols(); ir++)
       {
-        for (size_t i = colPtr[ir]; i < colPtr[ir + 1]; i++)
+        for (int i = colPtr[ir]; i < colPtr[ir + 1]; i++)
         {
           printf("(%d,%d) = %6.4f\n",this->getRowIdx()[i],ir,this->getData()[i]);
         }
@@ -198,11 +199,11 @@ class JOGComplexSparseMatrix: public OGComplexSparseMatrix
       printf("datalen:%d\n",this->getDatalen());
       printf("rows:%d\n",this->getRows());
       printf("cols:%d\n",this->getCols());
-      printf("[nnz density = %4.2f\%. rows = %d, columns = %d]\n", nnz, this->getRows(), this->getCols());
+      printf("[nnz density = %4.2f. rows = %d, columns = %d]\n", nnz, this->getRows(), this->getCols());
       int * colPtr = this->getColPtr();
-      for (size_t ir = 0; ir < this->getCols(); ir++)
+      for (int ir = 0; ir < this->getCols(); ir++)
       {
-        for (size_t i = colPtr[ir]; i < colPtr[1]; i++)
+        for (int i = colPtr[ir]; i < colPtr[1]; i++)
         {
           printf("(%d,%d) = %6.4f + %6.4fi \n",this->getRowIdx()[i],ir,this->getData()[i].real(),this->getData()[i].imag());
         }
@@ -257,7 +258,8 @@ template <typename T, typename S> T * bindPrimitiveArrayData(jobject obj, jmetho
   }
   S * array = reinterpret_cast<S *>(&dataobj);
   T * _dataptr = (T *) env->GetPrimitiveArrayCritical(*array,NULL);
-};
+  return _dataptr;
+}
 
 /**
  * free (unbind) the data in an OGArray class from a T pointer
@@ -303,7 +305,7 @@ template <typename T, typename S> void unbindPrimitiveArrayData(T * nativeData, 
   jobject dataobj = env->CallObjectMethod(obj, method);
   S * array = reinterpret_cast<S *>(&dataobj);
   env->ReleasePrimitiveArrayCritical(*array, (void *)nativeData, 0);
-};
+}
 
 /**
  * free (unbind) the data in an OGArray class from a T pointer
@@ -326,7 +328,7 @@ template <typename T> void unbindOGArrayData(T * nativeData, jobject obj)
   jobject dataobj = env->CallObjectMethod(obj, OGTerminalClazz_getData);
   jdoubleArray * array = reinterpret_cast<jdoubleArray *>(&dataobj);
   env->ReleasePrimitiveArrayCritical(*array, (void *)nativeData, 0);
-};
+}
 
 /**
  * Spec for an OGExpr node derived from a java object
@@ -439,7 +441,14 @@ class ExprFactory
       }
       jobject typeobj = env->CallObjectMethod(obj, OGNumericClazz_getType);
       jlong ID = env->GetLongField(typeobj,OGExprTypeEnumClazz__hashdefined);
-      printf("Clazz Type is hashdefined as %lld\n",ID);
+#ifdef __MINGW32__
+      unsigned int high, low;
+      low = (long long unsigned int)ID & 0x00000000FFFFFFFFULL;
+      high = ((long long unsigned int)ID & 0xFFFFFFFF00000000ULL) >> 32;
+      printf("Clazz Type is hashdefined as %x%x\n", high, low);
+#else
+      printf("Clazz Type is hashdefined as %lld\n",(long long int)ID);
+#endif
       switch(ID)
       {
       case OGREALMATRIX_ENUM:
@@ -580,83 +589,83 @@ JOGExpr::JOGExpr(jobject * obj)
   printf("Making assignment\n");
 #endif
   this->setArgs(local_args);
-};
+}
 
 JOGExpr:: ~JOGExpr()
 {
   _backingObject = NULL;
-};
+}
 
 
 /**
  * JCOPY implementation details
  * COPY node derived from a java COPY node
  */
-JCOPY::JCOPY(jobject * obj): JOGExpr(obj) { };
+JCOPY::JCOPY(jobject * obj): JOGExpr(obj) { }
 void JCOPY::debug_print()
 {
   printf("JCOPY class\n");
-};
+}
 JCOPY::~JCOPY()
 {
   _backingObject = NULL;
-};
+}
 
 /**
  * JPLUS implementation details
  * PLUS node derived from a java PLUS node
  */
-JPLUS::JPLUS(jobject * obj): JOGExpr(obj) { };
+JPLUS::JPLUS(jobject * obj): JOGExpr(obj) { }
 void JPLUS::debug_print()
 {
   printf("JPLUS class\n");
-};
+}
 JPLUS::~JPLUS()
 {
   _backingObject = NULL;
-};
+}
 
 /**
  * JMINUS implementation details
  * MINUS node derived from a java MINUS node
  */
-JMINUS::JMINUS(jobject * obj): JOGExpr(obj) { };
+JMINUS::JMINUS(jobject * obj): JOGExpr(obj) { }
 void JMINUS::debug_print()
 {
   printf("JMINUS class\n");
-};
+}
 JMINUS::~JMINUS()
 {
   _backingObject = NULL;
-};
+}
 
 /**
  * JSVD implementation details
  * SVD node derived from a java SVD node
  */
-JSVD::JSVD(jobject * obj): JOGExpr(obj) { };
+JSVD::JSVD(jobject * obj): JOGExpr(obj) { }
 void JSVD::debug_print()
 {
   printf("JSVD class\n");
-};
+}
 JSVD::~JSVD()
 {
   _backingObject = NULL;
-};
+}
 
 /**
  * JSELECTRESULT implementation details
  * SELECTRESULT node derived from a java SVD node
  */
-JSELECTRESULT::JSELECTRESULT(jobject * obj): JOGExpr(obj) { };
+JSELECTRESULT::JSELECTRESULT(jobject * obj): JOGExpr(obj) { }
 void JSELECTRESULT::debug_print()
 {
   printf("JSELECTRESULT class\n");
-};
+}
 JSELECTRESULT::~JSELECTRESULT()
 {
   _backingObject = NULL;
-};
+}
 
 
 
@@ -671,10 +680,10 @@ void * instantiateJClassAsCXXClass(jobject obj)
   printf("In converter\n");
   convert::ExprFactory * factory = new convert::ExprFactory();
   return factory->getExpr(obj);
-};
+}
 
 
-}; // namespace ends
+} // namespace ends
 
 #ifdef __cplusplus
 extern "C" {
@@ -691,7 +700,7 @@ extern "C" {
    * Signature: (Lcom/opengamma/longdog/datacontainers/OGNumeric;)Lcom/opengamma/longdog/datacontainers/OGNumeric;
    */
   JNIEXPORT jobject JNICALL Java_com_opengamma_longdog_materialisers_Materialisers_materialise
-  (JNIEnv * env, jclass clazz, jobject obj)
+  (JNIEnv SUPPRESS_UNUSED *env, jclass SUPPRESS_UNUSED clazz, jobject obj)
   {
 
     printf("Entering materialise function\n");
@@ -703,7 +712,8 @@ extern "C" {
 
     printf("Calling entrypt function\n");
     // pass to entrypt
-    struct c_OGNumeric * answer = entrypt((struct c_OGNumeric *) chain);
+    //struct c_OGNumeric * answer = (should answer be used later?)
+    entrypt((struct c_OGNumeric *) chain);
 
     printf("Calling delete\n");
 //     delete chain;

--- a/src/jshim/jvmcache.c
+++ b/src/jshim/jvmcache.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "jvmcache.h"
+#include "winprint64.h"
 #define _DEBUG
 
 #ifdef __cplusplus
@@ -31,7 +32,7 @@ extern "C" {
 #ifdef __cplusplus
 extern "C"
 #endif
-JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *jvm, void *reserved)
+JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *jvm, void __attribute__ ((unused)) *reserved)
 {
 #ifdef _DEBUG
   printf("OnLoad called, caching VM ptr\n");
@@ -39,7 +40,13 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *jvm, void *reserved)
 
   JVMcache=jvm; // set the lib level JVM to the on-load JVM ptr
 #ifdef _DEBUG
-  printf("vm ptr at 0x%llx\n",JVMcache);
+#ifdef __MINGW32__
+  unsigned int high, low;
+  INT64HIGHLOW(JVMcache, high, low);
+  printf("vm ptr at 0x%x%x\n", high, low);
+#else
+  printf("vm ptr at 0x%llx\n", (long long unsigned int)JVMcache);
+#endif
 #endif
   JNIEnv *env=NULL;
   if ((*jvm)->GetEnv(jvm, (void **)&env, JNI_VERSION_1_2))
@@ -217,12 +224,18 @@ jint registerGlobalMethodReference(JNIEnv * env, jclass * globalRef, jmethodID *
   else
   {
 #ifdef _DEBUG
-    printf("Method found %s() 0x%llx\n",methodName,methodToSet);
+#ifdef __MINGW32__
+  unsigned int high, low;
+  INT64HIGHLOW(methodToSet, high, low);
+  printf("Method found %s() 0x%x%x\n", methodName, high, low);
+#else
+    printf("Method found %s() 0x%llx\n",methodName,(long long unsigned int)methodToSet);
+#endif
 #endif
   }
 
   return 0;
-};
+}
 
 
 #ifdef __cplusplus

--- a/src/librdag/CMakeLists.txt
+++ b/src/librdag/CMakeLists.txt
@@ -11,7 +11,7 @@ SET(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -Wl,--no-undefined")
 SET(CMAKE_CC_FLAGS  "${CMAKE_CC_FLAGS} -Wl,--no-undefined -frepo")
  
 
-add_library(rdag SHARED entrypt.cc exprtypes.cc)
+add_library(rdag SHARED entrypt.cc exprtypes.cc expression.cc)
 set_target_properties(rdag PROPERTIES SOVERSION ${longdog_VERSION_MAJOR} VERSION ${longdog_VERSION})
 install(TARGETS rdag DESTINATION lib)
 

--- a/src/librdag/CMakeLists.txt
+++ b/src/librdag/CMakeLists.txt
@@ -11,7 +11,7 @@ SET(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -Wl,--no-undefined")
 SET(CMAKE_CC_FLAGS  "${CMAKE_CC_FLAGS} -Wl,--no-undefined -frepo")
  
 
-add_library(rdag SHARED entrypt.cc exprtypes.cc expression.cc)
+add_library(rdag SHARED entrypt.cc exprtypes.cc expression.cc visitor.cc)
 set_target_properties(rdag PROPERTIES SOVERSION ${longdog_VERSION_MAJOR} VERSION ${longdog_VERSION})
 install(TARGETS rdag DESTINATION lib)
 

--- a/src/librdag/entrypt.cc
+++ b/src/librdag/entrypt.cc
@@ -1,6 +1,6 @@
 #include <stdio.h>
 #include "entrypt.h"
-#include "bindings.hh"
+#include "expression.hh"
 #include "exprtypeenum.h"
 #include <typeinfo>
 #include <iostream>

--- a/src/librdag/entrypt.cc
+++ b/src/librdag/entrypt.cc
@@ -45,7 +45,6 @@ class PrintTreeVisitor: public librdag::Visitor
       std::vector<librdag::OGNumeric *> * tmp = thing->getArgs();
       //hmmm perhaps we should either store the args as a raw array, or insist on everything being a vector.
       // anyway, walk over given args
-      librdag::OGNumeric * data = *(tmp->data());
       std::vector<librdag::OGNumeric *>::iterator it;
       for(it = tmp->begin();  it != tmp->end(); it++)
       {
@@ -54,23 +53,23 @@ class PrintTreeVisitor: public librdag::Visitor
     };
     void visit(librdag::OGArray<real16> *thing)
     {
-      cout << "Have OGArray<real16>\n";
+      cout << "Have OGArray<real16> " << thing << endl;
     }
     void visit(librdag::OGMatrix<real16> *thing)
     {
-      cout << "Have OGMatrix<real16>\n";
+      cout << "Have OGMatrix<real16> " << thing << endl;
     }
     void visit(librdag::OGArray<complex16> *thing)
     {
-      cout << "Have OGArray<complex16>\n";
+      cout << "Have OGArray<complex16> " << thing << endl;
     }
     void visit(librdag::OGScalar<real16> *thing)
     {
-      cout << "Have OGScalar<real16>\n";
+      cout << "Have OGScalar<real16> " << thing << endl;
     }
     void visit(librdag::OGScalar<complex16> *thing)
     {
-      cout << "Have OGScalar<complex16>\n";
+      cout << "Have OGScalar<complex16> " << thing << endl;
     }
 };
 

--- a/src/librdag/expression.cc
+++ b/src/librdag/expression.cc
@@ -1,0 +1,143 @@
+/**
+ * Copyright (C) 2012 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+#include <iostream>
+#include "expression.hh"
+#include "visitor.hh"
+
+using namespace std;
+
+namespace librdag
+{
+
+/*
+ * OGNumeric
+ */
+
+OGNumeric::OGNumeric() {};
+
+OGNumeric::~OGNumeric()
+{
+  cout << "in OGNumeric destructor" << endl;
+};
+
+void OGNumeric::debug_print()
+{
+  cout << "Abstract OGNumeric type" << endl;
+}
+
+/*
+ * OGExpr
+ */
+
+OGExpr::OGExpr() {};
+
+OGExpr::OGExpr(OGExpr& copy)
+{
+  this->_args = new std::vector<OGNumeric *>(*copy.getArgs());
+}
+
+OGExpr::OGExpr(const librdag::OGNumeric * const args, const int nargs)
+{
+	this->_args = new std::vector<OGNumeric *>;
+	for(size_t i = 0; i < nargs; i++)
+	{
+		this->_args->push_back(const_cast<OGNumeric *> (&args[i]));
+	}
+};
+
+OGExpr::~OGExpr()
+{
+	for (std::vector<OGNumeric *>::iterator it = this->_args->begin() ; it != this->_args->end(); it++)
+	{
+		delete &it;
+	}
+	delete this->_args;
+};
+
+OGExpr&
+OGExpr::operator=(OGExpr& rhs)
+{
+  rhs.setArgs(this->getArgs());
+  return *this;
+}
+
+std::vector<OGNumeric *> *
+OGExpr::getArgs()
+{
+	return this->_args;
+};
+
+// FIXME: Should replace this with construct from a vector
+void
+OGExpr::setArgs(std::vector<OGNumeric *> * args)
+{
+	this->_args = args;
+};
+
+size_t
+OGExpr::getNArgs()
+{
+  return this->_args->size();
+};
+
+void
+OGExpr::debug_print()
+{
+	cout << "OGExpr base class" << endl;
+}
+
+void
+OGExpr::accept(Visitor &v)
+{
+  v.visit(this);
+};
+
+/**
+ * Things that extend OGExpr
+ */
+
+COPY::COPY() {};
+
+void
+COPY::debug_print()
+{
+	cout << "COPY base class" << endl;
+}
+
+PLUS::PLUS() {};
+
+void
+PLUS::debug_print()
+{
+	cout << "PLUS base class" << endl;
+}
+
+MINUS::MINUS() {};
+
+void
+MINUS::debug_print()
+{
+	cout << "MINUS base class" << endl;
+}
+
+SVD::SVD() {};
+
+void
+SVD::debug_print()
+{
+	cout << "SVD base class" << endl;
+}
+
+SELECTRESULT::SELECTRESULT() {};
+
+void
+SELECTRESULT::debug_print()
+{
+	printf("SELECTRESULT base class\n");
+}
+
+}

--- a/src/librdag/expression.cc
+++ b/src/librdag/expression.cc
@@ -17,12 +17,12 @@ namespace librdag
  * OGNumeric
  */
 
-OGNumeric::OGNumeric() {};
+OGNumeric::OGNumeric() {}
 
 OGNumeric::~OGNumeric()
 {
   cout << "in OGNumeric destructor" << endl;
-};
+}
 
 void OGNumeric::debug_print()
 {
@@ -33,7 +33,7 @@ void OGNumeric::debug_print()
  * OGExpr
  */
 
-OGExpr::OGExpr() {};
+OGExpr::OGExpr() {}
 
 OGExpr::OGExpr(OGExpr& copy)
 {
@@ -43,11 +43,11 @@ OGExpr::OGExpr(OGExpr& copy)
 OGExpr::OGExpr(const librdag::OGNumeric * const args, const int nargs)
 {
 	this->_args = new std::vector<OGNumeric *>;
-	for(size_t i = 0; i < nargs; i++)
+	for(int i = 0; i < nargs; i++)
 	{
 		this->_args->push_back(const_cast<OGNumeric *> (&args[i]));
 	}
-};
+}
 
 OGExpr::~OGExpr()
 {
@@ -56,7 +56,7 @@ OGExpr::~OGExpr()
 		delete &it;
 	}
 	delete this->_args;
-};
+}
 
 OGExpr&
 OGExpr::operator=(OGExpr& rhs)
@@ -69,20 +69,20 @@ std::vector<OGNumeric *> *
 OGExpr::getArgs()
 {
 	return this->_args;
-};
+}
 
 // FIXME: Should replace this with construct from a vector
 void
 OGExpr::setArgs(std::vector<OGNumeric *> * args)
 {
 	this->_args = args;
-};
+}
 
 size_t
 OGExpr::getNArgs()
 {
   return this->_args->size();
-};
+}
 
 void
 OGExpr::debug_print()
@@ -94,13 +94,13 @@ void
 OGExpr::accept(Visitor &v)
 {
   v.visit(this);
-};
+}
 
 /**
  * Things that extend OGExpr
  */
 
-COPY::COPY() {};
+COPY::COPY() {}
 
 void
 COPY::debug_print()
@@ -108,7 +108,7 @@ COPY::debug_print()
 	cout << "COPY base class" << endl;
 }
 
-PLUS::PLUS() {};
+PLUS::PLUS() {}
 
 void
 PLUS::debug_print()
@@ -116,7 +116,7 @@ PLUS::debug_print()
 	cout << "PLUS base class" << endl;
 }
 
-MINUS::MINUS() {};
+MINUS::MINUS() {}
 
 void
 MINUS::debug_print()
@@ -124,7 +124,7 @@ MINUS::debug_print()
 	cout << "MINUS base class" << endl;
 }
 
-SVD::SVD() {};
+SVD::SVD() {}
 
 void
 SVD::debug_print()
@@ -132,7 +132,7 @@ SVD::debug_print()
 	cout << "SVD base class" << endl;
 }
 
-SELECTRESULT::SELECTRESULT() {};
+SELECTRESULT::SELECTRESULT() {}
 
 void
 SELECTRESULT::debug_print()

--- a/src/librdag/visitor.cc
+++ b/src/librdag/visitor.cc
@@ -1,0 +1,15 @@
+/**
+ * Copyright (C) 2012 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+#include "visitor.hh"
+
+namespace librdag {
+
+Visitor::Visitor() {}
+
+Visitor::~Visitor() {}
+
+}

--- a/src/ogrpath/rpath_hack.c
+++ b/src/ogrpath/rpath_hack.c
@@ -1,12 +1,13 @@
 #include <jni.h>
 #include "rpath_hack.h"
+#include "warningmacros.h"
 
 #ifdef __MINGW32__
 
 #ifdef __cplusplus
 extern "C"
 #endif
-JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *jvm, void *reserved)
+JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *jvm, void SUPPRESS_UNUSED *reserved)
 {
      printf("OnLoad called for rpath_hack\n"); 
      
@@ -19,13 +20,15 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *jvm, void *reserved)
      return JNI_VERSION_1_2;    
 }
 
+int varInThisLib = 0;
+
 #ifdef __cplusplus
 extern "C"
 #endif
 // gets the handle to *the current* module, use address of this lib and don't increment ref count
 HMODULE getThisLibHandle() {
     HMODULE lib = NULL;
-    GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS|GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, (LPCTSTR)getThisLibHandle, &lib);
+    GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS|GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, (LPCTSTR)&varInThisLib, &lib);
     return lib;
 }
 


### PR DESCRIPTION
Add -Wall -Wextra -Werror -pedantic flags to build, and set flags for each build type appropriately.

Errors detected with these flags included several missing returns, unsafe comparisons, etc. 

The set of changes included fixes all the errors that were highlighted by these flags.

Buildbot pass: http://devmaths-lx-1:8011/builders/nyqwk2-testing/builds/26
