### PR TITLE
[MAT-184] Some addition of const and virtual

### DIFF
--- a/include/containers.hh
+++ b/include/containers.hh
@@ -27,7 +27,7 @@ class NonOwningPtrVector
   public:
     NonOwningPtrVector()
     {
-      _vector = new vector<T*>();
+      _vector = new vector<T const *>();
     }
 
     ~NonOwningPtrVector()
@@ -35,9 +35,9 @@ class NonOwningPtrVector
       delete _vector;
     }
 
-    typedef typename vector<T*>::const_iterator citerator;
+    typedef typename vector<T const *>::const_iterator citerator;
 
-    void push_back(T* arg)
+    void push_back(T const * arg)
     {
       _check_arg(arg);
       _vector->push_back(arg);
@@ -83,8 +83,8 @@ class NonOwningPtrVector
     }
 
   private:
-    vector<T*>* _vector;
-    void _check_arg(T* arg)
+    vector<T const *>* _vector;
+    void _check_arg(T const * arg)
     {
       if (arg == nullptr)
       {

--- a/include/visitor.hh
+++ b/include/visitor.hh
@@ -27,14 +27,14 @@ class Visitor
   public:
     Visitor() = default;
     virtual ~Visitor() = default;
-    virtual void visit(OGExpr *thing) = 0;
-    virtual void visit(OGArray<real16> *thing) = 0;
-    virtual void visit(OGArray<complex16> *thing) = 0;
-    virtual void visit(OGMatrix<real16> *thing) = 0;
-    virtual void visit(OGMatrix<complex16> *thing) = 0;
-    virtual void visit(OGScalar<real16> *thing) = 0;
-    virtual void visit(OGScalar<complex16> *thing) = 0;
-    virtual void visit(OGScalar<int> *thing) = 0;
+    virtual void visit(OGExpr const *thing) = 0;
+    virtual void visit(OGArray<real16> const *thing) = 0;
+    virtual void visit(OGArray<complex16> const *thing) = 0;
+    virtual void visit(OGMatrix<real16> const *thing) = 0;
+    virtual void visit(OGMatrix<complex16> const *thing) = 0;
+    virtual void visit(OGScalar<real16> const *thing) = 0;
+    virtual void visit(OGScalar<complex16> const *thing) = 0;
+    virtual void visit(OGScalar<int> const *thing) = 0;
 };
 
 }

--- a/src/jshim/jshim.cc
+++ b/src/jshim/jshim.cc
@@ -242,13 +242,13 @@ class JOGRealSparseMatrix: public OGRealSparseMatrix
       printf("\nJava bound OGRealSparseMatrix\n");
       OGRealSparseMatrix::debug_print();
     }
-    real16 ** toReal16ArrayOfArrays() override
+    real16 ** toReal16ArrayOfArrays() const override
     {
       double ** foo = NULL;
       printf("returning null as no impl yet!!!!\n");
       return foo;
     }
-    complex16 ** toComplex16ArrayOfArrays() override
+    complex16 ** toComplex16ArrayOfArrays() const override
     {
       complex16 ** foo = NULL;
       printf("returning null as no impl yet!!!!\n");
@@ -287,13 +287,13 @@ class JOGComplexSparseMatrix: public OGComplexSparseMatrix
       printf("\nJava bound OGComplexSparseMatrix\n");
       OGComplexSparseMatrix::debug_print();
     }
-    real16 ** toReal16ArrayOfArrays() override
+    real16 ** toReal16ArrayOfArrays() const override
     {
       double ** foo = NULL;
       printf("returning null as no impl yet!!!!\n");
       return foo;
     }
-    complex16 ** toComplex16ArrayOfArrays() override
+    complex16 ** toComplex16ArrayOfArrays() const override
     {
       complex16 ** foo = NULL;
       printf("returning null as no impl yet!!!!\n");
@@ -711,8 +711,7 @@ class DispatchToReal16ArrayOfArrays: public librdag::Visitor
 {
   public:
 
-    DispatchToReal16ArrayOfArrays() {}
-    ~DispatchToReal16ArrayOfArrays()
+    virtual ~DispatchToReal16ArrayOfArrays() override
     {
       real16 ** arr = this->getData();
       if(arr)
@@ -725,41 +724,41 @@ class DispatchToReal16ArrayOfArrays: public librdag::Visitor
         delete arr;
       }
     }
-    void visit(librdag::OGExpr SUPPRESS_UNUSED *thing)
+    virtual void visit(librdag::OGExpr const SUPPRESS_UNUSED *thing) override
     {
       throw std::runtime_error("DispatchToReal16ArrayOfArrays::visit(librdag::OGExpr)");
     };
-    void visit(librdag::OGArray<real16> *thing)
+    virtual void visit(librdag::OGArray<real16> const *thing) override
     {
       this->setData(thing->toReal16ArrayOfArrays());
       this->setRows(thing->getRows());
       this->setCols(thing->getCols());
     }
-    void visit(librdag::OGArray<complex16> SUPPRESS_UNUSED *thing)
+    virtual void visit(librdag::OGArray<complex16> const SUPPRESS_UNUSED *thing) override
     {
       throw std::runtime_error("DispatchToReal16ArrayOfArrays::visit(librdag::OGArray<complex16>)");
     }
-    void visit(librdag::OGMatrix<real16> *thing)
+    virtual void visit(librdag::OGMatrix<real16> const *thing) override
     {
       this->setData(thing->toReal16ArrayOfArrays());
       this->setRows(thing->getRows());
       this->setCols(thing->getCols());
     }
-    void visit(librdag::OGMatrix<complex16> SUPPRESS_UNUSED *thing)
+    virtual void visit(librdag::OGMatrix<complex16> const SUPPRESS_UNUSED *thing) override
     {
       throw std::runtime_error("DispatchToReal16ArrayOfArrays::visit(librdag::OGMatrix<complex16>)");
     }
-    void visit(librdag::OGScalar<real16> *thing)
+    virtual void visit(librdag::OGScalar<real16> const *thing) override
     {
       this->setData(thing->toReal16ArrayOfArrays());
       this->setRows(1);
       this->setCols(1);
     }
-    void visit(librdag::OGScalar<complex16> SUPPRESS_UNUSED *thing)
+    virtual void visit(librdag::OGScalar<complex16> const SUPPRESS_UNUSED *thing) override
     {
       throw std::runtime_error("DispatchToReal16ArrayOfArrays::visit(librdag::OGScalar<complex16>)");
     }
-    void visit(librdag::OGScalar<int> SUPPRESS_UNUSED *thing)
+    virtual void visit(librdag::OGScalar<int> const SUPPRESS_UNUSED *thing) override
     {
       throw std::runtime_error("DispatchToReal16ArrayOfArrays::visit(librdag::OGScalar<int>)");
     }
@@ -796,9 +795,7 @@ class DispatchToReal16ArrayOfArrays: public librdag::Visitor
 class DispatchToComplex16ArrayOfArrays: public librdag::Visitor
 {
   public:
-
-    DispatchToComplex16ArrayOfArrays() {}
-    ~DispatchToComplex16ArrayOfArrays()
+    virtual ~DispatchToComplex16ArrayOfArrays() override
     {
       complex16 ** arr = this->getData();
       if(arr)
@@ -811,43 +808,43 @@ class DispatchToComplex16ArrayOfArrays: public librdag::Visitor
         delete arr;
       }
     }
-    void visit(librdag::OGExpr SUPPRESS_UNUSED *thing)
+    virtual void visit(librdag::OGExpr const SUPPRESS_UNUSED *thing) override
     {
       throw std::runtime_error("DispatchToReal16ArrayOfArrays::visit(librdag::OGExpr)");
     };
-    void visit(librdag::OGArray<complex16> *thing)
+    virtual void visit(librdag::OGArray<complex16> const *thing) override
     {
       printf("Visitor: librdag::OGArray<complex16> branch\n");
       this->setData(thing->toComplex16ArrayOfArrays());
       this->setRows(thing->getRows());
       this->setCols(thing->getCols());
     }
-    void visit(librdag::OGArray<real16> SUPPRESS_UNUSED *thing)
+    virtual void visit(librdag::OGArray<real16> const SUPPRESS_UNUSED *thing) override
     {
       throw std::runtime_error("DispatchToReal16ArrayOfArrays::visit(librdag::OGArray<real16>)");
     }
-    void visit(librdag::OGMatrix<complex16> *thing)
+    virtual void visit(librdag::OGMatrix<complex16> const *thing) override
     {
       printf("Visitor: librdag::OGMatrix<complex16> branch\n");
       this->setData(thing->toComplex16ArrayOfArrays());
       this->setRows(thing->getRows());
       this->setCols(thing->getCols());
     }
-    void visit(librdag::OGMatrix<real16> SUPPRESS_UNUSED *thing)
+    virtual void visit(librdag::OGMatrix<real16> const SUPPRESS_UNUSED *thing) override
     {
       throw std::runtime_error("DispatchToReal16ArrayOfArrays::visit(librdag::OGMatrix<real16>)");
     }
-    void visit(librdag::OGScalar<complex16> *thing)
+    virtual void visit(librdag::OGScalar<complex16> const *thing) override
     {
       this->setData(thing->toComplex16ArrayOfArrays());
       this->setRows(1);
       this->setCols(1);
     }
-    void visit(librdag::OGScalar<real16> SUPPRESS_UNUSED *thing)
+    virtual void visit(librdag::OGScalar<real16> const SUPPRESS_UNUSED *thing) override
     {
       throw std::runtime_error("DispatchToReal16ArrayOfArrays::visit(librdag::OGScalar<real16>)");
     }
-    void visit(librdag::OGScalar<int> SUPPRESS_UNUSED *thing)
+    virtual void visit(librdag::OGScalar<int> const SUPPRESS_UNUSED *thing) override
     {
       throw std::runtime_error("DispatchToReal16ArrayOfArrays::visit(librdag::OGScalar<int>)");
     }

--- a/src/librdag/entrypt.cc
+++ b/src/librdag/entrypt.cc
@@ -26,8 +26,8 @@ class Walker
   public:
     Walker();
     ~Walker();
-    librdag::OGNumeric * walk(librdag::OGNumeric * numeric_expr_types);
-    void talkandwalk(librdag::OGNumeric * numeric_expr_types);
+    librdag::OGNumeric * walk(librdag::OGNumeric* numeric_expr_types);
+    void talkandwalk(librdag::OGNumeric const * numeric_expr_types);
 };
 
 /**
@@ -45,7 +45,7 @@ class PrintTreeVisitor: public librdag::Visitor
     {
       _walker = NULL;
     }
-    void visit(librdag::OGExpr *thing)
+    virtual void visit(librdag::OGExpr const *thing) override
     {
       cout << "Have OGExpr type ";
       thing->debug_print();
@@ -58,31 +58,31 @@ class PrintTreeVisitor: public librdag::Visitor
         _walker->talkandwalk(*(it));
       }
     };
-    void visit(librdag::OGArray<real16> *thing)
+    void visit(librdag::OGArray<real16> const *thing) override
     {
       cout << "Have OGArray<real16> " << thing << endl;
     }
-    void visit(librdag::OGMatrix<real16> *thing)
+    void visit(librdag::OGMatrix<real16> const *thing) override
     {
       cout << "Have OGMatrix<real16> " << thing << endl;
     }
-    void visit(librdag::OGMatrix<complex16> *thing)
+    void visit(librdag::OGMatrix<complex16> const *thing) override
     {
       cout << "Have OGMatrix<complex16> " << thing << endl;
     }    
-    void visit(librdag::OGArray<complex16> *thing)
+    void visit(librdag::OGArray<complex16> const *thing) override
     {
       cout << "Have OGArray<complex16> " << thing << endl;
     }
-    void visit(librdag::OGScalar<real16> *thing)
+    void visit(librdag::OGScalar<real16> const *thing) override
     {
       cout << "Have OGScalar<real16> " << thing << endl;
     }
-    void visit(librdag::OGScalar<complex16> *thing)
+    void visit(librdag::OGScalar<complex16> const *thing) override
     {
       cout << "Have OGScalar<complex16> " << thing << endl;
     }
-    void visit(librdag::OGScalar<int> *thing)
+    void visit(librdag::OGScalar<int> const *thing) override
     {
       cout << "Have OGScalar<int> " << thing << endl;
     }
@@ -110,7 +110,7 @@ librdag::OGNumeric * Walker::walk(librdag::OGNumeric * numeric_expr_types)
   printf("Finished Walking DAG.\n");
   return numeric_expr_types;
 }
-void Walker::talkandwalk(librdag::OGNumeric * numeric_expr_types)
+void Walker::talkandwalk(librdag::OGNumeric const * numeric_expr_types)
 {
   level++;
   const char ch = ' ';

--- a/src/librdag/execution.cc
+++ b/src/librdag/execution.cc
@@ -19,7 +19,7 @@ class Lineariser: public Visitor
       return _execlist;
     }
 
-    virtual void visit(OGExpr *tree)
+    virtual void visit(OGExpr const *tree) override
     {
       const ArgContainer* args = tree->getArgs();
       for (auto it = args->begin(); it != args->end(); ++it)
@@ -29,43 +29,43 @@ class Lineariser: public Visitor
       _execlist->push_back(tree);
     }
 
-    virtual void visit(OGArray<real16> *thing)
+    virtual void visit(OGArray<real16> const *thing)
     {
       visit_terminal(thing);
     }
 
-    virtual void visit(OGArray<complex16> *thing)
+    virtual void visit(OGArray<complex16> const *thing)
     {
       visit_terminal(thing);
     }
 
-    virtual void visit(OGMatrix<real16> *thing)
+    virtual void visit(OGMatrix<real16> const *thing)
     {
       visit_terminal(thing);
     }
 
-    virtual void visit(OGMatrix<complex16> *thing)
+    virtual void visit(OGMatrix<complex16> const *thing)
     {
       visit_terminal(thing);
     }
 
-    virtual void visit(OGScalar<real16> *thing)
+    virtual void visit(OGScalar<real16> const *thing)
     {
       visit_terminal(thing);
     }
 
-    virtual void visit(OGScalar<complex16> *thing)
+    virtual void visit(OGScalar<complex16> const *thing)
     {
       visit_terminal(thing);
     }
 
-    virtual void visit(OGScalar<int> *thing)
+    virtual void visit(OGScalar<int> const *thing)
     {
       visit_terminal(thing);
     }
 
   private:
-    void visit_terminal(OGTerminal *tree)
+    void visit_terminal(OGTerminal const *tree)
     {
       _execlist->push_back(tree);
     }

--- a/src/librdag/expression.cc
+++ b/src/librdag/expression.cc
@@ -17,14 +17,12 @@ namespace librdag
  * OGNumeric
  */
 
-OGNumeric::OGNumeric() {}
-
 OGNumeric::~OGNumeric()
 {
 }
 
 void
-OGNumeric::debug_print()
+OGNumeric::debug_print() const
 {
   cout << "Abstract OGNumeric type" << endl;
 }
@@ -138,19 +136,19 @@ OGExpr::getArgs() const
 }
 
 size_t
-OGExpr::getNArgs()
+OGExpr::getNArgs() const
 {
   return this->_args->size();
 }
 
 void
-OGExpr::debug_print()
+OGExpr::debug_print() const
 {
 	cout << "OGExpr base class" << endl;
 }
 
 void
-OGExpr::accept(Visitor &v)
+OGExpr::accept(Visitor &v) const
 {
   v.visit(this);
 }
@@ -178,7 +176,7 @@ OGBinaryExpr::OGBinaryExpr(ArgContainer* args): OGExpr(args)
 COPY::COPY(ArgContainer* args): OGUnaryExpr(args) {}
 
 OGNumeric*
-COPY::copy()
+COPY::copy() const
 {
   return new COPY(this->getArgs()->copy());
 }
@@ -190,7 +188,7 @@ COPY::asCOPY() const
 }
 
 void
-COPY::debug_print()
+COPY::debug_print() const
 {
 	cout << "COPY base class" << endl;
 }
@@ -198,7 +196,7 @@ COPY::debug_print()
 PLUS::PLUS(ArgContainer* args): OGBinaryExpr(args) {}
 
 OGNumeric*
-PLUS::copy()
+PLUS::copy() const
 {
   return new PLUS(this->getArgs()->copy());
 }
@@ -210,7 +208,7 @@ PLUS::asPLUS() const
 }
 
 void
-PLUS::debug_print()
+PLUS::debug_print() const
 {
 	cout << "PLUS base class" << endl;
 }
@@ -219,7 +217,7 @@ MINUS::MINUS(ArgContainer* args): OGBinaryExpr(args) {
 }
 
 OGNumeric*
-MINUS::copy()
+MINUS::copy() const
 {
   return new MINUS(this->getArgs()->copy());
 }
@@ -231,7 +229,7 @@ MINUS::asMINUS() const
 }
 
 void
-MINUS::debug_print()
+MINUS::debug_print() const
 {
 	cout << "MINUS base class" << endl;
 }
@@ -239,7 +237,7 @@ MINUS::debug_print()
 SVD::SVD(ArgContainer* args): OGUnaryExpr(args) {}
 
 OGNumeric*
-SVD::copy()
+SVD::copy() const
 {
   return new SVD(this->getArgs()->copy());
 }
@@ -251,7 +249,7 @@ SVD::asSVD() const
 }
 
 void
-SVD::debug_print()
+SVD::debug_print() const
 {
 	cout << "SVD base class" << endl;
 }
@@ -266,7 +264,7 @@ SELECTRESULT::SELECTRESULT(ArgContainer* args): OGBinaryExpr(args) {
 }
 
 OGNumeric*
-SELECTRESULT::copy()
+SELECTRESULT::copy() const
 {
   return new SELECTRESULT(this->getArgs()->copy());
 }
@@ -278,7 +276,7 @@ SELECTRESULT::asSELECTRESULT() const
 }
 
 void
-SELECTRESULT::debug_print()
+SELECTRESULT::debug_print() const
 {
 	printf("SELECTRESULT base class\n");
 }

--- a/src/librdag/test/check_execution.cc
+++ b/src/librdag/test/check_execution.cc
@@ -67,7 +67,7 @@ TEST(LinearisationTest, BinaryTreeLinearisation)
   EXPECT_EQ(3, el1->size());
   // Check ordering. We iterate over the list and get
   // its contents first.
-  OGNumeric* nodes[3];
+  const OGNumeric* nodes[3];
   int i = 0;
   for (auto it = el1->begin(); it != el1->end(); ++it)
   {
@@ -113,7 +113,7 @@ TEST(LinearisationTest, BinaryUnaryLinearisation)
   ExecutionList *el1 = new ExecutionList(plus);
   // Check ordering. We iterate over the list and get
   // its contents first.
-  OGNumeric* nodes[4];
+  const OGNumeric* nodes[4];
   int i = 0;
   for (auto it = el1->begin(); it != el1->end(); ++it)
   {


### PR DESCRIPTION
The original intention of this commit was to make
OGNumeric::debug_print, copy and accept const. The result was the
requirement for all the added consts.

Along the way many methods that were virtual in the superclass
were declared non-virtual in the subclass.
