### PR TITLE
Mat 161 - add diagonal matrix support through JNI

### DIFF
--- a/src/java/src/main/java/com/opengamma/longdog/datacontainers/matrix/OGComplexDiagonalMatrix.java
+++ b/src/java/src/main/java/com/opengamma/longdog/datacontainers/matrix/OGComplexDiagonalMatrix.java
@@ -96,7 +96,7 @@ public class OGComplexDiagonalMatrix extends OGDiagonalMatrix {
     int len = Math.max(diag.length, Math.min(rows, columns)); // max as zero fill on short diag
     _data = new double[len * 2];
     double[] tmp = DenseMemoryManipulation.convertSinglePointerToZeroInterleavedSinglePointer(diag);
-    System.arraycopy(tmp, 0, _data, 0, len * 2);
+    System.arraycopy(tmp, 0, _data, 0, tmp.length);
   }
 
   /**

--- a/src/java/src/main/java/com/opengamma/longdog/datacontainers/matrix/OGComplexDiagonalMatrix.java
+++ b/src/java/src/main/java/com/opengamma/longdog/datacontainers/matrix/OGComplexDiagonalMatrix.java
@@ -93,7 +93,7 @@ public class OGComplexDiagonalMatrix extends OGDiagonalMatrix {
     }
     _rows = rows;
     _cols = columns;
-    int len = Math.min(diag.length, Math.min(rows, columns));
+    int len = Math.max(diag.length, Math.min(rows, columns)); // max as zero fill on short diag
     _data = new double[len * 2];
     double[] tmp = DenseMemoryManipulation.convertSinglePointerToZeroInterleavedSinglePointer(diag);
     System.arraycopy(tmp, 0, _data, 0, len * 2);
@@ -120,10 +120,10 @@ public class OGComplexDiagonalMatrix extends OGDiagonalMatrix {
     }
     _rows = rows;
     _cols = columns;
-    int len = Math.min(real.length, Math.min(rows, columns));
+    int len = Math.max(real.length, Math.min(rows, columns)); // max as zero fill on short diag   
     _data = new double[len * 2];
     double[] tmp = DenseMemoryManipulation.convertTwoSinglePointersToInterleavedSinglePointer(real, imag);
-    System.arraycopy(tmp, 0, _data, 0, len * 2);
+    System.arraycopy(tmp, 0, _data, 0, real.length * 2);
   }
 
   /**

--- a/src/java/src/main/java/com/opengamma/longdog/datacontainers/matrix/OGRealDiagonalMatrix.java
+++ b/src/java/src/main/java/com/opengamma/longdog/datacontainers/matrix/OGRealDiagonalMatrix.java
@@ -52,9 +52,9 @@ public class OGRealDiagonalMatrix extends OGDiagonalMatrix {
     Catchers.catchNullFromArgList(diag, 1);
     _rows = rows;
     _cols = columns;
-    int len = Math.min(diag.length, Math.min(rows, columns));
+    int len = Math.max(diag.length, Math.min(rows, columns)); // max as zero fill on short diag
     _data = new double[len];
-    System.arraycopy(diag, 0, _data, 0, len);
+    System.arraycopy(diag, 0, _data, 0, diag.length);
   }
 
   /**

--- a/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionIllegalArgument.java
+++ b/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionIllegalArgument.java
@@ -16,11 +16,11 @@ public class MathsExceptionIllegalArgument extends MathsException {
   }
 
   public MathsExceptionIllegalArgument(final String s) {
-    super(s + " points to null.");
+    super(s);
   }
 
   public MathsExceptionIllegalArgument(final String s, final Throwable cause) {
-    super(s + " points to null.", cause);
+    super(s, cause);
   }
 
   public MathsExceptionIllegalArgument(final Throwable cause) {

--- a/src/java/src/test/java/com/opengamma/longdog/datacontainers/TestLongdog.java
+++ b/src/java/src/test/java/com/opengamma/longdog/datacontainers/TestLongdog.java
@@ -140,8 +140,8 @@ public class TestLongdog {
     }
     System.out.println("Back in java land");
   }
-  
-  @Test(enabled=false)
+
+  @Test(enabled = false)
   public void test9() {
     OGNumeric A = new OGComplexDiagonalMatrix(new double[] { 1, 2, 3, 4 }, new double[] { 10, 20, 30, 40 });
     ComplexArrayContainer result = Materialisers.toComplexArrayContainer(A);
@@ -155,5 +155,5 @@ public class TestLongdog {
     }
     System.out.println("Back in java land");
   }
-  
+
 }

--- a/src/java/src/test/java/com/opengamma/longdog/datacontainers/TestLongdog.java
+++ b/src/java/src/test/java/com/opengamma/longdog/datacontainers/TestLongdog.java
@@ -12,9 +12,11 @@ import org.testng.annotations.Test;
 
 import com.opengamma.longdog.DOGMA2;
 import com.opengamma.longdog.datacontainers.matrix.OGComplexDenseMatrix;
+import com.opengamma.longdog.datacontainers.matrix.OGComplexDiagonalMatrix;
 import com.opengamma.longdog.datacontainers.matrix.OGComplexSparseMatrix;
 import com.opengamma.longdog.datacontainers.matrix.OGLogicalMatrix;
 import com.opengamma.longdog.datacontainers.matrix.OGRealDenseMatrix;
+import com.opengamma.longdog.datacontainers.matrix.OGRealDiagonalMatrix;
 import com.opengamma.longdog.datacontainers.matrix.OGRealSparseMatrix;
 import com.opengamma.longdog.datacontainers.other.ComplexArrayContainer;
 import com.opengamma.longdog.datacontainers.other.OGResult;
@@ -86,20 +88,72 @@ public class TestLongdog {
     }
     System.out.println("Back in java land");
   }
-  
+
   @Test
   public void test5() {
-    OGNumeric  A= new OGComplexDenseMatrix(new double[][] { { 1, 2, 3 }, { 4, 5, 6 } }, new double[][] { { 10, 20, 30 }, { 40, 50, 60 } });
+    OGNumeric A = new OGComplexDenseMatrix(new double[][] { { 1, 2, 3 }, { 4, 5, 6 } }, new double[][] { { 10, 20, 30 }, { 40, 50, 60 } });
     ComplexArrayContainer result = Materialisers.toComplexArrayContainer(A);
     System.out.println("Real array of dimension [" + result.getReal().length + "],[" + result.getReal()[0].length + "]");
     for (int i = 0; i < result.getReal().length; i++) {
       System.out.println(Arrays.toString(result.getReal()[i]));
     }
-    System.out.println("Imag array of dimension [" + result.getImag().length + "],[" + result.getImag()[0].length + "]");    
+    System.out.println("Imag array of dimension [" + result.getImag().length + "],[" + result.getImag()[0].length + "]");
     for (int i = 0; i < result.getImag().length; i++) {
       System.out.println(Arrays.toString(result.getImag()[i]));
-    }    
+    }
     System.out.println("Back in java land");
   }
 
+  @Test
+  public void test6() {
+    OGNumeric A = new OGRealDiagonalMatrix(new double[] { 1, 2, 3, 4 });
+    double[][] result = Materialisers.toDoubleArrayOfArrays(A);
+    System.out.println("Array of dimension [" + result.length + "],[" + result[0].length + "]");
+    for (int i = 0; i < result.length; i++) {
+      System.out.println(Arrays.toString(result[i]));
+    }
+    System.out.println("Back in java land");
+  }
+
+  @Test
+  public void test7() {
+    OGNumeric A = new OGRealDiagonalMatrix(new double[] { 1, 2, 3, 4 }, 6, 7);
+    double[][] result = Materialisers.toDoubleArrayOfArrays(A);
+    System.out.println("Array of dimension [" + result.length + "],[" + result[0].length + "]");
+    for (int i = 0; i < result.length; i++) {
+      System.out.println(Arrays.toString(result[i]));
+    }
+    System.out.println("Back in java land");
+  }
+
+  @Test
+  public void test8() {
+    OGNumeric A = new OGComplexDiagonalMatrix(new double[] { 1, 2, 3, 4 }, new double[] { 10, 20, 30, 40 }, 6, 7);
+    ComplexArrayContainer result = Materialisers.toComplexArrayContainer(A);
+    System.out.println("Real array of dimension [" + result.getReal().length + "],[" + result.getReal()[0].length + "]");
+    for (int i = 0; i < result.getReal().length; i++) {
+      System.out.println(Arrays.toString(result.getReal()[i]));
+    }
+    System.out.println("Imag array of dimension [" + result.getImag().length + "],[" + result.getImag()[0].length + "]");
+    for (int i = 0; i < result.getImag().length; i++) {
+      System.out.println(Arrays.toString(result.getImag()[i]));
+    }
+    System.out.println("Back in java land");
+  }
+  
+  @Test(enabled=false)
+  public void test9() {
+    OGNumeric A = new OGComplexDiagonalMatrix(new double[] { 1, 2, 3, 4 }, new double[] { 10, 20, 30, 40 });
+    ComplexArrayContainer result = Materialisers.toComplexArrayContainer(A);
+    System.out.println("Real array of dimension [" + result.getReal().length + "],[" + result.getReal()[0].length + "]");
+    for (int i = 0; i < result.getReal().length; i++) {
+      System.out.println(Arrays.toString(result.getReal()[i]));
+    }
+    System.out.println("Imag array of dimension [" + result.getImag().length + "],[" + result.getImag()[0].length + "]");
+    for (int i = 0; i < result.getImag().length; i++) {
+      System.out.println(Arrays.toString(result.getImag()[i]));
+    }
+    System.out.println("Back in java land");
+  }
+  
 }

--- a/src/java/src/test/java/com/opengamma/longdog/datacontainers/matrix/OGComplexDiagonalMatrixTest.java
+++ b/src/java/src/test/java/com/opengamma/longdog/datacontainers/matrix/OGComplexDiagonalMatrixTest.java
@@ -181,11 +181,11 @@ public class OGComplexDiagonalMatrixTest {
   // sending in ok double[], int, int constructor
   @Test
   public void testDoublePtrIntIntConstructorInternalDataTest() {
-    OGComplexDiagonalMatrix D = new OGComplexDiagonalMatrix(data4x3diagdreal, 16, 32);
+    OGComplexDiagonalMatrix D = new OGComplexDiagonalMatrix(data4x3diagdreal, 6, 7);
     assertTrue(D.getClass() == OGComplexDiagonalMatrix.class);
-    assertTrue(Arrays.equals(D.getData(), interleavedreal4x3));
-    assertTrue(D.getRows() == 16);
-    assertTrue(D.getCols() == 32);
+    assertTrue(Arrays.equals(D.getData(), new double[] { 1, 0, 2, 0, 3, 0, 0, 0, 0, 0, 0, 0 }));
+    assertTrue(D.getRows() == 6);
+    assertTrue(D.getCols() == 7);
   }
 
   // sending in ok double, int, int  constructor

--- a/src/java/src/test/java/com/opengamma/longdog/datacontainers/matrix/OGRealDiagonalMatrixTest.java
+++ b/src/java/src/test/java/com/opengamma/longdog/datacontainers/matrix/OGRealDiagonalMatrixTest.java
@@ -54,11 +54,11 @@ public class OGRealDiagonalMatrixTest {
   // sending in ok double[], int, int constructor
   @Test
   public void testDoublePtrIntIntConstructorInternalDataTest() {
-    OGRealDiagonalMatrix D = new OGRealDiagonalMatrix(data4x3diagd, 16, 32);
+    OGRealDiagonalMatrix D = new OGRealDiagonalMatrix(data4x3diagd, 6, 7);
     assertTrue(D.getClass() == OGRealDiagonalMatrix.class);
-    assertTrue(Arrays.equals(D.getData(), data4x3diagd));
-    assertTrue(D.getRows() == 16);
-    assertTrue(D.getCols() == 32);
+    assertTrue(Arrays.equals(D.getData(), new double[] { 1, 2, 3, 0, 0, 0 }));
+    assertTrue(D.getRows() == 6);
+    assertTrue(D.getCols() == 7);
   }
 
   // sending in bad rows double, int, int constructor
@@ -128,5 +128,5 @@ public class OGRealDiagonalMatrixTest {
     OGRealDiagonalMatrix D = new OGRealDiagonalMatrix(data4x3diagd, 4, 3);
     D.toString();
   }
-  
+
 }

--- a/src/java/src/test/java/com/opengamma/longdog/materialisers/TestOGComplexDenseMatrixMaterialise.java
+++ b/src/java/src/test/java/com/opengamma/longdog/materialisers/TestOGComplexDenseMatrixMaterialise.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (C) 2013 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+package com.opengamma.longdog.materialisers;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.opengamma.longdog.datacontainers.matrix.OGComplexDenseMatrix;
+import com.opengamma.longdog.datacontainers.other.ComplexArrayContainer;
+import com.opengamma.longdog.exceptions.MathsException;
+import com.opengamma.longdog.testhelpers.ArraysHelpers;
+
+public class TestOGComplexDenseMatrixMaterialise {
+
+  @DataProvider
+  public Object[][] dataContainer() {
+    Object[][] obj = new Object[4][4];
+
+    obj[0][0] = new double[][] { { 1 } };
+    obj[0][1] = new double[][] { { 10 } };
+    obj[0][2] = new double[][] { { 1 } };
+    obj[0][3] = new double[][] { { 10 } };
+
+    obj[1][0] = new double[][] { { 1, 2, 3, 4 } };
+    obj[1][1] = new double[][] { { 10, 20, 30, 40 } };
+    obj[1][2] = new double[][] { { 1, 2, 3, 4 } };
+    obj[1][3] = new double[][] { { 10, 20, 30, 40 } };
+
+    obj[2][0] = new double[][] { { 1 }, { 2 }, { 3 }, { 4 } };
+    obj[2][1] = new double[][] { { 10 }, { 20 }, { 30 }, { 40 } };
+    obj[2][2] = new double[][] { { 1 }, { 2 }, { 3 }, { 4 } };
+    obj[2][3] = new double[][] { { 10 }, { 20 }, { 30 }, { 40 } };
+
+    obj[3][0] = new double[][] { { 1, 2, 3 }, { 4, 5, 6 }, { 7, 8, 9 }, { 10, 11, 12 } };
+    obj[3][1] = new double[][] { { 10, 20, 30 }, { 40, 50, 60 }, { 70, 80, 90 }, { 100, 110, 120 } };
+    obj[3][2] = new double[][] { { 1, 2, 3 }, { 4, 5, 6 }, { 7, 8, 9 }, { 10, 11, 12 } };
+    obj[3][3] = new double[][] { { 10, 20, 30 }, { 40, 50, 60 }, { 70, 80, 90 }, { 100, 110, 120 } };
+
+    return obj;
+  };
+
+  @Test(dataProvider = "dataContainer")
+  public void materialiseToJComplexContainer(double[][] inputReal, double[][] inputImag, double[][] expectedReal, double[][] expectedImag) {
+    OGComplexDenseMatrix tmp = new OGComplexDenseMatrix(inputReal, inputImag);
+    ComplexArrayContainer answer = Materialisers.toComplexArrayContainer(tmp);
+    if (!ArraysHelpers.ArraysEquals(expectedReal, answer.getReal())) {
+      throw new MathsException("REAL: Arrays not equal");
+    }
+    if (!ArraysHelpers.ArraysEquals(expectedImag, answer.getImag())) {
+      throw new MathsException("IMAG: Arrays not equal");
+    }
+  }
+
+}

--- a/src/java/src/test/java/com/opengamma/longdog/materialisers/TestOGComplexDiagonalMatrixMaterialise.java
+++ b/src/java/src/test/java/com/opengamma/longdog/materialisers/TestOGComplexDiagonalMatrixMaterialise.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (C) 2013 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+package com.opengamma.longdog.materialisers;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.opengamma.longdog.datacontainers.matrix.OGComplexDiagonalMatrix;
+import com.opengamma.longdog.datacontainers.other.ComplexArrayContainer;
+import com.opengamma.longdog.exceptions.MathsException;
+import com.opengamma.longdog.testhelpers.ArraysHelpers;
+
+public class TestOGComplexDiagonalMatrixMaterialise {
+
+  @DataProvider
+  public Object[][] dataContainer() {
+    Object[][] obj = new Object[3][6];
+
+    obj[0][0] = new double[] { 1 };
+    obj[0][1] = new double[] { 10 };    
+    obj[0][2] = 1;
+    obj[0][3] = 1;
+    obj[0][4] = new double[][] { { 1 } };
+    obj[0][5] = new double[][] { { 10 } };
+
+    obj[1][0] = new double[] { 1, 2, 3, 4 };
+    obj[1][1] = new double[] { 10, 20, 30, 40 };    
+    obj[1][2] = 4;
+    obj[1][3] = 4;
+    obj[1][4] = new double[][] { { 1, 0, 0, 0 }, { 0, 2, 0, 0 }, { 0, 0, 3, 0 }, { 0, 0, 0, 4 } };
+    obj[1][5] = new double[][] { { 10, 0, 0, 0 }, { 0, 20, 0, 0 }, { 0, 0, 30, 0 }, { 0, 0, 0, 40 } };    
+
+    obj[2][0] = new double[] { 1, 2, 3, 4 };
+    obj[2][1] = new double[] { 10, 20, 30, 40 };    
+    obj[2][2] = 6;
+    obj[2][3] = 7;
+    obj[2][4] = new double[][] { { 1, 0, 0, 0, 0, 0, 0 }, { 0, 2, 0, 0, 0, 0, 0 }, { 0, 0, 3, 0, 0, 0, 0 }, { 0, 0, 0, 4, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 } };
+    obj[2][5] = new double[][] { { 10, 0, 0, 0, 0, 0, 0 }, { 0, 20, 0, 0, 0, 0, 0 }, { 0, 0, 30, 0, 0, 0, 0 }, { 0, 0, 0, 40, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 }, { 0, 0, 0, 0, 0, 0, 0 } };    
+
+    return obj;
+  };
+
+  @Test(dataProvider = "dataContainer")
+  public void materialiseToJDoubleArray(double[] inputReal, double[] inputComplex, int rows, int cols, double[][] expectedReal, double[][] expectedImag) {
+    OGComplexDiagonalMatrix tmp = new OGComplexDiagonalMatrix(inputReal, inputComplex, rows, cols);
+    ComplexArrayContainer answer = Materialisers.toComplexArrayContainer(tmp);
+    if (!ArraysHelpers.ArraysEquals(expectedReal, answer.getReal())) {
+      throw new MathsException("REAL: Arrays not equal");
+    }
+    if (!ArraysHelpers.ArraysEquals(expectedImag, answer.getImag())) {
+      throw new MathsException("IMAG: Arrays not equal");
+    }
+  }
+
+}

--- a/src/java/src/test/java/com/opengamma/longdog/materialisers/TestOGRealDenseMatrixMaterialise.java
+++ b/src/java/src/test/java/com/opengamma/longdog/materialisers/TestOGRealDenseMatrixMaterialise.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) 2013 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+package com.opengamma.longdog.materialisers;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.opengamma.longdog.datacontainers.matrix.OGRealDenseMatrix;
+import com.opengamma.longdog.exceptions.MathsException;
+import com.opengamma.longdog.testhelpers.ArraysHelpers;
+
+public class TestOGRealDenseMatrixMaterialise {
+
+  @DataProvider
+  public Object[][] dataContainer() {
+    Object[][] obj = new Object[4][2];
+    
+    
+    obj[0][0] = new double[][] {{1}};
+    obj[0][1] = new double[][] {{1}};
+
+    obj[1][0] = new double[][] {{1,2,3,4}};
+    obj[1][1] = new double[][] {{1,2,3,4}};
+
+    obj[2][0] = new double[][] {{1},{2},{3},{4}};
+    obj[2][1] = new double[][] {{1},{2},{3},{4}};    
+
+    obj[3][0] = new double[][] {{1,2,3},{4,5,6},{7,8,9},{10,11,12}};
+    obj[3][1] = new double[][] {{1,2,3},{4,5,6},{7,8,9},{10,11,12}};
+    
+    return obj;
+  };
+
+  @Test(dataProvider = "dataContainer")
+  public void materialiseToJDoubleArray(double[][] input, double[][] expected) {
+    OGRealDenseMatrix tmp = new OGRealDenseMatrix(input);
+    double[][] answer = Materialisers.toDoubleArrayOfArrays(tmp);
+    if (!ArraysHelpers.ArraysEquals(expected, answer)) {
+      throw new MathsException("Arrays not equal");
+    }
+  }
+
+}

--- a/src/java/src/test/java/com/opengamma/longdog/materialisers/TestOGRealDiagonalMatrixMaterialise.java
+++ b/src/java/src/test/java/com/opengamma/longdog/materialisers/TestOGRealDiagonalMatrixMaterialise.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2013 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+package com.opengamma.longdog.materialisers;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.opengamma.longdog.datacontainers.matrix.OGRealDiagonalMatrix;
+import com.opengamma.longdog.exceptions.MathsException;
+import com.opengamma.longdog.testhelpers.ArraysHelpers;
+
+public class TestOGRealDiagonalMatrixMaterialise {
+
+  @DataProvider
+  public Object[][] dataContainer() {
+    Object[][] obj = new Object[3][4];
+    
+    
+    obj[0][0] = new double[] {1};
+    obj[0][1] = 1;
+    obj[0][2] = 1;
+    obj[0][3] = new double[][] {{1}};
+
+    obj[1][0] = new double[] {1,2,3,4};
+    obj[1][1] = 4;
+    obj[1][2] = 4;
+    obj[1][3] = new double[][] {{1,0,0,0},{0,2,0,0},{0,0,3,0},{0,0,0,4}};
+
+    obj[2][0] = new double[] {1,2,3,4};
+    obj[2][1] = 6;
+    obj[2][2] = 7;
+    obj[2][3] = new double[][] {{1,0,0,0,0,0,0},{0,2,0,0,0,0,0},{0,0,3,0,0,0,0},{0,0,0,4,0,0,0},{0,0,0,0,0,0,0},{0,0,0,0,0,0,0}};
+    
+    return obj;
+  };
+
+  @Test(dataProvider = "dataContainer")
+  public void materialiseToJDoubleArray(double[] input, int rows, int cols, double[][] expected) {
+    OGRealDiagonalMatrix tmp = new OGRealDiagonalMatrix(input, rows, cols);
+    double[][] answer = Materialisers.toDoubleArrayOfArrays(tmp);
+    if (!ArraysHelpers.ArraysEquals(expected, answer)) {
+      throw new MathsException("Arrays not equal");
+    }
+  }
+
+}

--- a/src/java/src/test/java/com/opengamma/longdog/testhelpers/ArraysHelpers.java
+++ b/src/java/src/test/java/com/opengamma/longdog/testhelpers/ArraysHelpers.java
@@ -1,0 +1,37 @@
+package com.opengamma.longdog.testhelpers;
+
+import java.util.Arrays;
+
+import com.opengamma.longdog.helpers.Catchers;
+
+/**
+ * Helper class for arrays
+ */
+public class ArraysHelpers {
+
+  /**
+   * Returns true if the two arrays are numerically equal
+   * @param array1 the first array
+   * @param array2 the second array
+   * @return true if the two arrays are numerically equal
+   */
+  public static boolean ArraysEquals(double[][] array1, double[][] array2) {
+    Catchers.catchNullFromArgList(array1, 1);
+    Catchers.catchNullFromArgList(array2, 2);
+    if (array1 == array2)
+    {
+      return true;
+    }
+    int rows = array1.length;
+    if (rows != array2.length)
+    {
+      return false;
+    }
+    for (int i = 0; i < rows; i++) {
+      if (!Arrays.equals(array1[i], array2[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/src/jshim/jshim.cc
+++ b/src/jshim/jshim.cc
@@ -450,67 +450,89 @@ class ExprFactory
       {
       case OGREALMATRIX_ENUM:
       {
+#ifdef _DEBUG        
         printf("Binding a JOGRealMatrix\n");
+#endif        
         _expr = new JOGRealMatrix(&obj);
       }
       break;
       case OGCOMPLEXMATRIX_ENUM:
       {
+#ifdef _DEBUG        
         printf("Binding a JOGComplexMatrix\n");
+#endif                
         _expr = new JOGComplexMatrix(&obj);
       }
       break;
       case OGREALSPARSEMATRIX_ENUM:
       {
+#ifdef _DEBUG        
         printf("Binding a JOGRealSparseMatrix\n");
+#endif                
         _expr = new JOGRealSparseMatrix(&obj);
       }
       break;
       case OGCOMPLEXSPARSEMATRIX_ENUM:
       {
+#ifdef _DEBUG        
         printf("Binding a JOGComplexSparseMatrix\n");
+#endif                
         _expr = new JOGComplexSparseMatrix(&obj);
       }
       break;
       case OGREALDIAGONALMATRIX_ENUM:
       {
+#ifdef _DEBUG        
         printf("Binding a JOGRealDiagonalMatrix\n");
+#endif                
         _expr = new JOGRealDiagonalMatrix(&obj);
       }
       break;
       case OGCOMPLEXDIAGONALMATRIX_ENUM:
       {
+#ifdef _DEBUG        
         printf("Binding a JOGComplexDiagonalMatrix\n");
+#endif                
         _expr = new JOGComplexDiagonalMatrix(&obj);
       }
       break;      
       case COPY_ENUM:
       {
+#ifdef _DEBUG        
         printf("COPY function\n");
+#endif                
         _expr = new COPY(generateArgs(&obj));
       }
       break;
       case MINUS_ENUM:
       {
+#ifdef _DEBUG          
         printf("MINUS function\n");
+#endif                
         _expr = new MINUS(generateArgs(&obj));
       }
       break;
       case PLUS_ENUM:
       {
+#ifdef _DEBUG          
         printf("PLUS function\n");
+#endif                
         _expr = new PLUS(generateArgs(&obj));
       }
       break;
       case SVD_ENUM:
       {
+#ifdef _DEBUG          
         printf("SVD function\n");
+#endif                
         _expr = new SVD(generateArgs(&obj));
       }
       break;
       case SELECTRESULT_ENUM:
       {
+#ifdef _DEBUG          
         printf("Select Result function\n");
+#endif                
         _expr = new SELECTRESULT(generateArgs(&obj));
       }
       break;

--- a/src/jshim/jshim.cc
+++ b/src/jshim/jshim.cc
@@ -452,42 +452,36 @@ class ExprFactory
       {
         printf("Binding a JOGRealMatrix\n");
         _expr = new JOGRealMatrix(&obj);
-        _expr->debug_print();
       }
       break;
       case OGCOMPLEXMATRIX_ENUM:
       {
         printf("Binding a JOGComplexMatrix\n");
         _expr = new JOGComplexMatrix(&obj);
-        _expr->debug_print();
       }
       break;
       case OGREALSPARSEMATRIX_ENUM:
       {
         printf("Binding a JOGRealSparseMatrix\n");
         _expr = new JOGRealSparseMatrix(&obj);
-        _expr->debug_print();
       }
       break;
       case OGCOMPLEXSPARSEMATRIX_ENUM:
       {
         printf("Binding a JOGComplexSparseMatrix\n");
         _expr = new JOGComplexSparseMatrix(&obj);
-        _expr->debug_print();
       }
       break;
       case OGREALDIAGONALMATRIX_ENUM:
       {
         printf("Binding a JOGRealDiagonalMatrix\n");
         _expr = new JOGRealDiagonalMatrix(&obj);
-        _expr->debug_print();
       }
       break;
       case OGCOMPLEXDIAGONALMATRIX_ENUM:
       {
         printf("Binding a JOGComplexDiagonalMatrix\n");
         _expr = new JOGComplexDiagonalMatrix(&obj);
-        _expr->debug_print();
       }
       break;      
       case COPY_ENUM:


### PR DESCRIPTION
This PR adds support for diagonal matrix classes.
- Fixes up prototype diagonal matrix C++ code.
- Slightly alters internal storage and `<cinit>` behaviour in java as C/C++ doesn't know about the data lengths, the cost of this change in terms of algorithmic complexity is trivially small as the data sets are essentially vectors. The change essentially zero pads a short diagonal to min(rows,cols) so that loop bounds and algs are cleaner.
- Adds our first end to end test of a java `OGTerminal` `java -> C++ -> java` round trip. This is done as a materialise on `OG*Matrix` and `OG*DiagonalMatrix` classes.

bb pass: [http://devmaths-lx-1:8011/builders/nyqwk2-testing/builds/73](http://devmaths-lx-1:8011/builders/nyqwk2-testing/builds/73)
