### PR TITLE
[MAT-221] Fix confusing PtrVector class hierarchy

### DIFF
--- a/include/containers.hh
+++ b/include/containers.hh
@@ -18,49 +18,55 @@ namespace librdag {
 
 /*
  * A vector that holds pointers. Null pointers are not allowed.
- *
- * Data that a NonOwningPtrVector points to is not owned by it.
  */
 template<typename T>
-class NonOwningPtrVector
+class PtrVector
 {
   public:
-    NonOwningPtrVector();
-    ~NonOwningPtrVector();
+    PtrVector();
+    virtual ~PtrVector();
     typedef typename vector<T const *>::const_iterator citerator;
     void push_back(T const * arg);
     size_t size() const;
     citerator begin() const;
     citerator end() const;
     const T* operator[](size_t n) const;
-    NonOwningPtrVector* copy() const;
-  protected:
-    void emptyVector();
+    virtual PtrVector* copy() const = 0;
   private:
     vector<T const *>* _vector;
     void _check_arg(T const * arg);
 };
 
 /*
- * A vector that holds pointers. Null pointers are not allowed.
- *
- * Data that a PtrVector points to is owned by it. Classes held in a PtrVector
- * must define a method copy() that returns a pointer to a copy of itself.
+ * A vector that holds pointers that point to data that it does not own.
  */
 template<typename T>
-class PtrVector: public NonOwningPtrVector<T>
+class NonOwningPtrVector: public PtrVector<T>
 {
   public:
-    ~PtrVector();
-    PtrVector* copy() const;
+    virtual NonOwningPtrVector* copy() const override;
+};
+
+/*
+ * A vector that holds pointers that point to data that it owns.
+ *
+ * Classes held in an OwningPtrVector must define a method copy() that returns
+ * a pointer to a copy of itself.
+ */
+template<typename T>
+class OwningPtrVector: public PtrVector<T>
+{
+  public:
+    virtual ~OwningPtrVector() override;
+    virtual OwningPtrVector* copy() const override;
 };
 
 class OGNumeric;
 
 extern template class NonOwningPtrVector<int>;
 extern template class NonOwningPtrVector<OGNumeric>;
-extern template class PtrVector<int>;
-extern template class PtrVector<OGNumeric>;
+extern template class OwningPtrVector<int>;
+extern template class OwningPtrVector<OGNumeric>;
 
 } // namespace librdag
 

--- a/include/expression.hh
+++ b/include/expression.hh
@@ -90,7 +90,7 @@ class OGTerminal: public OGNumeric
 /*
  * Container for expression arguments
  */
-typedef PtrVector<OGNumeric> ArgContainer;
+typedef OwningPtrVector<OGNumeric> ArgContainer;
 
 /**
  *  Expr type

--- a/src/librdag/containers.cc
+++ b/src/librdag/containers.cc
@@ -11,24 +11,24 @@
 namespace librdag {
 
 /**
- * NonOwningPtrVector
+ * PtrVector
  */
 
 template<typename T>
-NonOwningPtrVector<T>::NonOwningPtrVector()
+PtrVector<T>::PtrVector()
 {
   _vector = new vector<T const *>();
 }
 
 template<typename T>
-NonOwningPtrVector<T>::~NonOwningPtrVector()
+PtrVector<T>::~PtrVector()
 {
   delete _vector;
 }
 
 template<typename T>
 void
-NonOwningPtrVector<T>::push_back(T const * arg)
+PtrVector<T>::push_back(T const * arg)
 {
   _check_arg(arg);
   _vector->push_back(arg);
@@ -36,31 +36,48 @@ NonOwningPtrVector<T>::push_back(T const * arg)
 
 template<typename T>
 size_t
-NonOwningPtrVector<T>::size() const
+PtrVector<T>::size() const
 {
   return _vector->size();
 }
 
 template<typename T>
-typename NonOwningPtrVector<T>::citerator
-NonOwningPtrVector<T>::begin() const
+typename PtrVector<T>::citerator
+PtrVector<T>::begin() const
 {
   return _vector->begin();
 }
 
 template<typename T>
-typename NonOwningPtrVector<T>::citerator
-NonOwningPtrVector<T>::end() const
+typename PtrVector<T>::citerator
+PtrVector<T>::end() const
 {
   return _vector->end();
 }
 
 template<typename T>
 const T*
-NonOwningPtrVector<T>::operator[](size_t n) const
+PtrVector<T>::operator[](size_t n) const
 {
   return (*_vector)[n];
 }
+
+template<typename T>
+void
+PtrVector<T>::_check_arg(T const * arg)
+{
+  if (arg == nullptr)
+  {
+    throw new librdagException();
+  }
+}
+
+template class PtrVector<int>;
+template class PtrVector<OGNumeric>;
+
+/**
+ * NonOwningPtrVector
+ */
 
 template<typename T>
 NonOwningPtrVector<T>*
@@ -74,57 +91,41 @@ NonOwningPtrVector<T>::copy() const
   return c;
 }
 
+template class NonOwningPtrVector<int>;
+template class NonOwningPtrVector<OGNumeric>;
+
+/**
+ * OwningPtrVector
+ */
+
 template<typename T>
-void
-NonOwningPtrVector<T>::emptyVector()
+OwningPtrVector<T>::~OwningPtrVector()
 {
-  for (auto it = _vector->begin(); it != _vector->end(); ++it)
+  for (auto it = this->begin(); it != this->end(); ++it)
   {
     delete *it;
   }
 }
 
-template<typename T>
-void
-NonOwningPtrVector<T>::_check_arg(T const * arg)
-{
-  if (arg == nullptr)
-  {
-    throw new librdagException();
-  }
-}
-
-template class NonOwningPtrVector<int>;
-template class NonOwningPtrVector<OGNumeric>;
-
-/**
- * PtrVector
- */
-
-template<typename T>
-PtrVector<T>::~PtrVector()
-{
-  NonOwningPtrVector<T>::emptyVector();
-}
-
 namespace detail {
 
 /**
- * PtrVector expects classes to implement the copy() method - this is fine.
- * However, fundamental types do not implement copy, but we know how to copy
- * them. ptrvector_copy_impl defines an implementation for classes using copy()
- * and an implementation for fundamental types that manually copies the data.
+ * OwningPtrVector expects classes to implement the copy() method - this is
+ * fine.  However, fundamental types do not implement copy, but we know how to
+ * copy them. ptrvector_copy_impl defines an implementation for classes using
+ * copy() and an implementation for fundamental types that manually copies the
+ * data.
  */
 
 template<typename T, bool Q = is_fundamental<T>::value >
-struct ptrvector_copy_impl;
+struct owningptrvector_copy_impl;
 
 template<typename T>
-struct ptrvector_copy_impl<T, false>
+struct owningptrvector_copy_impl<T, false>
 {
-  PtrVector<T>* operator()(const PtrVector<T>* src)
+  OwningPtrVector<T>* operator()(const OwningPtrVector<T>* src)
   {
-    PtrVector<T>* c = new PtrVector<T>();
+    OwningPtrVector<T>* c = new OwningPtrVector<T>();
     for (auto it = src->begin(); it != src->end(); ++it)
     {
       c->push_back((*it)->copy());
@@ -134,11 +135,11 @@ struct ptrvector_copy_impl<T, false>
 };
 
 template<typename T>
-struct ptrvector_copy_impl<T, true>
+struct owningptrvector_copy_impl<T, true>
 {
-  PtrVector<T>* operator()(const PtrVector<T>* src)
+  OwningPtrVector<T>* operator()(const OwningPtrVector<T>* src)
   {
-    PtrVector<T>* c = new PtrVector<T>();
+    OwningPtrVector<T>* c = new OwningPtrVector<T>();
     for (auto it = src->begin(); it != src->end(); ++it)
     {
       T* n = new T;
@@ -152,13 +153,13 @@ struct ptrvector_copy_impl<T, true>
 } // namespace detail
 
 template<typename T>
-PtrVector<T>*
-PtrVector<T>::copy() const
+OwningPtrVector<T>*
+OwningPtrVector<T>::copy() const
 {
-  return detail::ptrvector_copy_impl<T>()(this);
+  return detail::owningptrvector_copy_impl<T>()(this);
 }
 
-template class PtrVector<int>;
-template class PtrVector<OGNumeric>;
+template class OwningPtrVector<int>;
+template class OwningPtrVector<OGNumeric>;
 
 } // namespace librdag

--- a/src/librdag/test/check_containers.cc
+++ b/src/librdag/test/check_containers.cc
@@ -14,9 +14,9 @@ using namespace librdag;
  * Test rationale: check the functionality that we wrapped in the derived class
  * only. Otherwise we're just testing the C++ compiler/STL implementation.
  */
-TEST(ContainerTest, PtrVectorTest) {
+TEST(ContainerTest, OwningPtrVectorTest) {
   // Default constructor
-  PtrVector<int> *pv1 = new PtrVector<int>();
+  OwningPtrVector<int> *pv1 = new OwningPtrVector<int>();
   EXPECT_EQ(0, pv1->size());
 
   // Add elements
@@ -50,11 +50,11 @@ TEST(ContainerTest, PtrVectorTest) {
   }
   EXPECT_EQ(5, i);
 
-  // Copy the PtrVector
-  PtrVector<int> *pv2 = pv1->copy();
+  // Copy the OwningPtrVector
+  OwningPtrVector<int> *pv2 = pv1->copy();
 
   // Test the copy is the same as the original
-  PtrVector<int>::citerator it1, it2;
+  OwningPtrVector<int>::citerator it1, it2;
   for (it1 = pv1->begin(), it2 = pv2->begin(); it1 != pv1->end(), it2 != pv2->end(); ++it1, ++it2)
   {
     EXPECT_EQ(**it1, **it2);


### PR DESCRIPTION
PtrVector is now the bases. OwningPtrVector and NonOwningPtrVector
implement their own copy methods that behave accordingly.

OwningPtrVector also deletes the vector elements on destruction.

Buildbot pass: http://devmaths-lx-1:8011/builders/nyqwk2-testing/builds/178
