### PR TITLE
[MAT-201] add JNI bindings for OG{Real,Complex}Scalar

### DIFF
--- a/src/java/pom.xml
+++ b/src/java/pom.xml
@@ -1,9 +1,3 @@
-<!--
- Copyright (C) 2013 - present by OpenGamma Inc. and the OpenGamma group of companies
-
- Please see distribution for license.
--->
-
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">

--- a/src/java/src/main/java/com/opengamma/longdog/materialisers/Materialisers.java
+++ b/src/java/src/main/java/com/opengamma/longdog/materialisers/Materialisers.java
@@ -10,6 +10,7 @@ import com.opengamma.longdog.datacontainers.OGNumeric;
 import com.opengamma.longdog.datacontainers.lazy.OGExpr;
 import com.opengamma.longdog.datacontainers.matrix.OGArray;
 import com.opengamma.longdog.datacontainers.other.ComplexArrayContainer;
+import com.opengamma.longdog.datacontainers.scalar.OGScalar;
 import com.opengamma.longdog.helpers.Catchers;
 import com.opengamma.longdog.nativeloader.NativeLibraries;
 import com.opengamma.longdog.nodes.SELECTRESULT;
@@ -80,7 +81,7 @@ public class Materialisers {
     Catchers.catchCondition(level < 0, "Level must be >= 0");
     final String tab = "   ";
     level++;
-    while (!(OGArray.class.isAssignableFrom(arg.getClass()))) {
+    while (!(OGArray.class.isAssignableFrom(arg.getClass()) || OGScalar.class.isAssignableFrom(arg.getClass()))) {
       OGExpr expr = (OGExpr) arg;
       buf.append(new String(new char[level]).replace("\0", tab) + arg.getClass());
       if (expr instanceof SELECTRESULT) {

--- a/src/java/src/test/java/com/opengamma/longdog/materialisers/TestOGComplexScalarMaterialise.java
+++ b/src/java/src/test/java/com/opengamma/longdog/materialisers/TestOGComplexScalarMaterialise.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2013 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+package com.opengamma.longdog.materialisers;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.opengamma.longdog.datacontainers.other.ComplexArrayContainer;
+import com.opengamma.longdog.datacontainers.scalar.OGComplexScalar;
+import com.opengamma.longdog.exceptions.MathsException;
+import com.opengamma.longdog.testhelpers.ArraysHelpers;
+
+public class TestOGComplexScalarMaterialise {
+
+  @DataProvider
+  public Object[][] dataContainer() {
+    Object[][] obj = new Object[1][3];
+
+    obj[0][0] = new double[] { 1.d, 10.d };
+    obj[0][1] = new double[][] { { 1 } };
+    obj[0][2] = new double[][] { { 10 } };
+
+    return obj;
+  };
+
+  @Test(dataProvider = "dataContainer")
+  public void materialiseToJDoubleArray(double[] input, double[][] expectedReal, double[][] expectedImag) {
+    OGComplexScalar tmp = new OGComplexScalar(input);
+    ComplexArrayContainer answer = Materialisers.toComplexArrayContainer(tmp);
+    if (!ArraysHelpers.ArraysEquals(expectedReal, answer.getReal())) {
+      throw new MathsException("REAL: Arrays not equal");
+    }
+    if (!ArraysHelpers.ArraysEquals(expectedImag, answer.getImag())) {
+      throw new MathsException("IMAG: Arrays not equal");
+    }
+  }
+
+}

--- a/src/java/src/test/java/com/opengamma/longdog/materialisers/TestOGRealScalarMaterialise.java
+++ b/src/java/src/test/java/com/opengamma/longdog/materialisers/TestOGRealScalarMaterialise.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) 2013 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+package com.opengamma.longdog.materialisers;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.opengamma.longdog.datacontainers.scalar.OGRealScalar;
+import com.opengamma.longdog.exceptions.MathsException;
+import com.opengamma.longdog.testhelpers.ArraysHelpers;
+
+public class TestOGRealScalarMaterialise {
+
+  @DataProvider
+  public Object[][] dataContainer() {
+    Object[][] obj = new Object[1][2];
+    
+    
+    obj[0][0] = 10.d;
+    obj[0][1] = new double[][] {{10}};
+   
+    return obj;
+  };
+
+  @Test(dataProvider = "dataContainer")
+  public void materialiseToJDoubleArray(double input, double[][] expected) {
+    OGRealScalar tmp = new OGRealScalar(input);
+    double[][] answer = Materialisers.toDoubleArrayOfArrays(tmp);
+    if (!ArraysHelpers.ArraysEquals(expected, answer)) {
+      throw new MathsException("Arrays not equal");
+    }
+  }
+
+}

--- a/src/jshim/jshim.cc
+++ b/src/jshim/jshim.cc
@@ -86,7 +86,10 @@ template <typename T> struct OGTerminalPtrContainer_t
 
 
 /*
- * An OGRealScalar backed by data pinned from a Java based OGRealScalar
+ * An OGRealScalar backed by data pinned from a Java based OGRealScalar.
+ * Note that _dataref is assigned on construction of the OGRealScalar base class,
+ * this is to keep JNI calls to a minimum by holding reference to the data pointer needed
+ * to free via the ReleasePrimitiveArrayCritical() function.
  */
 class JOGRealScalar: public OGRealScalar
 {
@@ -103,6 +106,7 @@ class JOGRealScalar: public OGRealScalar
     {
       unbindOGArrayData<real16>(this->_dataRef, *_backingObject);      
       this->_backingObject = nullptr;
+      this->_dataRef = nullptr;
     };
     void debug_print()
     {
@@ -115,7 +119,10 @@ class JOGRealScalar: public OGRealScalar
 };
 
 /*
- * An OGComplexScalar backed by data pinned from a Java based OGRealScalar
+ * An OGComplexScalar backed by data pinned from a Java based OGRealScalar.
+ * Note that _dataref is assigned on construction of the OGComplexScalar base class,
+ * this is to keep JNI calls to a minimum by holding reference to the data pointer needed
+ * to free via the ReleasePrimitiveArrayCritical() function.
  */
 class JOGComplexScalar: public OGComplexScalar
 {
@@ -132,6 +139,7 @@ class JOGComplexScalar: public OGComplexScalar
     {
       unbindOGArrayData<complex16>(this->_dataRef, *_backingObject);      
       this->_backingObject = nullptr;
+      this->_dataRef = nullptr;
     };
     void debug_print()
     {

--- a/src/jshim/jshim.cc
+++ b/src/jshim/jshim.cc
@@ -84,6 +84,67 @@ template <typename T> struct OGTerminalPtrContainer_t
   int * rowIdx;
 };
 
+
+/*
+ * An OGRealScalar backed by data pinned from a Java based OGRealScalar
+ */
+class JOGRealScalar: public OGRealScalar
+{
+  public:
+    using OGRealScalar::OGRealScalar;
+    JOGRealScalar(jobject * obj): OGRealScalar
+      (
+        static_cast<real16 *>(_dataRef = bindPrimitiveArrayData<real16, jdoubleArray>(*obj, OGTerminalClazz_getData))[0]
+      )
+    {
+      this->_backingObject = obj;
+    };
+    ~JOGRealScalar()
+    {
+      unbindOGArrayData<real16>(this->_dataRef, *_backingObject);      
+      this->_backingObject = nullptr;
+    };
+    void debug_print()
+    {
+      printf("\nJava bound OGRealScalar\n");
+      OGRealScalar::debug_print();
+    }
+  private:
+    jobject * _backingObject = nullptr;
+    real16 * _dataRef = nullptr;
+};
+
+/*
+ * An OGComplexScalar backed by data pinned from a Java based OGRealScalar
+ */
+class JOGComplexScalar: public OGComplexScalar
+{
+  public:
+    using OGComplexScalar::OGComplexScalar;
+    JOGComplexScalar(jobject * obj): OGComplexScalar
+      (
+        static_cast<complex16 *>(_dataRef = bindPrimitiveArrayData<complex16, jdoubleArray>(*obj, OGTerminalClazz_getData))[0]
+      )
+    {
+      this->_backingObject = obj;
+    };
+    ~JOGComplexScalar()
+    {
+      unbindOGArrayData<complex16>(this->_dataRef, *_backingObject);      
+      this->_backingObject = nullptr;
+    };
+    void debug_print()
+    {
+      printf("\nJava bound JOGComplexScalar\n");
+      OGComplexScalar::debug_print();
+    }
+  private:
+    jobject * _backingObject = nullptr;
+    complex16 * _dataRef = nullptr;
+};
+
+
+
 /*
  * An OGRealMatrix backed by data pinned from a Java based OGRealMatrix
  */
@@ -454,6 +515,22 @@ class ExprFactory
 
       switch(ID)
       {
+      case OGREALSCALAR_ENUM:
+      {
+#ifdef _DEBUG
+        printf("Binding a JOGRealScalar\n");
+#endif
+        _expr = new JOGRealScalar(&obj);
+      } 
+      break;
+      case OGCOMPLEXSCALAR_ENUM:
+      {
+#ifdef _DEBUG
+        printf("Binding a JOGComplexScalar\n");
+#endif
+        _expr = new JOGComplexScalar(&obj);
+      } 
+      break;
       case OGREALMATRIX_ENUM:
       {
 #ifdef _DEBUG


### PR DESCRIPTION
Addresses MAT-201
- Adds binding for OGRealScalar and OGComplexScalar
- Does something a bit naughty by assigning a ref to the underlying JVM data ptr on assignment this is so:
  - JNI calls are kept to a minimum
  - The unbindPrimitiveArrayData<T,S> template can be reused opposed to having to implement 3/4 of it again in the dtor of the JOG*Scalar methods.
- Quick fix in pom.xml, apparently <!-- --> is not allowed and eclipse won't resolve the pom with it in.

BB pass: [http://devmaths-lx-1:8011/builders/nyqwk2-testing/builds/106](http://devmaths-lx-1:8011/builders/nyqwk2-testing/builds/106)
