### PR TITLE
Addition of testing and removal of Diamond

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,7 @@ set(CMAKE_JAVA_INCLUDE_PATH $ENV{CLASSPATH})
 # Place executables and libraries in bin on Windows so that its linker can find them.
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${longdog_BINARY_DIR}/bin)
 
+set(GTEST_ROOT $ENV{GTEST_ROOT})
 find_package(GTest REQUIRED)
 include_directories(${GTEST_INCLUDE_DIRS})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,9 +65,13 @@ set(CMAKE_JAVA_TARGET_OUTPUT_DIR ${JARDIR})
 
 set(CMAKE_JAVA_INCLUDE_PATH $ENV{CLASSPATH})
 
-add_subdirectory(src)
+# Place executables and libraries in bin on Windows so that its linker can find them.
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${longdog_BINARY_DIR}/bin)
 
 enable_testing()
+
+add_subdirectory(src)
+
 set(LONGDOG ${PROJECT_NAME}-${longdog_VERSION})
 set(LONGDOGJAR ${JARDIR}/${LONGDOG}.jar)
 set(LONGDOGTESTJAR ${JARDIR}/${LONGDOG}-tests.jar)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,9 @@ set(CMAKE_JAVA_INCLUDE_PATH $ENV{CLASSPATH})
 # Place executables and libraries in bin on Windows so that its linker can find them.
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${longdog_BINARY_DIR}/bin)
 
+find_package(GTest REQUIRED)
+include_directories(${GTEST_INCLUDE_DIRS})
+
 enable_testing()
 
 add_subdirectory(src)

--- a/include/entrypt.h
+++ b/include/entrypt.h
@@ -1,5 +1,6 @@
-#ifndef entrypt_h
-#define entrypt_h
+#ifndef _ENTRYPT_H
+#define _ENTRYPT_H
+
 struct c_OGNumeric;
 
 #ifdef __cplusplus

--- a/include/expression.hh
+++ b/include/expression.hh
@@ -134,6 +134,10 @@ template <class T> class OGScalar: public OGNumeric
     {
       v.visit(this);
     };
+    T getValue()
+    {
+      return this->_value;
+    }
 };
 
 typedef OGScalar<real16> OGRealScalar;

--- a/include/expression.hh
+++ b/include/expression.hh
@@ -20,7 +20,6 @@
 using namespace std;
 
 
-
 /*
  * The namespace for the DAG library
  */
@@ -53,39 +52,48 @@ class OGExpr: public OGNumeric
     OGExpr& operator=(OGExpr& rhs);
 
     std::vector<OGNumeric *> * getArgs();
-    // FIXME: should replace this with a construct from vector
-    void setArgs(std::vector<OGNumeric *> * args);
+
     size_t getNArgs();
     virtual void debug_print();
     void accept(Visitor &v);
   private:
     std::vector<OGNumeric *> * _args = NULL;
+  protected:
+    void setArgs(std::vector<OGNumeric *> * args);
 };
 
 /**
  * Things that extend OGExpr
  */
 
+class OGBinaryExpr : virtual public OGExpr
+{
+  public:
+	  OGBinaryExpr();
+	  OGBinaryExpr(OGNumeric* left, OGNumeric* right);
+};
+
 class COPY: virtual public OGExpr
 {
   public:
-    COPY();
     void debug_print();
 };
 
 
-class PLUS: virtual public OGExpr
+class PLUS: virtual public OGBinaryExpr
 {
   public:
-    PLUS();
+	  PLUS();
+	  PLUS(OGNumeric* left, OGNumeric* right);
     void debug_print();
 };
 
 
-class MINUS: virtual public OGExpr
+class MINUS: virtual public OGBinaryExpr
 {
   public:
     MINUS();
+	  MINUS(OGNumeric* left, OGNumeric* right);
     void debug_print();
 };
 
@@ -128,15 +136,8 @@ template <class T> class OGScalar: public OGNumeric
     };
 };
 
-class OGRealScalar: public OGScalar<real16>
-{
-
-};
-
-class OGComplexScalar: public OGScalar<complex16>
-{
-
-};
+typedef OGScalar<real16> OGRealScalar;
+typedef OGScalar<complex16> OGComplexScalar;
 
 
 template <typename T> class OGArray: public OGNumeric

--- a/include/expression.hh
+++ b/include/expression.hh
@@ -76,6 +76,7 @@ class OGBinaryExpr : virtual public OGExpr
 class COPY: virtual public OGExpr
 {
   public:
+	  COPY();
     void debug_print();
 };
 
@@ -121,9 +122,14 @@ template <class T> class OGScalar: public OGNumeric
   public:
     OGScalar() {};
 
+    OGScalar(const OGScalar * const copy)
+    {
+    	this->_value = copy->_value;
+    }
+
     OGScalar(const OGScalar& copy)
     {
-      copy._value= this->_value;
+      this->_value= copy._value;
     }
 
     OGScalar(T data)

--- a/include/expression.hh
+++ b/include/expression.hh
@@ -46,7 +46,7 @@ class OGExpr: public OGNumeric
   public:
     OGExpr();
     explicit OGExpr(OGExpr& copy);
-    OGExpr(const librdag::OGNumeric * const args, const int nargs);
+    OGExpr(const OGNumeric * const args, const int nargs);
     virtual ~OGExpr();
 
     OGExpr& operator=(OGExpr& rhs);
@@ -73,7 +73,7 @@ class OGBinaryExpr : virtual public OGExpr
 	  OGBinaryExpr(OGNumeric* left, OGNumeric* right);
 };
 
-class COPY: virtual public OGExpr
+class COPY: public OGExpr
 {
   public:
 	  COPY();
@@ -81,7 +81,7 @@ class COPY: virtual public OGExpr
 };
 
 
-class PLUS: virtual public OGBinaryExpr
+class PLUS: public OGBinaryExpr
 {
   public:
 	  PLUS();
@@ -90,7 +90,7 @@ class PLUS: virtual public OGBinaryExpr
 };
 
 
-class MINUS: virtual public OGBinaryExpr
+class MINUS: public OGBinaryExpr
 {
   public:
     MINUS();
@@ -98,14 +98,14 @@ class MINUS: virtual public OGBinaryExpr
     void debug_print();
 };
 
-class SVD: virtual public OGExpr
+class SVD: public OGExpr
 {
   public:
     SVD();
     void debug_print();
 };
 
-class SELECTRESULT: virtual public OGExpr
+class SELECTRESULT: public OGExpr
 {
   public:
     SELECTRESULT();

--- a/src/librdag/entrypt.cc
+++ b/src/librdag/entrypt.cc
@@ -5,6 +5,8 @@
 #include <typeinfo>
 #include <iostream>
 
+using namespace std;
+
 namespace parser
 {
 /*

--- a/src/librdag/expression.cc
+++ b/src/librdag/expression.cc
@@ -110,6 +110,8 @@ OGBinaryExpr::OGBinaryExpr(OGNumeric* left, OGNumeric* right)
 	this->setArgs(args);
 }
 
+COPY::COPY() {}
+
 void
 COPY::debug_print()
 {

--- a/src/librdag/expression.cc
+++ b/src/librdag/expression.cc
@@ -100,7 +100,15 @@ OGExpr::accept(Visitor &v)
  * Things that extend OGExpr
  */
 
-COPY::COPY() {}
+OGBinaryExpr::OGBinaryExpr() {}
+
+OGBinaryExpr::OGBinaryExpr(OGNumeric* left, OGNumeric* right)
+{
+	vector<OGNumeric*> *args = new vector<OGNumeric*>();
+	args->push_back(left);
+	args->push_back(right);
+	this->setArgs(args);
+}
 
 void
 COPY::debug_print()
@@ -110,6 +118,8 @@ COPY::debug_print()
 
 PLUS::PLUS() {}
 
+PLUS::PLUS(OGNumeric* left, OGNumeric* right) : OGBinaryExpr(left, right) {}
+
 void
 PLUS::debug_print()
 {
@@ -117,6 +127,8 @@ PLUS::debug_print()
 }
 
 MINUS::MINUS() {}
+
+MINUS::MINUS(OGNumeric* left, OGNumeric* right) : OGBinaryExpr(left, right) {}
 
 void
 MINUS::debug_print()

--- a/src/librdag/test/CMakeLists.txt
+++ b/src/librdag/test/CMakeLists.txt
@@ -13,7 +13,8 @@ set(TESTS check_entrypt)
 
 # Compile and link each test and add to the list of tests
 foreach(TEST ${TESTS})
-  add_executable(${TEST} ${TEST}.c)
+  add_executable(${TEST} ${TEST}.cc)
   target_link_libraries(${TEST} rdag)
-  add_test(${TEST} ${TEST})
+  get_target_property(TEST_LOC ${TEST} LOCATION)
+  add_test(${TEST} ${TEST_LOC})
 endforeach()

--- a/src/librdag/test/CMakeLists.txt
+++ b/src/librdag/test/CMakeLists.txt
@@ -14,7 +14,10 @@ set(TESTS check_entrypt)
 # Compile and link each test and add to the list of tests
 foreach(TEST ${TESTS})
   add_executable(${TEST} ${TEST}.cc)
-  target_link_libraries(${TEST} rdag)
+  target_link_libraries(${TEST} rdag ${GTEST_BOTH_LIBRARIES})
   get_target_property(TEST_LOC ${TEST} LOCATION)
   add_test(${TEST} ${TEST_LOC})
+  GTEST_ADD_TESTS(${TEST_LOC} "" check_expressions.cc)
 endforeach()
+
+

--- a/src/librdag/test/CMakeLists.txt
+++ b/src/librdag/test/CMakeLists.txt
@@ -9,14 +9,13 @@ SET(CMAKE_FC_FLAGS  "${CMAKE_FC_FLAGS} ${GCC_COVERAGE_COMPILE_FLAGS} -cpp" )
 
 link_directories(${longdog_BINARY_DIR}/src/librdag})
 
-set(TESTS check_entrypt)
+set(TESTS check_expressions)
 
 # Compile and link each test and add to the list of tests
 foreach(TEST ${TESTS})
   add_executable(${TEST} ${TEST}.cc)
-  target_link_libraries(${TEST} rdag ${GTEST_BOTH_LIBRARIES})
+  target_link_libraries(${TEST} rdag ${GTEST_BOTH_LIBRARIES} pthread)
   get_target_property(TEST_LOC ${TEST} LOCATION)
-  add_test(${TEST} ${TEST_LOC})
   GTEST_ADD_TESTS(${TEST_LOC} "" check_expressions.cc)
 endforeach()
 

--- a/src/librdag/test/check_entrypt.c
+++ b/src/librdag/test/check_entrypt.c
@@ -1,5 +1,0 @@
-#include "entrypt.h"
-
-int main(void ) {
-  return 0;
-}

--- a/src/librdag/test/check_entrypt.cc
+++ b/src/librdag/test/check_entrypt.cc
@@ -1,0 +1,10 @@
+#include "entrypt.h"
+#include "expression.hh"
+
+using namespace std;
+using namespace librdag;
+
+int main(void ) {
+  OGExpr *plus = new PLUS(new OGRealScalar(2), new OGRealScalar(3));
+  entrypt((struct c_OGNumeric*) plus);
+}

--- a/src/librdag/test/check_expressions.cc
+++ b/src/librdag/test/check_expressions.cc
@@ -1,0 +1,15 @@
+#include "entrypt.h"
+#include "expression.hh"
+
+using namespace std;
+using namespace librdag;
+
+TEST(OGExprTest, ScalarValues) {
+  OGNumeric *real = OGRealScalar(1.0);
+  EXPECT_EQ(1.0, real->getValue());
+}
+
+TEST(OGExprTest, ComplexValues) {
+  OGNumeric *complx = OGComplexScalar(1.0, 2.0);
+  EXPECT_EQ(1.0+2.0i, complx->getValue();
+}

--- a/src/librdag/test/check_expressions.cc
+++ b/src/librdag/test/check_expressions.cc
@@ -5,8 +5,6 @@
 using namespace std;
 using namespace librdag;
 
-
-
 TEST(OGExprTest, ScalarValues) {
 	// Constructor
   OGRealScalar *real = new OGRealScalar(1.0);

--- a/src/librdag/test/check_expressions.cc
+++ b/src/librdag/test/check_expressions.cc
@@ -1,15 +1,60 @@
 #include "entrypt.h"
 #include "expression.hh"
+#include "gtest/gtest.h"
 
 using namespace std;
 using namespace librdag;
 
+
+
 TEST(OGExprTest, ScalarValues) {
-  OGNumeric *real = OGRealScalar(1.0);
-  EXPECT_EQ(1.0, real->getValue());
+	// Constructor
+  OGRealScalar *real = new OGRealScalar(1.0);
+  ASSERT_EQ(1.0, real->getValue());
+  // Copy constructor from pointer
+  OGRealScalar *realCopy1 = new OGRealScalar(real);
+  EXPECT_EQ(1.0, realCopy1->getValue());
+  // Copy constructor from object
+  OGRealScalar *realCopy2 = new OGRealScalar(*real);
+  EXPECT_EQ(1.0, realCopy2->getValue());
+  // Cleanup
+  delete real;
+  delete realCopy1;
+  delete realCopy2;
 }
 
 TEST(OGExprTest, ComplexValues) {
-  OGNumeric *complx = OGComplexScalar(1.0, 2.0);
-  EXPECT_EQ(1.0+2.0i, complx->getValue();
+	// Constructor
+  OGComplexScalar *complx = new OGComplexScalar(complex16(1.0,2.0));
+  ASSERT_EQ(complex16(1.0,2.0), complx->getValue());
+  // Copy constructor from pointer
+  OGComplexScalar *complxCopy1 = new OGComplexScalar(complx);
+  EXPECT_EQ(complex16(1.0,2.0), complxCopy1->getValue());
+  // Copy constructor from object
+  OGComplexScalar *complxCopy2 = new OGComplexScalar(*complx);
+  EXPECT_EQ(complex16(1.0,2.0), complxCopy2->getValue());
+  delete complx;
+  delete complxCopy1;
+  delete complxCopy2;
 }
+
+TEST(OGExprTest, COPY){
+
+}
+
+TEST(OGExprTest, PLUS){
+
+}
+
+TEST(OGExprTest, MINUS){
+
+}
+
+TEST(OGExprTest, SVD){
+
+}
+
+TEST(OGExprTest, SELECTRESULT){
+
+}
+


### PR DESCRIPTION
This pull request consists of:
1. Setup of CMake for using the Google Test framework, and some rudimentary tests to ensure that it works.
2. Various refactoring/bugfix of previously-untested functionality/implementation of missing but useful functions in the expression hierarchy
3. Removal of the diamond inheritance in jshim. Each class has a factory function that constructs itself and then uses JOGExpr to construct its arguments, which it can then set on itself. This is because JOGExpr can't access setArgs() of OGExpr anymore. The factory functions can be refactored to reduce duplication, but I'm making this pull request sooner than that so that we are working on more similar interfaces before diverging too far.
