### PR TITLE
[MAT-196] Make arguments of expressions immutable.

### DIFF
--- a/include/containers.hh
+++ b/include/containers.hh
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2013 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * See distribution for licence.
+ *
+ */
+
+#ifndef _CONTAINERS_HH
+#define _CONTAINERS_HH
+
+#include <vector>
+#include "exceptions.hh"
+#include "warningmacros.h"
+
+using namespace std;
+
+namespace librdag {
+
+/*
+ * A vector that holds pointers. Null pointers are not allowed.
+ *
+ * Data that a PtrVector points to is owned by it.
+ */
+template<typename T>
+class PtrVector
+{
+  public:
+    PtrVector()
+    {
+      _vector = new vector<T*>();
+    }
+
+    ~PtrVector()
+    {
+      for (auto it = _vector->begin(); it != _vector->end(); ++it)
+      {
+        delete *it;
+      }
+      delete _vector;
+    }
+
+    typedef typename vector<T*>::const_iterator citerator;
+
+    void push_back(T* arg)
+    {
+      _check_arg(arg);
+      _vector->push_back(arg);
+    }
+
+    size_t size()
+    {
+      return _vector->size();
+    }
+
+    citerator begin()
+    {
+      return _vector->begin();
+    }
+
+    citerator end()
+    {
+      return _vector->end();
+    }
+
+    const T* operator[](size_t n)
+    {
+      return (*_vector)[n];
+    }
+
+  private:
+    vector<T*>* _vector;
+    void _check_arg(T* arg)
+    {
+      if (arg == nullptr)
+      {
+        throw new librdagException();
+      }
+    }
+};
+
+} // namespace librdag
+
+#endif /* _CONTAINERS_HH */

--- a/src/jshim/jshim.cc
+++ b/src/jshim/jshim.cc
@@ -364,7 +364,7 @@ class JOGExpr
   private:
     jobject * _backingObject = NULL;
   protected:
-    std::vector<OGNumeric *> *generateArgs();
+    ArgContainer* generateArgs();
 };
 /**
  * COPY node spec derived from a java COPY node
@@ -564,7 +564,7 @@ JOGExpr::JOGExpr(jobject * obj)
   this->_backingObject = obj;
 }
 
-std::vector<OGNumeric *> *
+ArgContainer*
 JOGExpr::generateArgs()
 {
   jobject *obj = this->_backingObject;
@@ -601,7 +601,7 @@ JOGExpr::generateArgs()
 #ifdef _DEBUG
   printf("JOGExpr arg size is %d\n",len);
 #endif
-  std::vector<OGNumeric *> * local_args = new std::vector<librdag::OGNumeric *>;
+  ArgContainer* local_args = new ArgContainer();
   ExprFactory * factory = new ExprFactory();
   for(int i=0; i<len; i++)
   {

--- a/src/librdag/entrypt.cc
+++ b/src/librdag/entrypt.cc
@@ -44,11 +44,10 @@ class PrintTreeVisitor: public librdag::Visitor
       cout << "Have OGExpr type ";
       thing->debug_print();
       cout << "\n";
-      std::vector<librdag::OGNumeric *> * tmp = thing->getArgs();
+      librdag::ArgContainer* tmp = thing->getArgs();
       //hmmm perhaps we should either store the args as a raw array, or insist on everything being a vector.
       // anyway, walk over given args
-      std::vector<librdag::OGNumeric *>::iterator it;
-      for(it = tmp->begin();  it != tmp->end(); it++)
+      for(auto it = tmp->begin();  it != tmp->end(); it++)
       {
         _walker->talkandwalk(*(it));
       }

--- a/src/librdag/test/CMakeLists.txt
+++ b/src/librdag/test/CMakeLists.txt
@@ -9,14 +9,14 @@ SET(CMAKE_FC_FLAGS  "${CMAKE_FC_FLAGS} ${GCC_COVERAGE_COMPILE_FLAGS} -cpp" )
 
 link_directories(${longdog_BINARY_DIR}/src/librdag})
 
-set(TESTS check_expressions)
+set(TESTS check_expressions check_containers)
 
 # Compile and link each test and add to the list of tests
 foreach(TEST ${TESTS})
   add_executable(${TEST} ${TEST}.cc)
   target_link_libraries(${TEST} rdag ${GTEST_BOTH_LIBRARIES} pthread)
   get_target_property(TEST_LOC ${TEST} LOCATION)
-  GTEST_ADD_TESTS(${TEST_LOC} "" check_expressions.cc)
+  GTEST_ADD_TESTS(${TEST_LOC} "" ${TEST}.cc)
   if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     add_test(${TEST}_valgrind valgrind --leak-check=full --error-exitcode=1 ${TEST_LOC})
   endif()

--- a/src/librdag/test/check_containers.cc
+++ b/src/librdag/test/check_containers.cc
@@ -1,0 +1,51 @@
+#include "containers.hh"
+#include "gtest/gtest.h"
+
+using namespace std;
+using namespace librdag;
+
+/*
+ * Test rationale: check the functionality that we wrapped in the derived class
+ * only. Otherwise we're just testing the C++ compiler/STL implementation.
+ */
+TEST(ContainerTest, PtrVectorTest) {
+  // Default constructor
+  PtrVector<int> *pv1 = new PtrVector<int>();
+  EXPECT_EQ(0, pv1->size());
+
+  // Add elements
+  size_t n = 5;
+  int** i_ptr_list = (int**)malloc(sizeof(int*)*n);
+  for (size_t i = 0; i < n; ++i)
+  {
+    int* intp = new int(i);
+    i_ptr_list[i] = intp;
+    pv1->push_back(intp);
+  }
+
+  // Check size matches number of inserted elements
+  ASSERT_EQ(5, pv1->size());
+
+  // Test operator[]
+  for (size_t i = 0; i < n; ++i)
+  {
+    const int* ptr = (*pv1)[i];
+    EXPECT_EQ(i_ptr_list[i], ptr);
+    EXPECT_EQ(i, *ptr);
+  }
+
+  // Test iteration over list
+  int i = 0;
+  for (auto it = pv1->begin(); it != pv1->end(); ++it)
+  {
+    EXPECT_EQ(*it, i_ptr_list[i]);
+    EXPECT_EQ(i, **it);
+    ++i;
+  }
+  EXPECT_EQ(5, i);
+
+  // Delete - no leaks should occur. pv1 owns the pointers to individual ints.
+  delete pv1;
+  // However, the list of pointers is not owned by it.
+  free(i_ptr_list);
+}

--- a/src/librdag/test/check_expressions.cc
+++ b/src/librdag/test/check_expressions.cc
@@ -47,17 +47,17 @@ TEST(OGExprTest, COPY){
   // Constructor
   OGRealScalar *real = new OGRealScalar(1.0);
   OGExpr *copy = new COPY(real);
-  std::vector<OGNumeric *> * args = copy->getArgs();
+  ArgContainer* args = copy->getArgs();
   ASSERT_EQ(1, copy->getNArgs());
-  EXPECT_EQ(real, dynamic_cast<OGRealScalar*>((*args)[0]));
+  EXPECT_EQ(real, ((*args)[0])->asOGRealScalar());
 
   // Constructor with args
-  std::vector<OGNumeric *> * newArgs = new std::vector<OGNumeric *>();
+  ArgContainer* newArgs = new ArgContainer();
   OGRealScalar *newReal = new OGRealScalar(3.14);
   newArgs->push_back(newReal);
   OGExpr *copyWithArgs = new COPY(newArgs);
   ASSERT_EQ(1, copyWithArgs->getNArgs());
-  EXPECT_EQ(newReal, dynamic_cast<OGRealScalar*>((*newArgs)[0]));
+  EXPECT_EQ(newReal, ((*newArgs)[0])->asOGRealScalar());
 
   // Constructor with args of wrong length
   // FIXME: Needs implementing once this throws an exception.
@@ -72,21 +72,21 @@ TEST(OGExprTest, PLUS){
   OGRealScalar *real = new OGRealScalar(1.0);
   OGComplexScalar *complx = new OGComplexScalar(complex16(2.0,3.0));
   OGExpr *plus = new PLUS(real, complx);
-  std::vector<OGNumeric *> * args = plus->getArgs();
+  ArgContainer* args = plus->getArgs();
   ASSERT_EQ(2, plus->getNArgs());
-  EXPECT_EQ(real, dynamic_cast<OGRealScalar*>((*args)[0]));
-  EXPECT_EQ(complx, dynamic_cast<OGComplexScalar*>((*args)[1]));
+  EXPECT_EQ(real, ((*args)[0])->asOGRealScalar());
+  EXPECT_EQ(complx, ((*args)[1])->asOGComplexScalar());
 
   // Constructor with args
-  std::vector<OGNumeric *> * newArgs = new std::vector<OGNumeric *>();
+  ArgContainer* newArgs = new ArgContainer();
   OGRealScalar *newReal = new OGRealScalar(3.14);
   OGComplexScalar *newComplx = new OGComplexScalar(complex16(2.7182, 2.7182));
   newArgs->push_back(newReal);
   newArgs->push_back(newComplx);
   OGExpr *plusWithArgs = new PLUS(newArgs);
   ASSERT_EQ(2, plusWithArgs->getNArgs());
-  EXPECT_EQ(newReal, dynamic_cast<OGRealScalar*>((*newArgs)[0]));
-  EXPECT_EQ(newComplx, dynamic_cast<OGComplexScalar*>((*newArgs)[1]));
+  EXPECT_EQ(newReal, ((*newArgs)[0])->asOGRealScalar());
+  EXPECT_EQ(newComplx, ((*newArgs)[1])->asOGComplexScalar());
 
   // Constructor with args of wrong length
   // FIXME: Needs implementing once this throws an exception.
@@ -101,21 +101,21 @@ TEST(OGExprTest, MINUS){
   OGRealScalar *real = new OGRealScalar(1.0);
   OGComplexScalar *complx = new OGComplexScalar(complex16(2.0,3.0));
   OGExpr *minus = new MINUS(real, complx);
-  std::vector<OGNumeric *> * args = minus->getArgs();
+  ArgContainer* args = minus->getArgs();
   ASSERT_EQ(2, minus->getNArgs());
-  EXPECT_EQ(real, dynamic_cast<OGRealScalar*>((*args)[0]));
-  EXPECT_EQ(complx, dynamic_cast<OGComplexScalar*>((*args)[1]));
+  EXPECT_EQ(real, ((*args)[0])->asOGRealScalar());
+  EXPECT_EQ(complx, ((*args)[1])->asOGComplexScalar());
 
   // Constructor with args
-  std::vector<OGNumeric *> * newArgs = new std::vector<OGNumeric *>();
+  ArgContainer* newArgs = new ArgContainer();
   OGRealScalar *newReal = new OGRealScalar(3.14);
   OGComplexScalar *newComplx = new OGComplexScalar(complex16(2.7182, 2.7182));
   newArgs->push_back(newReal);
   newArgs->push_back(newComplx);
   OGExpr *minusWithArgs = new MINUS(newArgs);
   ASSERT_EQ(2, minusWithArgs->getNArgs());
-  EXPECT_EQ(newReal, dynamic_cast<OGRealScalar*>((*newArgs)[0]));
-  EXPECT_EQ(newComplx, dynamic_cast<OGComplexScalar*>((*newArgs)[1]));
+  EXPECT_EQ(newReal, ((*newArgs)[0])->asOGRealScalar());
+  EXPECT_EQ(newComplx, ((*newArgs)[1])->asOGComplexScalar());
 
   // Constructor with args of wrong length
   // FIXME: Needs implementing once this throws an exception.
@@ -129,17 +129,17 @@ TEST(OGExprTest, SVD){
   // Constructor
   OGRealScalar *real = new OGRealScalar(1.0);
   OGExpr *svd = new SVD(real);
-  std::vector<OGNumeric *> * args = svd->getArgs();
+  ArgContainer* args = svd->getArgs();
   ASSERT_EQ(1, svd->getNArgs());
-  EXPECT_EQ(real, dynamic_cast<OGRealScalar*>((*args)[0]));
+  EXPECT_EQ(real, ((*args)[0])->asOGRealScalar());
 
   // Constructor with args
-  std::vector<OGNumeric *> * newArgs = new std::vector<OGNumeric *>();
+  ArgContainer* newArgs = new ArgContainer();
   OGRealScalar *newReal = new OGRealScalar(3.14);
   newArgs->push_back(newReal);
   OGExpr *svdWithArgs = new SVD(newArgs);
   ASSERT_EQ(1, svdWithArgs->getNArgs());
-  EXPECT_EQ(newReal, dynamic_cast<OGRealScalar*>((*newArgs)[0]));
+  EXPECT_EQ(newReal, ((*newArgs)[0])->asOGRealScalar());
 
   // Constructor with args of wrong length
   // FIXME: Needs implementing once this throws an exception.
@@ -154,21 +154,21 @@ TEST(OGExprTest, SELECTRESULT){
   OGRealScalar *real = new OGRealScalar(1.0);
   OGIntegerScalar *index = new OGIntegerScalar(1);
   OGExpr *select = new SELECTRESULT(real, index);
-  std::vector<OGNumeric *> * args = select->getArgs();
+  ArgContainer* args = select->getArgs();
   ASSERT_EQ(2, select->getNArgs());
-  EXPECT_EQ(real, dynamic_cast<OGRealScalar*>((*args)[0]));
-  EXPECT_EQ(index, dynamic_cast<OGIntegerScalar*>((*args)[1]));
+  EXPECT_EQ(real, ((*args)[0])->asOGRealScalar());
+  EXPECT_EQ(index, ((*args)[1])->asOGIntegerScalar());
 
   // Constructor with args
-  std::vector<OGNumeric *> * newArgs = new std::vector<OGNumeric *>();
+  ArgContainer* newArgs = new ArgContainer();
   OGRealScalar *newReal = new OGRealScalar(3.14);
   OGIntegerScalar *newIndex = new OGIntegerScalar(2);
   newArgs->push_back(newReal);
   newArgs->push_back(newIndex);
   OGExpr *selectWithArgs = new SELECTRESULT(newArgs);
   ASSERT_EQ(2, selectWithArgs->getNArgs());
-  EXPECT_EQ(newReal, dynamic_cast<OGRealScalar*>((*newArgs)[0]));
-  EXPECT_EQ(newIndex, dynamic_cast<OGIntegerScalar*>((*newArgs)[1]));
+  EXPECT_EQ(newReal, ((*newArgs)[0])->asOGRealScalar());
+  EXPECT_EQ(newIndex, ((*newArgs)[1])->asOGIntegerScalar());
 
   // Constructor with args of wrong length
   // FIXME: Needs implementing once this throws an exception.


### PR DESCRIPTION
This is done using the PtrVector class, which holds an STL vector
but only permits its contents to be read, not modified, and does
not allow null pointers to be inserted.

Presently only wrapper methods that are used are implemented.
Others may need to be implemented to get to other functionality of
the underlying vector in the future.

The consquence of making its contents immutable (and returning
only const pointers to its elements) is that dynamic_cast is not
possible because it would cast away the const-ness. In order to
get around this, a dynamic_cast-like mechanism is implemented for
the OGNumeric class.

So far this is only implemented for the scalar types: OGNumeric
has members asOG*Scalar, which are virtual and return null. The
derived class then overrides the method that mentions its name
(e.g. OGRealScalar overrides asOGRealScalar) so that it returns
the this pointer.

Thus, the effect of calling OGNumeric::asOGRealScalar() is the
same as using dynamic_cast<OGRealScalar*>(ptr), except that it
uses const pointers, and will work across module boundaries,
unlike C++ RTTI.
