### PR TITLE
[MAT-199] Check for null args on construction.

### DIFF
--- a/include/expression.hh
+++ b/include/expression.hh
@@ -95,7 +95,6 @@ class OGExpr: public OGNumeric
 class OGUnaryExpr: public OGExpr
 {
   protected:
-    OGUnaryExpr();
     OGUnaryExpr(ArgContainer* args);
     OGUnaryExpr(OGNumeric * args);
 };
@@ -103,7 +102,6 @@ class OGUnaryExpr: public OGExpr
 class OGBinaryExpr : public OGExpr
 {
   protected:
-    OGBinaryExpr();
     OGBinaryExpr(ArgContainer* args);
     OGBinaryExpr(OGNumeric* left, OGNumeric* right);
   private:
@@ -116,8 +114,6 @@ class COPY: public OGUnaryExpr
     COPY(OGNumeric *arg);
     COPY(ArgContainer *args);
     void debug_print();
-  protected:
-    COPY();
   private:
     explicit COPY(COPY& other);
 };
@@ -129,8 +125,6 @@ class PLUS: public OGBinaryExpr
     PLUS(OGNumeric* left, OGNumeric* right);
     PLUS(ArgContainer *args);
     void debug_print();
-  protected:
-    PLUS();
   private:
     explicit PLUS(PLUS& other);
 };
@@ -142,8 +136,6 @@ class MINUS: public OGBinaryExpr
     MINUS(OGNumeric* left, OGNumeric* right);
     MINUS(ArgContainer *args);
     void debug_print();
-  protected:
-    MINUS();
   private:
     explicit MINUS(MINUS& other);
 };
@@ -154,8 +146,6 @@ class SVD: public OGUnaryExpr
     SVD(OGNumeric * arg);
     SVD(ArgContainer *args);
     void debug_print();
-  protected:
-    SVD();
   private:
     explicit SVD(SVD& other);
 };
@@ -166,8 +156,6 @@ class SELECTRESULT: public OGBinaryExpr
     SELECTRESULT(OGNumeric *result, OGNumeric *index);
     SELECTRESULT(ArgContainer *args);
     void debug_print();
-  protected:
-    SELECTRESULT();
   private:
     explicit SELECTRESULT(SELECTRESULT& other);
 };

--- a/include/expression.hh
+++ b/include/expression.hh
@@ -79,7 +79,6 @@ class OGExpr: public OGNumeric
     virtual void debug_print();
     void accept(Visitor &v);
   protected:
-    OGExpr();
     OGExpr(ArgContainer* args);
     void setArgs(ArgContainer* args);
   private:
@@ -96,14 +95,12 @@ class OGUnaryExpr: public OGExpr
 {
   protected:
     OGUnaryExpr(ArgContainer* args);
-    OGUnaryExpr(OGNumeric * args);
 };
 
 class OGBinaryExpr : public OGExpr
 {
   protected:
     OGBinaryExpr(ArgContainer* args);
-    OGBinaryExpr(OGNumeric* left, OGNumeric* right);
   private:
     explicit OGBinaryExpr(OGBinaryExpr& other);
 };
@@ -111,7 +108,6 @@ class OGBinaryExpr : public OGExpr
 class COPY: public OGUnaryExpr
 {
   public:
-    COPY(OGNumeric *arg);
     COPY(ArgContainer *args);
     void debug_print();
   private:
@@ -122,7 +118,6 @@ class COPY: public OGUnaryExpr
 class PLUS: public OGBinaryExpr
 {
   public:
-    PLUS(OGNumeric* left, OGNumeric* right);
     PLUS(ArgContainer *args);
     void debug_print();
   private:
@@ -133,7 +128,6 @@ class PLUS: public OGBinaryExpr
 class MINUS: public OGBinaryExpr
 {
   public:
-    MINUS(OGNumeric* left, OGNumeric* right);
     MINUS(ArgContainer *args);
     void debug_print();
   private:
@@ -143,7 +137,6 @@ class MINUS: public OGBinaryExpr
 class SVD: public OGUnaryExpr
 {
   public:
-    SVD(OGNumeric * arg);
     SVD(ArgContainer *args);
     void debug_print();
   private:
@@ -153,7 +146,6 @@ class SVD: public OGUnaryExpr
 class SELECTRESULT: public OGBinaryExpr
 {
   public:
-    SELECTRESULT(OGNumeric *result, OGNumeric *index);
     SELECTRESULT(ArgContainer *args);
     void debug_print();
   private:

--- a/src/librdag/expression.cc
+++ b/src/librdag/expression.cc
@@ -47,13 +47,9 @@ const OGIntegerScalar* OGNumeric::asOGIntegerScalar() const
  * OGExpr
  */
 
-/*
- * If you use the default constructor, you must call setArgs so that arguments
- * are non-null before you finish construction.
- */
 OGExpr::OGExpr()
 {
-  this->_args = nullptr;
+  this->_args = new ArgContainer();
 }
 
 OGExpr::OGExpr(OGExpr& copy)
@@ -75,10 +71,10 @@ OGExpr::~OGExpr()
   delete this->_args;
 }
 
-ArgContainer *
+ArgContainer*
 OGExpr::getArgs()
 {
-	return this->_args;
+  return this->_args;
 }
 
 void
@@ -88,6 +84,8 @@ OGExpr::setArgs(ArgContainer * args)
   {
     throw new librdagException();
   }
+  // Old args are no longer required.
+  delete this->_args;
   this->_args = args;
 }
 
@@ -113,8 +111,6 @@ OGExpr::accept(Visitor &v)
  * Things that extend OGExpr
  */
 
-OGUnaryExpr::OGUnaryExpr() : OGExpr() {}
-
 OGUnaryExpr::OGUnaryExpr(ArgContainer* args)
 {
   if (args->size() != 1)
@@ -130,8 +126,6 @@ OGUnaryExpr::OGUnaryExpr(OGNumeric* arg)
   args->push_back(arg);
   this->setArgs(args);
 }
-
-OGBinaryExpr::OGBinaryExpr() : OGExpr() {}
 
 OGBinaryExpr::OGBinaryExpr(ArgContainer* args)
 {
@@ -150,8 +144,6 @@ OGBinaryExpr::OGBinaryExpr(OGNumeric* left, OGNumeric* right)
     this->setArgs(args);
 }
 
-COPY::COPY() : OGUnaryExpr() {}
-
 COPY::COPY(OGNumeric *arg) : OGUnaryExpr(arg) {}
 
 COPY::COPY(ArgContainer* args): OGUnaryExpr(args) {}
@@ -162,8 +154,6 @@ COPY::debug_print()
 	cout << "COPY base class" << endl;
 }
 
-PLUS::PLUS() : OGBinaryExpr() {}
-
 PLUS::PLUS(OGNumeric* left, OGNumeric* right) : OGBinaryExpr(left, right) {}
 
 PLUS::PLUS(ArgContainer* args): OGBinaryExpr(args) {}
@@ -173,8 +163,6 @@ PLUS::debug_print()
 {
 	cout << "PLUS base class" << endl;
 }
-
-MINUS::MINUS() : OGBinaryExpr() {}
 
 MINUS::MINUS(OGNumeric* left, OGNumeric* right) : OGBinaryExpr(left, right) {}
 
@@ -187,8 +175,6 @@ MINUS::debug_print()
 	cout << "MINUS base class" << endl;
 }
 
-SVD::SVD() : OGUnaryExpr() {}
-
 SVD::SVD(ArgContainer* args): OGUnaryExpr(args) {}
 
 SVD::SVD(OGNumeric* arg): OGUnaryExpr(arg) {}
@@ -198,8 +184,6 @@ SVD::debug_print()
 {
 	cout << "SVD base class" << endl;
 }
-
-SELECTRESULT::SELECTRESULT() : OGBinaryExpr() {}
 
 SELECTRESULT::SELECTRESULT(ArgContainer* args): OGBinaryExpr(args) {
   // Check that the second argument is an integer

--- a/src/librdag/expression.cc
+++ b/src/librdag/expression.cc
@@ -47,6 +47,10 @@ const OGIntegerScalar* OGNumeric::asOGIntegerScalar() const
  * OGExpr
  */
 
+/*
+ * If you use the default constructor, you must call setArgs so that arguments
+ * are non-null before you finish construction.
+ */
 OGExpr::OGExpr()
 {
   this->_args = nullptr;
@@ -59,6 +63,10 @@ OGExpr::OGExpr(OGExpr& copy)
 
 OGExpr::OGExpr(ArgContainer *args)
 {
+  if (args == nullptr)
+  {
+    throw new librdagException();
+  }
   this->_args = args;
 }
 
@@ -76,7 +84,11 @@ OGExpr::getArgs()
 void
 OGExpr::setArgs(ArgContainer * args)
 {
-	this->_args = args;
+  if (args == nullptr)
+  {
+    throw new librdagException();
+  }
+  this->_args = args;
 }
 
 size_t
@@ -107,9 +119,7 @@ OGUnaryExpr::OGUnaryExpr(ArgContainer* args)
 {
   if (args->size() != 1)
   {
-    //FIXME: Replace with exception when implemented.
-    // For now just die
-    exit(1);
+    throw new librdagException();
   }
   this->setArgs(args);
 }
@@ -123,12 +133,11 @@ OGUnaryExpr::OGUnaryExpr(OGNumeric* arg)
 
 OGBinaryExpr::OGBinaryExpr() : OGExpr() {}
 
-OGBinaryExpr::OGBinaryExpr(ArgContainer* args) {
+OGBinaryExpr::OGBinaryExpr(ArgContainer* args)
+{
   if (args->size() != 2)
   {
-    //FIXME: Replace with exception when implemented.
-    // For now just die
-    exit(1);
+    throw new librdagException();
   }
   this->setArgs(args);
 }

--- a/src/librdag/expression.cc
+++ b/src/librdag/expression.cc
@@ -47,11 +47,6 @@ const OGIntegerScalar* OGNumeric::asOGIntegerScalar() const
  * OGExpr
  */
 
-OGExpr::OGExpr()
-{
-  this->_args = new ArgContainer();
-}
-
 OGExpr::OGExpr(OGExpr& copy)
 {
   this->_args = new ArgContainer(*copy.getArgs());
@@ -77,18 +72,6 @@ OGExpr::getArgs()
   return this->_args;
 }
 
-void
-OGExpr::setArgs(ArgContainer * args)
-{
-  if (args == nullptr)
-  {
-    throw new librdagException();
-  }
-  // Old args are no longer required.
-  delete this->_args;
-  this->_args = args;
-}
-
 size_t
 OGExpr::getNArgs()
 {
@@ -111,40 +94,21 @@ OGExpr::accept(Visitor &v)
  * Things that extend OGExpr
  */
 
-OGUnaryExpr::OGUnaryExpr(ArgContainer* args)
+OGUnaryExpr::OGUnaryExpr(ArgContainer* args): OGExpr(args)
 {
   if (args->size() != 1)
   {
     throw new librdagException();
   }
-  this->setArgs(args);
 }
 
-OGUnaryExpr::OGUnaryExpr(OGNumeric* arg)
-{
-  ArgContainer* args = new ArgContainer();
-  args->push_back(arg);
-  this->setArgs(args);
-}
-
-OGBinaryExpr::OGBinaryExpr(ArgContainer* args)
+OGBinaryExpr::OGBinaryExpr(ArgContainer* args): OGExpr(args)
 {
   if (args->size() != 2)
   {
     throw new librdagException();
   }
-  this->setArgs(args);
 }
-
-OGBinaryExpr::OGBinaryExpr(OGNumeric* left, OGNumeric* right)
-{
-    ArgContainer* args = new ArgContainer();
-    args->push_back(left);
-    args->push_back(right);
-    this->setArgs(args);
-}
-
-COPY::COPY(OGNumeric *arg) : OGUnaryExpr(arg) {}
 
 COPY::COPY(ArgContainer* args): OGUnaryExpr(args) {}
 
@@ -154,8 +118,6 @@ COPY::debug_print()
 	cout << "COPY base class" << endl;
 }
 
-PLUS::PLUS(OGNumeric* left, OGNumeric* right) : OGBinaryExpr(left, right) {}
-
 PLUS::PLUS(ArgContainer* args): OGBinaryExpr(args) {}
 
 void
@@ -163,8 +125,6 @@ PLUS::debug_print()
 {
 	cout << "PLUS base class" << endl;
 }
-
-MINUS::MINUS(OGNumeric* left, OGNumeric* right) : OGBinaryExpr(left, right) {}
 
 MINUS::MINUS(ArgContainer* args): OGBinaryExpr(args) {
 }
@@ -177,8 +137,6 @@ MINUS::debug_print()
 
 SVD::SVD(ArgContainer* args): OGUnaryExpr(args) {}
 
-SVD::SVD(OGNumeric* arg): OGUnaryExpr(arg) {}
-
 void
 SVD::debug_print()
 {
@@ -188,16 +146,6 @@ SVD::debug_print()
 SELECTRESULT::SELECTRESULT(ArgContainer* args): OGBinaryExpr(args) {
   // Check that the second argument is an integer
   const OGIntegerScalar* i = (*args)[1]->asOGIntegerScalar();
-  if (i == nullptr)
-  {
-    // FIXME: Throw exception when exceptions set up. die for now.
-    exit(1);
-  }
-}
-
-SELECTRESULT::SELECTRESULT(OGNumeric* result, OGNumeric* index): OGBinaryExpr(result, index)
-{
-  const OGIntegerScalar* i = (*(this->getArgs()))[1]->asOGIntegerScalar();
   if (i == nullptr)
   {
     // FIXME: Throw exception when exceptions set up. die for now.

--- a/src/librdag/test/check_expressions.cc
+++ b/src/librdag/test/check_expressions.cc
@@ -45,13 +45,6 @@ TEST(OGExprTest, ComplexValues) {
 
 TEST(OGExprTest, COPY){
   // Constructor
-  OGRealScalar *real = new OGRealScalar(1.0);
-  OGExpr *copy = new COPY(real);
-  ArgContainer* args = copy->getArgs();
-  ASSERT_EQ(1, copy->getNArgs());
-  EXPECT_EQ(real, ((*args)[0])->asOGRealScalar());
-
-  // Constructor with args
   ArgContainer* newArgs = new ArgContainer();
   OGRealScalar *newReal = new OGRealScalar(3.14);
   newArgs->push_back(newReal);
@@ -63,21 +56,11 @@ TEST(OGExprTest, COPY){
   // FIXME: Needs implementing once this throws an exception.
 
   // Cleanup
-  delete copy;
   delete copyWithArgs;
 }
 
 TEST(OGExprTest, PLUS){
   // Constructor
-  OGRealScalar *real = new OGRealScalar(1.0);
-  OGComplexScalar *complx = new OGComplexScalar(complex16(2.0,3.0));
-  OGExpr *plus = new PLUS(real, complx);
-  ArgContainer* args = plus->getArgs();
-  ASSERT_EQ(2, plus->getNArgs());
-  EXPECT_EQ(real, ((*args)[0])->asOGRealScalar());
-  EXPECT_EQ(complx, ((*args)[1])->asOGComplexScalar());
-
-  // Constructor with args
   ArgContainer* newArgs = new ArgContainer();
   OGRealScalar *newReal = new OGRealScalar(3.14);
   OGComplexScalar *newComplx = new OGComplexScalar(complex16(2.7182, 2.7182));
@@ -92,21 +75,11 @@ TEST(OGExprTest, PLUS){
   // FIXME: Needs implementing once this throws an exception.
 
   // Cleanup
-  delete plus;
   delete plusWithArgs;
 }
 
 TEST(OGExprTest, MINUS){
   // Constructor
-  OGRealScalar *real = new OGRealScalar(1.0);
-  OGComplexScalar *complx = new OGComplexScalar(complex16(2.0,3.0));
-  OGExpr *minus = new MINUS(real, complx);
-  ArgContainer* args = minus->getArgs();
-  ASSERT_EQ(2, minus->getNArgs());
-  EXPECT_EQ(real, ((*args)[0])->asOGRealScalar());
-  EXPECT_EQ(complx, ((*args)[1])->asOGComplexScalar());
-
-  // Constructor with args
   ArgContainer* newArgs = new ArgContainer();
   OGRealScalar *newReal = new OGRealScalar(3.14);
   OGComplexScalar *newComplx = new OGComplexScalar(complex16(2.7182, 2.7182));
@@ -121,19 +94,11 @@ TEST(OGExprTest, MINUS){
   // FIXME: Needs implementing once this throws an exception.
 
   // Cleanup
-  delete minus;
   delete minusWithArgs;
 }
 
 TEST(OGExprTest, SVD){
   // Constructor
-  OGRealScalar *real = new OGRealScalar(1.0);
-  OGExpr *svd = new SVD(real);
-  ArgContainer* args = svd->getArgs();
-  ASSERT_EQ(1, svd->getNArgs());
-  EXPECT_EQ(real, ((*args)[0])->asOGRealScalar());
-
-  // Constructor with args
   ArgContainer* newArgs = new ArgContainer();
   OGRealScalar *newReal = new OGRealScalar(3.14);
   newArgs->push_back(newReal);
@@ -145,21 +110,11 @@ TEST(OGExprTest, SVD){
   // FIXME: Needs implementing once this throws an exception.
 
   // Cleanup
-  delete svd;
   delete svdWithArgs;
 }
 
 TEST(OGExprTest, SELECTRESULT){
   // Constructor
-  OGRealScalar *real = new OGRealScalar(1.0);
-  OGIntegerScalar *index = new OGIntegerScalar(1);
-  OGExpr *select = new SELECTRESULT(real, index);
-  ArgContainer* args = select->getArgs();
-  ASSERT_EQ(2, select->getNArgs());
-  EXPECT_EQ(real, ((*args)[0])->asOGRealScalar());
-  EXPECT_EQ(index, ((*args)[1])->asOGIntegerScalar());
-
-  // Constructor with args
   ArgContainer* newArgs = new ArgContainer();
   OGRealScalar *newReal = new OGRealScalar(3.14);
   OGIntegerScalar *newIndex = new OGIntegerScalar(2);
@@ -177,7 +132,6 @@ TEST(OGExprTest, SELECTRESULT){
   // FIXME: Needs implementing once this throws an exception.
 
   // Cleanup
-  delete select;
   delete selectWithArgs;
 }
 


### PR DESCRIPTION
Unfortunately there seems to be no way to get rid of OGExpr(),
because of the one- and two-argument constructors of OGUnaryExpr
and OGBinaryExpr. However, OGExpr objects will never end up with
null args as long as OGExpr subclass constructors always ensure
that setArgs() is called if the use the default OGExpr()
constructor.
