### PR TITLE
MAT-229: unit tests for C++ OGTerminals

### DIFF
--- a/include/expression.hh
+++ b/include/expression.hh
@@ -14,7 +14,7 @@
 #include <vector>
 #include <memory>
 
-#include "terminal.hh"
+#include "numeric.hh"
 #include "visitor.hh"
 #include "exceptions.hh"
 #include "containers.hh"

--- a/include/expression.hh
+++ b/include/expression.hh
@@ -14,80 +14,21 @@
 #include <vector>
 #include <memory>
 
-#include "numerictypes.hh"
+#include "terminal.hh"
 #include "visitor.hh"
 #include "exceptions.hh"
 #include "containers.hh"
-#include "uncopyable.hh"
 
 using namespace std;
 
 
-/*
+/**
  * The namespace for the DAG library
  */
 namespace librdag
 {
 
-/*
- * Forward declaration of class types for pidgin RTTI in OGNumeric
- */
-
-class COPY;
-class PLUS;
-class NEGATE;
-class SVD;
-class SELECTRESULT;
-class OGTerminal;
-class OGRealScalar;
-class OGComplexScalar;
-class OGIntegerScalar;
-class OGRealMatrix;
-class OGComplexMatrix;
-class OGRealDiagonalMatrix;
-class OGComplexDiagonalMatrix;
-class OGRealSparseMatrix;
-class OGComplexSparseMatrix;
-
-/*
- * Base class for absolutely everything!
- */
-class OGNumeric: private Uncopyable
-{
-  public:
-    virtual ~OGNumeric();
-    virtual void debug_print() const = 0;
-    virtual void accept(Visitor &v) const = 0;
-    virtual OGNumeric* copy() const = 0;
-    virtual const COPY* asCOPY() const;
-    virtual const PLUS* asPLUS() const;
-    virtual const NEGATE* asNEGATE() const;
-    virtual const SVD* asSVD() const;
-    virtual const SELECTRESULT* asSELECTRESULT() const;
-    virtual const OGTerminal* asOGTerminal() const;
-    virtual const OGRealScalar* asOGRealScalar() const;
-    virtual const OGComplexScalar* asOGComplexScalar() const;
-    virtual const OGIntegerScalar* asOGIntegerScalar() const;
-    virtual const OGRealMatrix* asOGRealMatrix() const;
-    virtual const OGComplexMatrix* asOGComplexMatrix() const;
-    virtual const OGRealDiagonalMatrix* asOGRealDiagonalMatrix() const;
-    virtual const OGComplexDiagonalMatrix* asOGComplexDiagonalMatrix() const;
-    virtual const OGRealSparseMatrix* asOGRealSparseMatrix() const;
-    virtual const OGComplexSparseMatrix* asOGComplexSparseMatrix() const;
-};
-
-/*
- * Base class for terminal nodes in the AST
- */
-class OGTerminal: public OGNumeric
-{
-  public:
-    virtual real16 ** toReal16ArrayOfArrays() const;
-    virtual complex16 ** toComplex16ArrayOfArrays() const;
-    virtual const OGTerminal* asOGTerminal() const override;
-};
-
-/*
+/**
  * Container for expression arguments
  */
 typedef OwningPtrVector<OGNumeric> ArgContainer;
@@ -172,190 +113,6 @@ class SELECTRESULT: public OGBinaryExpr
     virtual void debug_print() const override;
 };
 
-/**
- * Things that extend OGScalar
- */
-
-template <typename T>
-class OGScalar: public OGTerminal
-{
-  public:
-    OGScalar(T data);
-    virtual void accept(Visitor &v) const override;
-    T getValue() const;
-  protected:
-    T ** toArrayOfArrays() const;
-  private:
-    T _value;
-};
-
-extern template class OGScalar<real16>;
-extern template class OGScalar<complex16>;
-extern template class OGScalar<int>;
-
-class OGRealScalar: public OGScalar<real16>
-{
-  public:
-    OGRealScalar(real16 data);
-    virtual real16 ** toReal16ArrayOfArrays() const override;
-    virtual OGNumeric* copy() const override;
-    virtual const OGRealScalar* asOGRealScalar() const override;
-    virtual void debug_print() const override;
-};
-
-class OGComplexScalar: public OGScalar<complex16>
-{
-  public:
-    OGComplexScalar(complex16 data);
-    virtual complex16 ** toComplex16ArrayOfArrays() const override;
-    virtual OGNumeric* copy() const override;
-    virtual const OGComplexScalar* asOGComplexScalar() const override;
-    virtual void debug_print() const override;
-};
-
-class OGIntegerScalar: public OGScalar<int>
-{
-  public:
-    OGIntegerScalar(int data);
-    virtual OGNumeric* copy() const override;
-    virtual const OGIntegerScalar* asOGIntegerScalar() const override;
-    virtual void debug_print() const override;
-};
-
-template <typename T> class OGArray: public OGTerminal
-{
-  public:
-    virtual void accept(Visitor &v) const override;
-    T * getData() const;
-    int getRows() const;
-    int getCols() const;
-    int getDatalen() const;
-  protected:
-    void setData(T * data);
-    void setRows(int rows);
-    void setCols(int cols);
-    void setDatalen(int datalen);
-  private:
-    T * _data = nullptr;
-    int _rows  = 0;
-    int _cols  = 0;
-    int _datalen = 0;
-};
-
-/**
- * Things that extend OGMatrix
- */
-
-template <typename T> class OGMatrix: public OGArray<T>
-{
-  public:
-    OGMatrix(T * data, int rows, int cols);
-    virtual void accept(Visitor &v) const override;
-    T** toArrayOfArrays() const;
-};
-
-extern template class OGMatrix<real16>;
-extern template class OGMatrix<complex16>;
-
-class OGRealMatrix: public OGMatrix<real16>
-{
-  public:
-    using OGMatrix::OGMatrix;
-    virtual void debug_print() const override;
-    virtual real16 ** toReal16ArrayOfArrays() const override;
-    virtual OGNumeric* copy() const override;
-    virtual const OGRealMatrix* asOGRealMatrix() const override;
-};
-
-class OGComplexMatrix: public OGMatrix<complex16>
-{
-  public:
-    using OGMatrix::OGMatrix;
-    virtual void debug_print() const override;
-    virtual complex16 ** toComplex16ArrayOfArrays() const override;
-    virtual OGNumeric* copy() const override;
-    virtual const OGComplexMatrix* asOGComplexMatrix() const override;
-};
-
-class OGLogicalMatrix: public OGRealMatrix
-{
-
-};
-
-/**
- * Things that extend OGDiagonalMatrix
- */
-
-template <typename T> class OGDiagonalMatrix: public OGArray<T>
-{
-  public:
-    OGDiagonalMatrix(T * data, int rows, int cols);
-    virtual void accept(Visitor &v) const override;
-    T** toArrayOfArrays() const;
-};
-
-extern template class OGDiagonalMatrix<real16>;
-extern template class OGDiagonalMatrix<complex16>;
-
-class OGRealDiagonalMatrix: public OGDiagonalMatrix<real16>
-{
-  public:
-    using OGDiagonalMatrix::OGDiagonalMatrix;
-    virtual void debug_print() const override;
-    virtual real16** toReal16ArrayOfArrays() const override;
-    virtual OGNumeric* copy() const override;
-    virtual const OGRealDiagonalMatrix* asOGRealDiagonalMatrix() const override;
-};
-
-class OGComplexDiagonalMatrix: public OGDiagonalMatrix<complex16>
-{
-  public:
-    using OGDiagonalMatrix::OGDiagonalMatrix;
-    virtual void debug_print() const override;
-    virtual complex16** toComplex16ArrayOfArrays() const override;
-    virtual OGNumeric* copy() const override;
-    virtual const OGComplexDiagonalMatrix* asOGComplexDiagonalMatrix() const override;
-};
-
-/**
- * Things that extend OGSparseMatrix
- */
-
-template <typename T> class OGSparseMatrix: public OGArray<T>
-{
-  public:
-    OGSparseMatrix(int * colPtr, int * rowIdx, T * data, int rows, int cols);
-    virtual void accept(Visitor &v) const override;
-    int* getColPtr() const;
-    int* getRowIdx() const;
-  protected:
-    void setColPtr(int * colPtr);
-    void setRowIdx(int * rowIdx);
-  private:
-    int* _colPtr = nullptr; // the column pointer index
-    int* _rowIdx = nullptr; // the row index
-};
-
-extern template class OGSparseMatrix<real16>;
-extern template class OGSparseMatrix<complex16>;
-
-class OGRealSparseMatrix: public OGSparseMatrix<real16>
-{
-  public:
-    using OGSparseMatrix::OGSparseMatrix;
-    virtual void debug_print() const override;
-    virtual OGNumeric* copy() const override;
-    virtual const OGRealSparseMatrix* asOGRealSparseMatrix() const override;
-};
-
-class OGComplexSparseMatrix: public OGSparseMatrix<complex16>
-{
-  public:
-    using OGSparseMatrix::OGSparseMatrix;
-    virtual void debug_print() const override;
-    virtual OGNumeric* copy() const override;
-    virtual const OGComplexSparseMatrix* asOGComplexSparseMatrix() const override;
-};
 
 } // namespace librdag
 

--- a/include/jterminals.hh
+++ b/include/jterminals.hh
@@ -7,7 +7,7 @@
 #ifndef _JTERMINALS_HH
 #define _JTERMINALS_HH
 
-#include "expression.hh"
+#include "terminal.hh"
 #include "jni.h"
 
 namespace convert {

--- a/include/numeric.hh
+++ b/include/numeric.hh
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) 2013 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+#ifndef _NUMERIC_HH
+#define _NUMERIC_HH
+
+#include "uncopyable.hh"
+
+namespace librdag {
+  
+// fwd decl  
+class OGTerminal;
+class OGRealScalar;
+class OGComplexScalar;
+class OGIntegerScalar;
+class OGRealMatrix;
+class OGComplexMatrix;
+class OGRealDiagonalMatrix;
+class OGComplexDiagonalMatrix;
+class OGRealSparseMatrix;
+class OGComplexSparseMatrix;
+class Visitor;
+class COPY;
+class PLUS;
+class NEGATE;
+class SVD;
+class SELECTRESULT;
+
+/*
+ * Base class for absolutely everything!
+ */
+class OGNumeric: private Uncopyable
+{
+  public:
+    virtual ~OGNumeric();
+    virtual void debug_print() const = 0;
+    virtual void accept(Visitor &v) const = 0;
+    virtual OGNumeric* copy() const = 0;
+    virtual const COPY* asCOPY() const;
+    virtual const PLUS* asPLUS() const;
+    virtual const NEGATE* asNEGATE() const;
+    virtual const SVD* asSVD() const;
+    virtual const SELECTRESULT* asSELECTRESULT() const;
+    virtual const OGTerminal* asOGTerminal() const;
+    virtual const OGRealScalar* asOGRealScalar() const;
+    virtual const OGComplexScalar* asOGComplexScalar() const;
+    virtual const OGIntegerScalar* asOGIntegerScalar() const;
+    virtual const OGRealMatrix* asOGRealMatrix() const;
+    virtual const OGComplexMatrix* asOGComplexMatrix() const;
+    virtual const OGRealDiagonalMatrix* asOGRealDiagonalMatrix() const;
+    virtual const OGComplexDiagonalMatrix* asOGComplexDiagonalMatrix() const;
+    virtual const OGRealSparseMatrix* asOGRealSparseMatrix() const;
+    virtual const OGComplexSparseMatrix* asOGComplexSparseMatrix() const;
+};
+
+} 
+#endif // _NUMERIC_HH

--- a/include/terminal.hh
+++ b/include/terminal.hh
@@ -178,6 +178,7 @@ template <typename T> class OGSparseMatrix: public OGArray<T>
     virtual void accept(Visitor &v) const override;
     int* getColPtr() const;
     int* getRowIdx() const;
+    T** toArrayOfArrays() const;
   protected:
     void setColPtr(int * colPtr);
     void setRowIdx(int * rowIdx);
@@ -194,6 +195,7 @@ class OGRealSparseMatrix: public OGSparseMatrix<real16>
   public:
     using OGSparseMatrix::OGSparseMatrix;
     virtual void debug_print() const override;
+    virtual real16** toReal16ArrayOfArrays() const override;
     virtual OGNumeric* copy() const override;
     virtual const OGRealSparseMatrix* asOGRealSparseMatrix() const override;
 };
@@ -203,6 +205,7 @@ class OGComplexSparseMatrix: public OGSparseMatrix<complex16>
   public:
     using OGSparseMatrix::OGSparseMatrix;
     virtual void debug_print() const override;
+    virtual complex16** toComplex16ArrayOfArrays() const override;
     virtual OGNumeric* copy() const override;
     virtual const OGComplexSparseMatrix* asOGComplexSparseMatrix() const override;
 };

--- a/include/terminal.hh
+++ b/include/terminal.hh
@@ -1,0 +1,213 @@
+/**
+ * Copyright (C) 2013 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+#ifndef _TERMINAL_HH
+#define _TERMINAL_HH
+
+#include "numeric.hh"
+#include "numerictypes.hh"
+
+namespace librdag {
+   
+/*
+ * Base class for terminal nodes in the AST
+ */
+class OGTerminal: public OGNumeric
+{
+  public:
+    virtual real16 ** toReal16ArrayOfArrays() const;
+    virtual complex16 ** toComplex16ArrayOfArrays() const;
+    virtual const OGTerminal* asOGTerminal() const override;
+};
+
+/**
+ * Things that extend OGScalar
+ */
+
+template <typename T>
+class OGScalar: public OGTerminal
+{
+  public:
+    OGScalar(T data);
+    virtual void accept(Visitor &v) const override;
+    T getValue() const;
+    T ** toArrayOfArrays() const;
+  private:
+    T _value;
+};
+
+extern template class OGScalar<real16>;
+extern template class OGScalar<complex16>;
+extern template class OGScalar<int>;
+
+class OGRealScalar: public OGScalar<real16>
+{
+  public:
+    OGRealScalar(real16 data);
+    virtual real16 ** toReal16ArrayOfArrays() const override;
+    virtual OGNumeric* copy() const override;
+    virtual const OGRealScalar* asOGRealScalar() const override;
+    virtual void debug_print() const override;
+};
+
+class OGComplexScalar: public OGScalar<complex16>
+{
+  public:
+    OGComplexScalar(complex16 data);
+    virtual complex16 ** toComplex16ArrayOfArrays() const override;
+    virtual OGNumeric* copy() const override;
+    virtual const OGComplexScalar* asOGComplexScalar() const override;
+    virtual void debug_print() const override;
+};
+
+class OGIntegerScalar: public OGScalar<int>
+{
+  public:
+    OGIntegerScalar(int data);
+    virtual OGNumeric* copy() const override;
+    virtual const OGIntegerScalar* asOGIntegerScalar() const override;
+    virtual void debug_print() const override;
+};
+
+template <typename T> class OGArray: public OGTerminal
+{
+  public:
+    virtual void accept(Visitor &v) const override;
+    T * getData() const;
+    int getRows() const;
+    int getCols() const;
+    int getDatalen() const;
+  protected:
+    void setData(T * data);
+    void setRows(int rows);
+    void setCols(int cols);
+    void setDatalen(int datalen);
+  private:
+    T * _data = nullptr;
+    int _rows  = 0;
+    int _cols  = 0;
+    int _datalen = 0;
+};
+
+/**
+ * Things that extend OGMatrix
+ */
+
+template <typename T> class OGMatrix: public OGArray<T>
+{
+  public:
+    OGMatrix(T * data, int rows, int cols);
+    virtual void accept(Visitor &v) const override;
+    T** toArrayOfArrays() const;
+};
+
+extern template class OGMatrix<real16>;
+extern template class OGMatrix<complex16>;
+
+class OGRealMatrix: public OGMatrix<real16>
+{
+  public:
+    using OGMatrix::OGMatrix;
+    virtual void debug_print() const override;
+    virtual real16 ** toReal16ArrayOfArrays() const override;
+    virtual OGNumeric* copy() const override;
+    virtual const OGRealMatrix* asOGRealMatrix() const override;
+};
+
+class OGComplexMatrix: public OGMatrix<complex16>
+{
+  public:
+    using OGMatrix::OGMatrix;
+    virtual void debug_print() const override;
+    virtual complex16 ** toComplex16ArrayOfArrays() const override;
+    virtual OGNumeric* copy() const override;
+    virtual const OGComplexMatrix* asOGComplexMatrix() const override;
+};
+
+class OGLogicalMatrix: public OGRealMatrix
+{
+
+};
+
+/**
+ * Things that extend OGDiagonalMatrix
+ */
+
+template <typename T> class OGDiagonalMatrix: public OGArray<T>
+{
+  public:
+    OGDiagonalMatrix(T * data, int rows, int cols);
+    virtual void accept(Visitor &v) const override;
+    T** toArrayOfArrays() const;
+};
+
+extern template class OGDiagonalMatrix<real16>;
+extern template class OGDiagonalMatrix<complex16>;
+
+class OGRealDiagonalMatrix: public OGDiagonalMatrix<real16>
+{
+  public:
+    using OGDiagonalMatrix::OGDiagonalMatrix;
+    virtual void debug_print() const override;
+    virtual real16** toReal16ArrayOfArrays() const override;
+    virtual OGNumeric* copy() const override;
+    virtual const OGRealDiagonalMatrix* asOGRealDiagonalMatrix() const override;
+};
+
+class OGComplexDiagonalMatrix: public OGDiagonalMatrix<complex16>
+{
+  public:
+    using OGDiagonalMatrix::OGDiagonalMatrix;
+    virtual void debug_print() const override;
+    virtual complex16** toComplex16ArrayOfArrays() const override;
+    virtual OGNumeric* copy() const override;
+    virtual const OGComplexDiagonalMatrix* asOGComplexDiagonalMatrix() const override;
+};
+
+/**
+ * Things that extend OGSparseMatrix
+ */
+
+template <typename T> class OGSparseMatrix: public OGArray<T>
+{
+  public:
+    OGSparseMatrix(int * colPtr, int * rowIdx, T * data, int rows, int cols);
+    virtual void accept(Visitor &v) const override;
+    int* getColPtr() const;
+    int* getRowIdx() const;
+  protected:
+    void setColPtr(int * colPtr);
+    void setRowIdx(int * rowIdx);
+  private:
+    int* _colPtr = nullptr; // the column pointer index
+    int* _rowIdx = nullptr; // the row index
+};
+
+extern template class OGSparseMatrix<real16>;
+extern template class OGSparseMatrix<complex16>;
+
+class OGRealSparseMatrix: public OGSparseMatrix<real16>
+{
+  public:
+    using OGSparseMatrix::OGSparseMatrix;
+    virtual void debug_print() const override;
+    virtual OGNumeric* copy() const override;
+    virtual const OGRealSparseMatrix* asOGRealSparseMatrix() const override;
+};
+
+class OGComplexSparseMatrix: public OGSparseMatrix<complex16>
+{
+  public:
+    using OGSparseMatrix::OGSparseMatrix;
+    virtual void debug_print() const override;
+    virtual OGNumeric* copy() const override;
+    virtual const OGComplexSparseMatrix* asOGComplexSparseMatrix() const override;
+};
+
+
+} // end namespace librdag
+
+#endif // _TERMINAL_HH

--- a/src/jshim/dispatch.cc
+++ b/src/jshim/dispatch.cc
@@ -7,6 +7,7 @@
 #include "dispatch.hh"
 #include "visitor.hh"
 #include "warningmacros.h"
+#include "terminal.hh"
 #include "expression.hh"
 
 namespace convert {

--- a/src/librdag/CMakeLists.txt
+++ b/src/librdag/CMakeLists.txt
@@ -11,7 +11,7 @@ SET(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -Wl,--no-undefined")
 SET(CMAKE_CC_FLAGS  "${CMAKE_CC_FLAGS} -Wl,--no-undefined -frepo")
  
 
-add_library(rdag SHARED entrypt.cc expression.cc exceptions.cc execution.cc terminal.cc containers.cc)
+add_library(rdag SHARED entrypt.cc expression.cc exceptions.cc execution.cc terminal.cc containers.cc numeric.cc)
 set_target_properties(rdag PROPERTIES SOVERSION ${longdog_VERSION_MAJOR} VERSION ${longdog_VERSION})
 install(TARGETS rdag DESTINATION lib)
 

--- a/src/librdag/execution.cc
+++ b/src/librdag/execution.cc
@@ -5,6 +5,7 @@
  */
 
 #include "expression.hh"
+#include "terminal.hh"
 #include "execution.hh"
 
 namespace librdag {

--- a/src/librdag/expression.cc
+++ b/src/librdag/expression.cc
@@ -13,15 +13,6 @@ using namespace std;
 
 namespace librdag
 {
-/*
- * OGTerminal
- */
-
-const OGTerminal*
-OGTerminal::asOGTerminal() const
-{
-  return this;
-}
 
 /*
  * OGExpr

--- a/src/librdag/expression.cc
+++ b/src/librdag/expression.cc
@@ -5,7 +5,7 @@
  */
 
 #include <iostream>
-#include "expression.hh"
+#include "terminal.hh"
 #include "visitor.hh"
 
 using namespace std;

--- a/src/librdag/expression.cc
+++ b/src/librdag/expression.cc
@@ -5,118 +5,14 @@
  */
 
 #include <iostream>
+#include "expression.hh"
 #include "terminal.hh"
-#include "visitor.hh"
+#include "exceptions.hh"
 
 using namespace std;
 
 namespace librdag
 {
-
-/*
- * OGNumeric
- */
-
-OGNumeric::~OGNumeric()
-{
-}
-
-void
-OGNumeric::debug_print() const
-{
-  cout << "Abstract OGNumeric type" << endl;
-}
-
-const COPY*
-OGNumeric::asCOPY() const
-{
-  return nullptr;
-}
-
-const PLUS*
-OGNumeric::asPLUS() const
-{
-  return nullptr;
-}
-
-const NEGATE*
-OGNumeric::asNEGATE() const
-{
-  return nullptr;
-}
-
-const SVD*
-OGNumeric::asSVD() const
-{
-  return nullptr;
-}
-
-const SELECTRESULT*
-OGNumeric::asSELECTRESULT() const
-{
-  return nullptr;
-}
-
-const OGTerminal*
-OGNumeric::asOGTerminal() const
-{
-  return nullptr;
-}
-
-const OGRealScalar*
-OGNumeric::asOGRealScalar() const
-{
-  return nullptr;
-}
-
-const OGComplexScalar*
-OGNumeric::asOGComplexScalar() const
-{
-  return nullptr;
-}
-
-const OGIntegerScalar*
-OGNumeric::asOGIntegerScalar() const
-{
-  return nullptr;
-}
-
-const OGRealMatrix*
-OGNumeric::asOGRealMatrix() const
-{
-  return nullptr;
-}
-
-const OGComplexMatrix*
-OGNumeric::asOGComplexMatrix() const
-{
-  return nullptr;
-}
-
-const OGRealDiagonalMatrix*
-OGNumeric::asOGRealDiagonalMatrix() const
-{
-  return nullptr;
-}
-
-const OGComplexDiagonalMatrix*
-OGNumeric::asOGComplexDiagonalMatrix() const
-{
-  return nullptr;
-}
-
-const OGRealSparseMatrix*
-OGNumeric::asOGRealSparseMatrix() const
-{
-  return nullptr;
-}
-
-const OGComplexSparseMatrix*
-OGNumeric::asOGComplexSparseMatrix() const
-{
-  return nullptr;
-}
-
 /*
  * OGTerminal
  */

--- a/src/librdag/numeric.cc
+++ b/src/librdag/numeric.cc
@@ -1,0 +1,121 @@
+/**
+ * Copyright (C) 2013 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+#include <iostream>
+#include "numeric.hh"
+#include "expression.hh"
+#include "terminal.hh"
+
+using namespace std;
+
+namespace librdag
+{
+
+/*
+ * OGNumeric
+ */
+
+OGNumeric::~OGNumeric()
+{
+}
+
+void
+OGNumeric::debug_print() const
+{
+  cout << "Abstract OGNumeric type" << endl;
+}
+
+const COPY*
+OGNumeric::asCOPY() const
+{
+  return nullptr;
+}
+
+const PLUS*
+OGNumeric::asPLUS() const
+{
+  return nullptr;
+}
+
+const NEGATE*
+OGNumeric::asNEGATE() const
+{
+  return nullptr;
+}
+
+const SVD*
+OGNumeric::asSVD() const
+{
+  return nullptr;
+}
+
+const SELECTRESULT*
+OGNumeric::asSELECTRESULT() const
+{
+  return nullptr;
+}
+
+const OGTerminal*
+OGNumeric::asOGTerminal() const
+{
+  return nullptr;
+}
+
+const OGRealScalar*
+OGNumeric::asOGRealScalar() const
+{
+  return nullptr;
+}
+
+const OGComplexScalar*
+OGNumeric::asOGComplexScalar() const
+{
+  return nullptr;
+}
+
+const OGIntegerScalar*
+OGNumeric::asOGIntegerScalar() const
+{
+  return nullptr;
+}
+
+const OGRealMatrix*
+OGNumeric::asOGRealMatrix() const
+{
+  return nullptr;
+}
+
+const OGComplexMatrix*
+OGNumeric::asOGComplexMatrix() const
+{
+  return nullptr;
+}
+
+const OGRealDiagonalMatrix*
+OGNumeric::asOGRealDiagonalMatrix() const
+{
+  return nullptr;
+}
+
+const OGComplexDiagonalMatrix*
+OGNumeric::asOGComplexDiagonalMatrix() const
+{
+  return nullptr;
+}
+
+const OGRealSparseMatrix*
+OGNumeric::asOGRealSparseMatrix() const
+{
+  return nullptr;
+}
+
+const OGComplexSparseMatrix*
+OGNumeric::asOGComplexSparseMatrix() const
+{
+  return nullptr;
+}
+
+} // namespace librdag

--- a/src/librdag/terminal.cc
+++ b/src/librdag/terminal.cc
@@ -4,7 +4,7 @@
  * Please see distribution for license.
  */
 
-#include "expression.hh"
+#include "terminal.hh"
 
 namespace librdag {
 
@@ -15,13 +15,13 @@ namespace librdag {
 real16**
 OGTerminal::toReal16ArrayOfArrays() const
 {
-  throw new librdagException();
+  throw librdagException();
 }
 
 complex16**
 OGTerminal::toComplex16ArrayOfArrays() const
 {
-  throw new librdagException();
+  throw librdagException();
 }
 
 /**
@@ -189,6 +189,10 @@ template<typename T>
 void
 OGArray<T>::setData(T * data)
 {
+  if(data==nullptr)
+  {
+    throw librdagException();
+  }
   _data = data;
 }
 
@@ -196,6 +200,10 @@ template<typename T>
 void
 OGArray<T>::setRows(int rows)
 {
+  if(rows<0)
+  {
+    throw librdagException();
+  }  
   _rows = rows;
 }
 
@@ -203,6 +211,10 @@ template<typename T>
 void
 OGArray<T>::setCols(int cols)
 {
+  if(cols<0)
+  {
+    throw librdagException();
+  }
   _cols = cols;
 }
 
@@ -210,6 +222,10 @@ template<typename T>
 void
 OGArray<T>::setDatalen(int datalen)
 {
+  if(datalen<0)
+  {
+    throw librdagException();
+  }
   _datalen = datalen;
 }
 
@@ -528,6 +544,10 @@ template<typename T>
 void
 OGSparseMatrix<T>::setColPtr(int* colPtr)
 {
+  if(colPtr==nullptr)
+  {
+    throw librdagException();
+  }
   _colPtr = colPtr;
 }
 
@@ -535,6 +555,10 @@ template<typename T>
 void
 OGSparseMatrix<T>::setRowIdx(int* rowIdx)
 {
+  if(rowIdx==nullptr)
+  {
+    throw librdagException();
+  }  
   _rowIdx = rowIdx;
 }
 

--- a/src/librdag/terminal.cc
+++ b/src/librdag/terminal.cc
@@ -5,6 +5,8 @@
  */
 
 #include "terminal.hh"
+#include "exceptions.hh"
+#include "visitor.hh"
 
 namespace librdag {
 

--- a/src/librdag/test/CMakeLists.txt
+++ b/src/librdag/test/CMakeLists.txt
@@ -9,7 +9,7 @@ SET(CMAKE_FC_FLAGS  "${CMAKE_FC_FLAGS} ${GCC_COVERAGE_COMPILE_FLAGS} -cpp" )
 
 link_directories(${longdog_BINARY_DIR}/src/librdag})
 
-set(TESTS check_expressions check_containers check_execution check_rtti)
+set(TESTS check_expressions check_containers check_execution check_rtti check_terminals)
 
 # Compile and link each test and add to the list of tests
 foreach(TEST ${TESTS})

--- a/src/librdag/test/check_execution.cc
+++ b/src/librdag/test/check_execution.cc
@@ -6,6 +6,7 @@
 
 #include "execution.hh"
 #include "expression.hh"
+#include "terminal.hh"
 #include "gtest/gtest.h"
 
 using namespace std;

--- a/src/librdag/test/check_expressions.cc
+++ b/src/librdag/test/check_expressions.cc
@@ -5,6 +5,7 @@
  */
 
 #include "expression.hh"
+#include "terminal.hh"
 #include "gtest/gtest.h"
 
 using namespace std;
@@ -201,7 +202,7 @@ TEST(VirtualCopyTest, ComplexDiagonalMatrix){
 }
 
 TEST(VirtualCopyTest, RealSparseMatrix){
-  int colPtr[2] = { 0, 1 };
+  int colPtr[3] = { 0, 2, 2 };
   int rowIdx[2] = { 0, 1 };
   double rsparseData[2] = { 1.0, 2.0 };
   OGRealSparseMatrix *rsm1 = new OGRealSparseMatrix(colPtr, rowIdx, rsparseData, 2, 2);
@@ -217,7 +218,7 @@ TEST(VirtualCopyTest, RealSparseMatrix){
 }
 
 TEST(VirtualCopyTest, ComplexSparseMatrix){
-  int colPtr[2] = { 0, 1 };
+  int colPtr[3] = { 0, 2, 2 };
   int rowIdx[2] = { 0, 1 };
   complex16 csparseData[2] = { {1.0, 2.0}, {3.0, 4.0} };
   OGComplexSparseMatrix *csm1 = new OGComplexSparseMatrix(colPtr, rowIdx, csparseData, 2, 2);

--- a/src/librdag/test/check_rtti.cc
+++ b/src/librdag/test/check_rtti.cc
@@ -158,7 +158,7 @@ TEST_F(RTTITerminalTest, TestOGComplexDiagonalMatrix) {
 }
 
 TEST_F(RTTITerminalTest, TestOGRealSparseMatrix) {
-  int colPtr[2] = { 0, 1 };
+  int colPtr[3] = { 0, 2, 2 };
   int rowIdx[2] = { 0, 1 };
   double rsparseData[2] = { 1.0, 2.0 };
   node = new OGRealSparseMatrix(colPtr, rowIdx, rsparseData, 2, 2);
@@ -166,7 +166,7 @@ TEST_F(RTTITerminalTest, TestOGRealSparseMatrix) {
 }
 
 TEST_F(RTTITerminalTest, TestOGComplexSparseMatrix) {
-  int colPtr[2] = { 0, 1 };
+  int colPtr[3] = { 0, 2, 2 };
   int rowIdx[2] = { 0, 1 };
   complex16 csparseData[2] = { {1.0, 2.0}, {3.0, 4.0} };
   node = new OGComplexSparseMatrix(colPtr, rowIdx, csparseData, 2, 2);

--- a/src/librdag/test/check_rtti.cc
+++ b/src/librdag/test/check_rtti.cc
@@ -4,6 +4,7 @@
  * Please see distribution for license.
  */
 
+#include "terminal.hh"
 #include "expression.hh"
 #include "gtest/gtest.h"
 #include <string>

--- a/src/librdag/test/check_terminals.cc
+++ b/src/librdag/test/check_terminals.cc
@@ -267,7 +267,8 @@ TEST(TerminalsTest, OGRealMatrixTest) {
   // check getCols
   ASSERT_EQ(tmp->getCols(), cols);
   
-  tmp->debug_print();
+  // check getDatalen
+  ASSERT_EQ(tmp->getDatalen(), rows*cols);
   
   // wire up array for ArrOfArr test
   real16 expectedtmp[12] = {1,4,7,10,2,5,8,11,3,6,9,12};
@@ -304,7 +305,7 @@ TEST(TerminalsTest, OGRealMatrixTest) {
   
   // check copy and asOGRealMatrix
   OGNumeric * copy = tmp->copy();
-  ASSERT_TRUE(ArrayEquals<real16>(tmp->getData(),copy->asOGRealMatrix()->getData(),rows*cols));
+  ASSERT_TRUE(ArrayEquals<real16>(tmp->getData(),copy->asOGRealMatrix()->getData(),tmp->getDatalen()));
   ASSERT_EQ(tmp->getRows(),copy->asOGRealMatrix()->getRows());
   ASSERT_EQ(tmp->getCols(),copy->asOGRealMatrix()->getCols());
   ASSERT_EQ(copy,copy->asOGRealMatrix());
@@ -349,7 +350,8 @@ TEST(TerminalsTest, OGComplexMatrixTest) {
   // check getCols
   ASSERT_EQ(tmp->getCols(), cols);
   
-  tmp->debug_print();
+  // check getDatalen
+  ASSERT_EQ(tmp->getDatalen(), rows*cols);
   
   // wire up array for ArrOfArr test
   complex16 expectedtmp[12] = {{1,10},{4,40},{7,70},{10,100},{2,20},{5,50},{8,80},{11,110},{3,30},{6,60},{9,90},{12,120}};
@@ -386,7 +388,7 @@ TEST(TerminalsTest, OGComplexMatrixTest) {
   
   // check copy and asOGComplexMatrix
   OGNumeric * copy = tmp->copy();
-  ASSERT_TRUE(ArrayEquals<complex16>(tmp->getData(),copy->asOGComplexMatrix()->getData(),rows*cols));
+  ASSERT_TRUE(ArrayEquals<complex16>(tmp->getData(),copy->asOGComplexMatrix()->getData(),tmp->getDatalen()));
   ASSERT_EQ(tmp->getRows(),copy->asOGComplexMatrix()->getRows());
   ASSERT_EQ(tmp->getCols(),copy->asOGComplexMatrix()->getCols());
   ASSERT_EQ(copy,copy->asOGComplexMatrix());
@@ -397,4 +399,168 @@ TEST(TerminalsTest, OGComplexMatrixTest) {
 }
 
 
+/*
+ * Test OGRealDiagonalMatrix
+ */
+TEST(TerminalsTest, OGRealDiagonalMatrix) {
+  // data
+  real16 data [3] = {1,2,3};
+  int rows = 3;
+  int cols = 4;
 
+  // attempt construct from nullptr, should throw
+  real16 * null = nullptr;
+  OGRealDiagonalMatrix * tmp;
+  ASSERT_ANY_THROW(tmp = new OGRealDiagonalMatrix(null,rows,cols));
+  
+  // attempt construct from bad rows
+  tmp = nullptr;
+  ASSERT_ANY_THROW(tmp = new OGRealDiagonalMatrix(data,-1,cols));
+  
+  // attempt construct from bad cols
+  tmp = nullptr;
+  ASSERT_ANY_THROW(tmp = new OGRealDiagonalMatrix(data,rows,-1));
+  
+  // attempt construct from ok data
+  tmp = nullptr;
+  tmp = new OGRealDiagonalMatrix(data,rows,cols);
+  // check ctor worked
+  ASSERT_NE(tmp, nullptr);
+  
+  // check getRows
+  ASSERT_EQ(tmp->getRows(), rows);
+  
+  // check getCols
+  ASSERT_EQ(tmp->getCols(), cols);
+  
+  // check getDatalen
+  ASSERT_EQ(tmp->getDatalen(), rows>cols?cols:rows);
+  
+  // wire up array for ArrOfArr test
+  real16 expectedtmp[12] = {1,0,0,0,0,2,0,0,0,0,3,0};
+  real16 ** expected = new real16  * [rows];
+  for(int i = 0; i < rows; i++){
+    expected[i] = &(expectedtmp[i*cols]);
+  }
+  
+  // check toArrayOfArrays()
+  real16 ** computed = tmp->toArrayOfArrays();
+  ASSERT_TRUE(ArrayOfArraysEquals<real16>(expected,computed,rows,cols));
+  for(int i = 0; i < rows; i++){
+    delete [] computed[i];
+  }
+  delete [] computed;
+  
+  // check toReal16ArrayOfArrays()
+  computed = tmp->toReal16ArrayOfArrays();
+  ASSERT_TRUE(ArrayOfArraysEquals<real16>(expected,computed,rows,cols));
+  for(int i = 0; i < rows; i++){
+    delete [] computed[i];
+  }
+  delete [] computed;
+  delete [] expected;  
+   
+  // check toComplex16ArrayOfArrays, expect throw
+  ASSERT_ANY_THROW(tmp->toComplex16ArrayOfArrays());
+
+  // check visitor
+  FakeVisitor * v = new FakeVisitor();
+  tmp->accept(*v);
+  ASSERT_TRUE(v->hasBeenVisited());
+  delete v;  
+  
+  // check copy and asOGRealMatrix
+  OGNumeric * copy = tmp->copy();
+  ASSERT_TRUE(ArrayEquals<real16>(tmp->getData(),copy->asOGRealDiagonalMatrix()->getData(),tmp->getDatalen()));
+  ASSERT_EQ(tmp->getRows(),copy->asOGRealDiagonalMatrix()->getRows());
+  ASSERT_EQ(tmp->getCols(),copy->asOGRealDiagonalMatrix()->getCols());
+  ASSERT_EQ(copy,copy->asOGRealDiagonalMatrix());
+  
+  // clean up
+  delete copy;
+  delete tmp;
+}
+
+
+
+/*
+ * Test OGComplexDiagonalMatrix
+ */
+TEST(TerminalsTest, OGComplexDiagonalMatrix) {
+  // data
+  complex16 data [3] = {{1,10},{2,20},{3,30}};
+  int rows = 3;
+  int cols = 4;
+
+  // attempt construct from nullptr, should throw
+  complex16 * null = nullptr;
+  OGComplexDiagonalMatrix * tmp;
+  ASSERT_ANY_THROW(tmp = new OGComplexDiagonalMatrix(null,rows,cols));
+  
+  // attempt construct from bad rows
+  tmp = nullptr;
+  ASSERT_ANY_THROW(tmp = new OGComplexDiagonalMatrix(data,-1,cols));
+  
+  // attempt construct from bad cols
+  tmp = nullptr;
+  ASSERT_ANY_THROW(tmp = new OGComplexDiagonalMatrix(data,rows,-1));
+  
+  // attempt construct from ok data
+  tmp = nullptr;
+  tmp = new OGComplexDiagonalMatrix(data,rows,cols);
+  // check ctor worked
+  ASSERT_NE(tmp, nullptr);
+  
+  // check getRows
+  ASSERT_EQ(tmp->getRows(), rows);
+  
+  // check getCols
+  ASSERT_EQ(tmp->getCols(), cols);
+  
+  // check getDatalen
+  ASSERT_EQ(tmp->getDatalen(), rows>cols?cols:rows);
+  
+  // wire up array for ArrOfArr test
+  complex16 expectedtmp[12] = {{1,10},{0,0},{0,0},{0,0},{0,0},{2,20},{0,0},{0,0},{0,0},{0,0},{3,30},{0,0}};
+  complex16 ** expected = new complex16  * [rows];
+  for(int i = 0; i < rows; i++){
+    expected[i] = &(expectedtmp[i*cols]);
+  }
+  
+  // check toArrayOfArrays()
+  complex16 ** computed = tmp->toArrayOfArrays();
+  ASSERT_TRUE(ArrayOfArraysEquals<complex16>(expected,computed,rows,cols));
+  for(int i = 0; i < rows; i++){
+    delete [] computed[i];
+  }
+  delete [] computed;
+  
+  // check toComplex16ArrayOfArrays()
+  computed = tmp->toComplex16ArrayOfArrays();
+  ASSERT_TRUE(ArrayOfArraysEquals<complex16>(expected,computed,rows,cols));
+  for(int i = 0; i < rows; i++){
+    delete [] computed[i];
+  }
+  delete [] computed;
+  delete [] expected;  
+   
+  // check toReal16ArrayOfArrays, expect throw
+  ASSERT_ANY_THROW(tmp->toReal16ArrayOfArrays());
+
+  // check visitor
+  FakeVisitor * v = new FakeVisitor();
+  tmp->accept(*v);
+  ASSERT_TRUE(v->hasBeenVisited());
+  delete v;  
+  
+  // check copy and asOGRealMatrix
+  OGNumeric * copy = tmp->copy();
+  ASSERT_TRUE(ArrayEquals<complex16>(tmp->getData(),copy->asOGComplexDiagonalMatrix()->getData(),tmp->getDatalen()));
+  ASSERT_EQ(tmp->getRows(),copy->asOGComplexDiagonalMatrix()->getRows());
+  ASSERT_EQ(tmp->getCols(),copy->asOGComplexDiagonalMatrix()->getCols());
+  ASSERT_EQ(copy,copy->asOGComplexDiagonalMatrix());
+  
+  // clean up
+  delete copy;
+  delete tmp;
+}

--- a/src/librdag/test/check_terminals.cc
+++ b/src/librdag/test/check_terminals.cc
@@ -1,0 +1,398 @@
+/**
+ * Copyright (C) 2013 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+#include "expression.hh"
+#include "gtest/gtest.h"
+#include "warningmacros.h"
+
+using namespace std;
+using namespace librdag;
+
+/*
+ * Check an array equals another array in value
+ * @param expected the expected value
+ * @param computed the value computed which is to be tested
+ * @param length the length of the expected data
+ */
+template<typename T> bool ArrayEquals(T * expected, T * computed, size_t length)
+{
+    if(length<0){
+      throw librdagException();
+    }
+    for(size_t i=0; i < length; i++)
+    {
+        if(expected[i]!=computed[i])
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+
+/*
+ * Check an array of arrays equals another in value
+ * @param expected the expected value
+ * @param computed the value computed which is to be tested
+ * @param rows the number of rows in the expected data
+ * @param cols the number of cols in the expected data
+ */
+template<typename T> bool ArrayOfArraysEquals(T ** expected, T ** computed, size_t rows, size_t cols)
+{
+    if(rows<0){
+      throw librdagException();
+    }
+    for(size_t i=0; i < rows; i++)
+    {
+      if(!ArrayEquals<T>(expected[i],computed[i],cols))
+      {
+        return false;
+      }
+    }
+    return true;
+}
+
+/**
+ * To check that a class with accept Visitor is accepting correctly hasBeenVisited() returns true.
+ */
+class FakeVisitor: public librdag::Visitor
+{
+  public:
+  void visit(OGExpr const SUPPRESS_UNUSED *thing){
+    toggleHasBeenVisited();
+  };
+  void visit(OGArray<real16> const SUPPRESS_UNUSED *thing){
+    toggleHasBeenVisited();
+  };
+  void visit(OGArray<complex16> const SUPPRESS_UNUSED *thing){
+    toggleHasBeenVisited();
+  };
+  void visit(OGMatrix<real16> const SUPPRESS_UNUSED *thing){
+    toggleHasBeenVisited();
+  };
+  void visit(OGMatrix<complex16> const SUPPRESS_UNUSED *thing){
+    toggleHasBeenVisited();
+  };
+  void visit(OGScalar<real16> const SUPPRESS_UNUSED *thing){
+    toggleHasBeenVisited();
+  };
+  void visit(OGScalar<complex16> const SUPPRESS_UNUSED *thing){
+    toggleHasBeenVisited();
+  };
+  void visit(OGScalar<int> const SUPPRESS_UNUSED *thing){
+    toggleHasBeenVisited();
+  };
+  bool hasBeenVisited(){
+    return _hasBeenVisited;
+  }
+  private:
+  bool _hasBeenVisited = false;
+  void toggleHasBeenVisited()
+  {
+    _hasBeenVisited = !_hasBeenVisited;
+  }
+};
+
+/*
+ * Test OGRealScalar
+ */
+TEST(TerminalsTest, OGRealScalarTest) {
+  // test ctor
+  real16 value = 3.14e0;
+  OGRealScalar * tmp;
+  tmp = new OGRealScalar(value);
+  // check ctor worked
+  ASSERT_NE(tmp, nullptr); 
+  
+  // check getValue is ok
+  ASSERT_EQ(tmp->getValue(), value);
+
+  // wire up array for ArrOfArr test
+  real16 expectedtmp[1] = {3.14e0};
+  real16 ** expected = new real16 * [1];
+  expected[0] = &(expectedtmp[0]);
+  
+  // check toArrayOfArrays()
+  real16 ** computed = tmp->toArrayOfArrays();
+  ASSERT_TRUE(ArrayOfArraysEquals<real16>(expected,computed,1,1));
+  delete [] computed[0];
+  delete [] computed;
+
+  // check toReal16ArrayOfArrays
+  computed = tmp->toReal16ArrayOfArrays();
+  ASSERT_TRUE(ArrayOfArraysEquals<real16>(expected,computed,1,1));
+  delete [] computed[0];
+  delete [] computed;
+   
+  // check toComplex16ArrayOfArrays, should throw
+  ASSERT_ANY_THROW(tmp->toComplex16ArrayOfArrays());
+  
+  // check visitor
+  FakeVisitor * v = new FakeVisitor();
+  tmp->accept(*v);
+  ASSERT_TRUE(v->hasBeenVisited());
+  delete v;
+  
+  
+  // check copy and asOGRealScalar
+  OGNumeric * copy = tmp->copy();
+  ASSERT_EQ(tmp->getValue(),copy->asOGRealScalar()->getValue());
+  ASSERT_EQ(copy,copy->asOGRealScalar());
+  
+  // clean up
+  delete [] expected;
+  delete copy;
+  delete tmp;
+}
+
+
+/*
+ * Test OGComplexScalar
+ */
+TEST(TerminalsTest, OGComplexScalarTest) {
+  // test ctor
+  complex16 value = {3.14e0, 0.00159e0};
+  OGComplexScalar * tmp;
+  tmp = new OGComplexScalar(value);
+  // check ctor worked
+  ASSERT_NE(tmp, nullptr); 
+  
+  // check getValue is ok
+  ASSERT_EQ(tmp->getValue(), value);
+
+  // wire up array for ArrOfArr test
+  complex16 expectedtmp[1] = {{3.14e0, 0.00159e0}};
+  complex16  ** expected = new complex16  * [1];
+  expected[0] = &(expectedtmp[0]);
+   
+  // check toArrayOfArrays()
+  complex16 ** computed = tmp->toArrayOfArrays();
+  ASSERT_TRUE(ArrayOfArraysEquals<complex16>(expected,computed,1,1));
+  delete [] computed[0];
+  delete [] computed;
+
+  // check toComplex16ArrayOfArrays
+  computed = tmp->toComplex16ArrayOfArrays();
+  ASSERT_TRUE(ArrayOfArraysEquals<complex16>(expected,computed,1,1));
+  delete [] computed[0];
+  delete [] computed;
+
+  // check toReal16ArrayOfArrays, should throw
+  ASSERT_ANY_THROW(tmp->toReal16ArrayOfArrays());
+  
+  // check visitor
+  FakeVisitor * v = new FakeVisitor();
+  tmp->accept(*v);
+  ASSERT_TRUE(v->hasBeenVisited());
+  delete v;  
+  
+  // check copy and asOGComplexScalar
+  OGNumeric * copy = tmp->copy();
+  ASSERT_EQ(tmp->getValue(),copy->asOGComplexScalar()->getValue());
+  ASSERT_EQ(copy,copy->asOGComplexScalar());
+  
+  // clean up
+  delete [] expected;
+  delete copy;
+  delete tmp;
+}
+
+
+/*
+ * Test OGIntegerScalar
+ */
+TEST(TerminalsTest, OGIntegerScalarTest) {
+  // test ctor
+  int value = 3;
+  OGIntegerScalar * tmp;
+  tmp = new OGIntegerScalar(value);
+  // check ctor worked
+  ASSERT_NE(tmp, nullptr); 
+  
+  // check getValue is ok
+  ASSERT_EQ(tmp->getValue(), value);
+
+  // check toReal16ArrayOfArrays, should throw
+  ASSERT_ANY_THROW(tmp->toReal16ArrayOfArrays());
+   
+  // check toComplex16ArrayOfArrays, should throw
+  ASSERT_ANY_THROW(tmp->toComplex16ArrayOfArrays());
+  
+  // check copy and asOGIntegerScalar
+  OGNumeric * copy = tmp->copy();
+  ASSERT_EQ(tmp->getValue(),copy->asOGIntegerScalar()->getValue());
+  ASSERT_EQ(copy,copy->asOGIntegerScalar());
+  
+  // clean up
+  delete copy;
+  delete tmp;
+}
+
+/*
+ * Test OGRealMatrix
+ */
+TEST(TerminalsTest, OGRealMatrixTest) {
+  // data
+  real16 data [12] = {1,2,3,4,5,6,7,8,9,10,11,12};
+  int rows = 3;
+  int cols = 4;
+
+  // attempt construct from nullptr, should throw
+  real16 * null = nullptr;
+  OGRealMatrix * tmp;
+  ASSERT_ANY_THROW(tmp = new OGRealMatrix(null,rows,cols));
+  
+  // attempt construct from bad rows
+  tmp = nullptr;
+  ASSERT_ANY_THROW(tmp = new OGRealMatrix(data,-1,cols));
+  
+  // attempt construct from bad cols
+  tmp = nullptr;
+  ASSERT_ANY_THROW(tmp = new OGRealMatrix(data,rows,-1));
+  
+  // attempt construct from ok data
+  tmp = nullptr;
+  tmp = new OGRealMatrix(data,rows,cols);
+  // check ctor worked
+  ASSERT_NE(tmp, nullptr);
+  
+  // check getRows
+  ASSERT_EQ(tmp->getRows(), rows);
+  
+  // check getCols
+  ASSERT_EQ(tmp->getCols(), cols);
+  
+  tmp->debug_print();
+  
+  // wire up array for ArrOfArr test
+  real16 expectedtmp[12] = {1,4,7,10,2,5,8,11,3,6,9,12};
+  real16 ** expected = new real16  * [rows];
+  for(int i = 0; i < rows; i++){
+    expected[i] = &(expectedtmp[i*cols]);
+  }
+  
+  // check toArrayOfArrays()
+  real16 ** computed = tmp->toArrayOfArrays();
+  ASSERT_TRUE(ArrayOfArraysEquals<real16>(expected,computed,rows,cols));
+  for(int i = 0; i < rows; i++){
+    delete [] computed[i];
+  }
+  delete [] computed;
+  
+  // check toReal16ArrayOfArrays()
+  computed = tmp->toReal16ArrayOfArrays();
+  ASSERT_TRUE(ArrayOfArraysEquals<real16>(expected,computed,rows,cols));
+  for(int i = 0; i < rows; i++){
+    delete [] computed[i];
+  }
+  delete [] computed;
+  delete [] expected;  
+   
+  // check toComplex16ArrayOfArrays, expect throw
+  ASSERT_ANY_THROW(tmp->toComplex16ArrayOfArrays());
+
+  // check visitor
+  FakeVisitor * v = new FakeVisitor();
+  tmp->accept(*v);
+  ASSERT_TRUE(v->hasBeenVisited());
+  delete v;  
+  
+  // check copy and asOGRealMatrix
+  OGNumeric * copy = tmp->copy();
+  ASSERT_TRUE(ArrayEquals<real16>(tmp->getData(),copy->asOGRealMatrix()->getData(),rows*cols));
+  ASSERT_EQ(tmp->getRows(),copy->asOGRealMatrix()->getRows());
+  ASSERT_EQ(tmp->getCols(),copy->asOGRealMatrix()->getCols());
+  ASSERT_EQ(copy,copy->asOGRealMatrix());
+  
+  // clean up
+  delete copy;
+  delete tmp;
+}
+
+
+/*
+ * Test OGComplexMatrix
+ */
+TEST(TerminalsTest, OGComplexMatrixTest) {
+  // data
+  complex16 data [12] = {{1,10},{2,20},{3,30},{4,40},{5,50},{6,60},{7,70},{8,80},{9,90},{10,100},{11,110},{12,120}};
+  int rows = 3;
+  int cols = 4;
+
+  // attempt construct from nullptr, should throw
+  complex16 * null = nullptr;
+  OGComplexMatrix * tmp;
+  ASSERT_ANY_THROW(tmp = new OGComplexMatrix(null,rows,cols));
+  
+  // attempt construct from bad rows
+  tmp = nullptr;
+  ASSERT_ANY_THROW(tmp = new OGComplexMatrix(data,-1,cols));
+  
+  // attempt construct from bad cols
+  tmp = nullptr;
+  ASSERT_ANY_THROW(tmp = new OGComplexMatrix(data,rows,-1));
+  
+  // attempt construct from ok data
+  tmp = nullptr;
+  tmp = new OGComplexMatrix(data,rows,cols);
+  // check ctor worked
+  ASSERT_NE(tmp, nullptr);
+  
+  // check getRows
+  ASSERT_EQ(tmp->getRows(), rows);
+  
+  // check getCols
+  ASSERT_EQ(tmp->getCols(), cols);
+  
+  tmp->debug_print();
+  
+  // wire up array for ArrOfArr test
+  complex16 expectedtmp[12] = {{1,10},{4,40},{7,70},{10,100},{2,20},{5,50},{8,80},{11,110},{3,30},{6,60},{9,90},{12,120}};
+  complex16 ** expected = new complex16  * [rows];
+  for(int i = 0; i < rows; i++){
+    expected[i] = &(expectedtmp[i*cols]);
+  }
+  
+  // check toArrayOfArrays()
+  complex16 ** computed = tmp->toArrayOfArrays();
+  ASSERT_TRUE(ArrayOfArraysEquals<complex16>(expected,computed,rows,cols));
+  for(int i = 0; i < rows; i++){
+    delete [] computed[i];
+  }
+  delete [] computed;
+  
+  // check toComplex16ArrayOfArrays()
+  computed = tmp->toComplex16ArrayOfArrays();
+  ASSERT_TRUE(ArrayOfArraysEquals<complex16>(expected,computed,rows,cols));
+  for(int i = 0; i < rows; i++){
+    delete [] computed[i];
+  }
+  delete [] computed;
+  delete [] expected;  
+   
+  // check toReal16ArrayOfArrays, expect throw
+  ASSERT_ANY_THROW(tmp->toReal16ArrayOfArrays());
+
+  // check visitor
+  FakeVisitor * v = new FakeVisitor();
+  tmp->accept(*v);
+  ASSERT_TRUE(v->hasBeenVisited());
+  delete v;  
+  
+  // check copy and asOGComplexMatrix
+  OGNumeric * copy = tmp->copy();
+  ASSERT_TRUE(ArrayEquals<complex16>(tmp->getData(),copy->asOGComplexMatrix()->getData(),rows*cols));
+  ASSERT_EQ(tmp->getRows(),copy->asOGComplexMatrix()->getRows());
+  ASSERT_EQ(tmp->getCols(),copy->asOGComplexMatrix()->getCols());
+  ASSERT_EQ(copy,copy->asOGComplexMatrix());
+  
+  // clean up
+  delete copy;
+  delete tmp;
+}
+
+
+

--- a/src/librdag/test/check_terminals.cc
+++ b/src/librdag/test/check_terminals.cc
@@ -5,6 +5,7 @@
  */
 
 #include "terminal.hh"
+#include "expression.hh"
 #include "visitor.hh"
 #include "exceptions.hh"
 #include "gtest/gtest.h"
@@ -97,6 +98,23 @@ class FakeVisitor: public librdag::Visitor
     _hasBeenVisited = !_hasBeenVisited;
   }
 };
+
+/*
+ * Check OGTerminal base class behaves
+ */
+TEST(TerminalsTest, OGTerminalTest) {
+  OGNumeric * terminal_t = new OGRealScalar(3.14e0);
+  ArgContainer * args = new ArgContainer();
+  args->push_back(terminal_t);
+  OGNumeric * expr_t = new NEGATE(args);
+  const OGTerminal * term;
+  term = terminal_t->asOGTerminal();
+  ASSERT_NE(term,nullptr);
+  term = expr_t->asOGTerminal();
+  ASSERT_EQ(term,nullptr);
+  delete expr_t;
+  delete term;
+}
 
 /*
  * Test OGRealScalar
@@ -238,7 +256,7 @@ TEST(TerminalsTest, OGIntegerScalarTest) {
  */
 TEST(TerminalsTest, OGRealMatrixTest) {
   // data
-  real16 data [12] = {1,2,3,4,5,6,7,8,9,10,11,12};
+  real16 data [12] = {1e0,2e0,3e0,4e0,5e0,6e0,7e0,8e0,9e0,10e0,11e0,12e0};
   int rows = 3;
   int cols = 4;
 
@@ -270,8 +288,11 @@ TEST(TerminalsTest, OGRealMatrixTest) {
   // check getDatalen
   ASSERT_EQ(tmp->getDatalen(), rows*cols);
   
+  // check getData
+  ASSERT_TRUE(ArrayEquals(tmp->getData(),data,tmp->getDatalen()));
+  
   // wire up array for ArrOfArr test
-  real16 expectedtmp[12] = {1,4,7,10,2,5,8,11,3,6,9,12};
+  real16 expectedtmp[12] = {1e0,4e0,7e0,10e0,2e0,5e0,8e0,11e0,3e0,6e0,9e0,12e0};
   real16 ** expected = new real16  * [rows];
   for(int i = 0; i < rows; i++){
     expected[i] = &(expectedtmp[i*cols]);
@@ -305,6 +326,7 @@ TEST(TerminalsTest, OGRealMatrixTest) {
   
   // check copy and asOGRealMatrix
   OGNumeric * copy = tmp->copy();
+  ASSERT_EQ(tmp->getData(),copy->asOGRealMatrix()->getData());
   ASSERT_TRUE(ArrayEquals<real16>(tmp->getData(),copy->asOGRealMatrix()->getData(),tmp->getDatalen()));
   ASSERT_EQ(tmp->getRows(),copy->asOGRealMatrix()->getRows());
   ASSERT_EQ(tmp->getCols(),copy->asOGRealMatrix()->getCols());
@@ -321,7 +343,7 @@ TEST(TerminalsTest, OGRealMatrixTest) {
  */
 TEST(TerminalsTest, OGComplexMatrixTest) {
   // data
-  complex16 data [12] = {{1,10},{2,20},{3,30},{4,40},{5,50},{6,60},{7,70},{8,80},{9,90},{10,100},{11,110},{12,120}};
+  complex16 data [12] = {{1e0,10e0},{2e0,20e0},{3e0,30e0},{4e0,40e0},{5e0,50e0},{6e0,60e0},{7e0,70e0},{8e0,80e0},{9e0,90e0},{10e0,100e0},{11e0,110e0},{12e0,120e0}};
   int rows = 3;
   int cols = 4;
 
@@ -353,8 +375,11 @@ TEST(TerminalsTest, OGComplexMatrixTest) {
   // check getDatalen
   ASSERT_EQ(tmp->getDatalen(), rows*cols);
   
+  // check getData
+  ASSERT_TRUE(ArrayEquals(tmp->getData(),data,tmp->getDatalen()));
+  
   // wire up array for ArrOfArr test
-  complex16 expectedtmp[12] = {{1,10},{4,40},{7,70},{10,100},{2,20},{5,50},{8,80},{11,110},{3,30},{6,60},{9,90},{12,120}};
+  complex16 expectedtmp[12] = {{1e0,10e0},{4e0,40e0},{7e0,70e0},{10e0,100e0},{2e0,20e0},{5e0,50e0},{8e0,80e0},{11e0,110e0},{3e0,30e0},{6e0,60e0},{9e0,90e0},{12e0,120e0}};
   complex16 ** expected = new complex16  * [rows];
   for(int i = 0; i < rows; i++){
     expected[i] = &(expectedtmp[i*cols]);
@@ -388,6 +413,7 @@ TEST(TerminalsTest, OGComplexMatrixTest) {
   
   // check copy and asOGComplexMatrix
   OGNumeric * copy = tmp->copy();
+  ASSERT_EQ(tmp->getData(),copy->asOGComplexMatrix()->getData());
   ASSERT_TRUE(ArrayEquals<complex16>(tmp->getData(),copy->asOGComplexMatrix()->getData(),tmp->getDatalen()));
   ASSERT_EQ(tmp->getRows(),copy->asOGComplexMatrix()->getRows());
   ASSERT_EQ(tmp->getCols(),copy->asOGComplexMatrix()->getCols());
@@ -404,7 +430,7 @@ TEST(TerminalsTest, OGComplexMatrixTest) {
  */
 TEST(TerminalsTest, OGRealDiagonalMatrix) {
   // data
-  real16 data [3] = {1,2,3};
+  real16 data [3] = {1e0,2e0,3e0};
   int rows = 3;
   int cols = 4;
 
@@ -436,8 +462,11 @@ TEST(TerminalsTest, OGRealDiagonalMatrix) {
   // check getDatalen
   ASSERT_EQ(tmp->getDatalen(), rows>cols?cols:rows);
   
+  // check getData
+  ASSERT_TRUE(ArrayEquals(tmp->getData(),data,tmp->getDatalen()));  
+  
   // wire up array for ArrOfArr test
-  real16 expectedtmp[12] = {1,0,0,0,0,2,0,0,0,0,3,0};
+  real16 expectedtmp[12] = {1e0,0e0,0e0,0e0,0e0,2e0,0e0,0e0,0e0,0e0,3e0,0e0};
   real16 ** expected = new real16  * [rows];
   for(int i = 0; i < rows; i++){
     expected[i] = &(expectedtmp[i*cols]);
@@ -471,6 +500,7 @@ TEST(TerminalsTest, OGRealDiagonalMatrix) {
   
   // check copy and asOGRealMatrix
   OGNumeric * copy = tmp->copy();
+  ASSERT_EQ(tmp->getData(),copy->asOGRealDiagonalMatrix()->getData());
   ASSERT_TRUE(ArrayEquals<real16>(tmp->getData(),copy->asOGRealDiagonalMatrix()->getData(),tmp->getDatalen()));
   ASSERT_EQ(tmp->getRows(),copy->asOGRealDiagonalMatrix()->getRows());
   ASSERT_EQ(tmp->getCols(),copy->asOGRealDiagonalMatrix()->getCols());
@@ -488,7 +518,7 @@ TEST(TerminalsTest, OGRealDiagonalMatrix) {
  */
 TEST(TerminalsTest, OGComplexDiagonalMatrix) {
   // data
-  complex16 data [3] = {{1,10},{2,20},{3,30}};
+  complex16 data [3] = {{1e0,10e0},{2e0,20e0},{3e0,30e0}};
   int rows = 3;
   int cols = 4;
 
@@ -519,9 +549,12 @@ TEST(TerminalsTest, OGComplexDiagonalMatrix) {
   
   // check getDatalen
   ASSERT_EQ(tmp->getDatalen(), rows>cols?cols:rows);
+
+  // check getData
+  ASSERT_TRUE(ArrayEquals(tmp->getData(),data,tmp->getDatalen()));  
   
   // wire up array for ArrOfArr test
-  complex16 expectedtmp[12] = {{1,10},{0,0},{0,0},{0,0},{0,0},{2,20},{0,0},{0,0},{0,0},{0,0},{3,30},{0,0}};
+  complex16 expectedtmp[12] = {{1e0,10e0},{0e0,0e0},{0e0,0e0},{0e0,0e0},{0e0,0e0},{2e0,20e0},{0e0,0e0},{0e0,0e0},{0e0,0e0},{0e0,0e0},{3e0,30e0},{0e0,0e0}};
   complex16 ** expected = new complex16  * [rows];
   for(int i = 0; i < rows; i++){
     expected[i] = &(expectedtmp[i*cols]);
@@ -555,10 +588,240 @@ TEST(TerminalsTest, OGComplexDiagonalMatrix) {
   
   // check copy and asOGRealMatrix
   OGNumeric * copy = tmp->copy();
+  ASSERT_EQ(tmp->getData(),copy->asOGComplexDiagonalMatrix()->getData());
   ASSERT_TRUE(ArrayEquals<complex16>(tmp->getData(),copy->asOGComplexDiagonalMatrix()->getData(),tmp->getDatalen()));
   ASSERT_EQ(tmp->getRows(),copy->asOGComplexDiagonalMatrix()->getRows());
   ASSERT_EQ(tmp->getCols(),copy->asOGComplexDiagonalMatrix()->getCols());
   ASSERT_EQ(copy,copy->asOGComplexDiagonalMatrix());
+  
+  // clean up
+  delete copy;
+  delete tmp;
+}
+
+
+/*
+ * Test OGRealSparseMatrix
+ */
+TEST(TerminalsTest, OGRealSparseMatrix) {
+  // data
+  // double[][] data = { { 1, 2, 0, 0 }, { 3, 0, 4, 0 }, { 0, 5, 6, 0 }, { 0, 0, 7, 0 }, {0, 0, 0, 0} };
+  real16 data [7] = { 1.0e0, 3.0e0, 2.0e0, 5.0e0, 4.0e0, 6.0e0, 7.0e0 };
+  int colPtr [6] = { 0, 2, 4, 7, 7, 7 };
+  int rowIdx [7] = { 0, 1, 0, 2, 1, 2, 3 };
+  int rows = 5;
+  int cols = 4;
+
+  OGRealSparseMatrix * tmp;
+  int * nullintptr = nullptr;
+  
+  // attempt construct from colptr as null, should throw
+  tmp = nullptr;
+  ASSERT_ANY_THROW(tmp = new OGRealSparseMatrix(nullintptr,rowIdx,data,rows,cols));
+
+  // attempt construct from rowidx as null, should throw
+  tmp = nullptr;
+  ASSERT_ANY_THROW(tmp = new OGRealSparseMatrix(colPtr,nullintptr,data,rows,cols));
+
+  // attempt construct from data nullptr, should throw
+  real16 * nulldata = nullptr;
+  tmp = nullptr;
+  ASSERT_ANY_THROW(tmp = new OGRealSparseMatrix(colPtr,rowIdx,nulldata,rows,cols));
+  
+  // attempt construct from bad rows
+  tmp = nullptr;
+  ASSERT_ANY_THROW(tmp = new OGRealSparseMatrix(colPtr,rowIdx,data,-1,cols));
+
+  // attempt construct from bad cols
+  tmp = nullptr;
+  ASSERT_ANY_THROW(tmp = new OGRealSparseMatrix(colPtr,rowIdx,data,rows,-1));
+  
+  // attempt construct from ok data
+  tmp = nullptr;
+  tmp = new OGRealSparseMatrix(colPtr,rowIdx,data,rows,cols);
+  // check ctor worked
+  ASSERT_NE(tmp, nullptr);
+  
+  // check getRows
+  ASSERT_EQ(tmp->getRows(), rows);
+  
+  // check getCols
+  ASSERT_EQ(tmp->getCols(), cols);
+
+  // check getDatalen
+  ASSERT_EQ(tmp->getDatalen(), colPtr[cols]);
+
+  // check getData
+  ASSERT_TRUE(ArrayEquals(tmp->getData(),data,tmp->getDatalen()));
+  
+  // check getColPtr
+  ASSERT_TRUE(ArrayEquals(tmp->getColPtr(),colPtr,6));
+
+  // check getRowIdx
+  ASSERT_TRUE(ArrayEquals(tmp->getRowIdx(),rowIdx,7));
+  
+  // wire up array for ArrOfArr test
+  real16 expectedtmp[20] = { 1e0, 2e0, 0e0, 0e0 ,  3e0, 0e0, 4e0, 0e0 ,  0e0, 5e0, 6e0, 0e0 ,  0e0, 0e0, 7e0, 0e0 , 0e0, 0e0, 0e0, 0e0};
+  real16 ** expected = new real16  * [rows];
+  for(int i = 0; i < rows; i++){
+    expected[i] = &(expectedtmp[i*cols]);
+  }
+  
+  // check toArrayOfArrays()
+  real16 ** computed = tmp->toArrayOfArrays(); 
+  ASSERT_TRUE(ArrayOfArraysEquals<real16>(expected,computed,rows,cols));
+  for(int i = 0; i < rows; i++){
+    delete [] computed[i];
+  }
+  delete [] computed;
+
+  // check toReal16ArrayOfArrays()
+  computed = tmp->toReal16ArrayOfArrays();
+  ASSERT_TRUE(ArrayOfArraysEquals<real16>(expected,computed,rows,cols));
+  for(int i = 0; i < rows; i++){
+    delete [] computed[i];
+  }
+  delete [] computed;
+  delete [] expected;
+   
+  // check toComplex16ArrayOfArrays, expect throw
+  ASSERT_ANY_THROW(tmp->toComplex16ArrayOfArrays());
+
+  // check visitor
+  FakeVisitor * v = new FakeVisitor();
+  tmp->accept(*v);
+  ASSERT_TRUE(v->hasBeenVisited());
+  delete v;  
+  
+  // check copy and asOGRealSparseMatrix
+  OGNumeric * copy = tmp->copy();
+  ASSERT_EQ(tmp->getData(),copy->asOGRealSparseMatrix()->getData());
+  ASSERT_TRUE(ArrayEquals(tmp->getData(),copy->asOGRealSparseMatrix()->getData(),tmp->getDatalen()));
+  ASSERT_EQ(tmp->getRows(),copy->asOGRealSparseMatrix()->getRows());
+  ASSERT_EQ(tmp->getCols(),copy->asOGRealSparseMatrix()->getCols());
+  ASSERT_EQ(tmp->getRowIdx(),copy->asOGRealSparseMatrix()->getRowIdx());
+  ASSERT_TRUE(ArrayEquals(tmp->getRowIdx(),copy->asOGRealSparseMatrix()->getRowIdx(),7));
+  ASSERT_EQ(tmp->getColPtr(),copy->asOGRealSparseMatrix()->getColPtr());
+  ASSERT_TRUE(ArrayEquals(tmp->getColPtr(),copy->asOGRealSparseMatrix()->getColPtr(),6));
+  ASSERT_EQ(copy,copy->asOGRealSparseMatrix());
+  
+  // clean up
+  delete copy;
+  delete tmp;
+}
+
+
+/*
+ * Test OGComplexSparseMatrix
+ */
+TEST(TerminalsTest, OGComplexSparseMatrix) {
+  // data
+//   double[][] realData = { { 1, 2, 0, 0 }, { 5, 0, 7, 0 }, { 0, 10, 11, 0 }, { 0, 0, 15, 0 } };
+//   double[][] imagData = { { 10, 20, 30, 0 }, { 0, 60, 70, 0 }, { 90, 100, 0, 120 }, { 0, 0, 0, 160 } };
+  complex16 data [12] = { {1, 10}, {5, 0}, {0, 90}, {2, 20}, {0, 60}, {10, 100}, {0, 30}, {7, 70}, {11, 0}, {15, 0}, {0, 120}, {0, 160} };
+  int colPtr [6] = { 0, 3, 6, 10, 12, 12 };
+  int rowIdx [12] = { 0, 1, 2, 0, 1, 2, 0, 1, 2, 3, 2, 3 };
+  int rows = 5;
+  int cols = 4;
+
+  OGComplexSparseMatrix * tmp;
+  int * nullintptr = nullptr;
+  
+  // attempt construct from colptr as null, should throw
+  tmp = nullptr;
+  ASSERT_ANY_THROW(tmp = new OGComplexSparseMatrix(nullintptr,rowIdx,data,rows,cols));
+
+  // attempt construct from rowidx as null, should throw
+  tmp = nullptr;
+  ASSERT_ANY_THROW(tmp = new OGComplexSparseMatrix(colPtr,nullintptr,data,rows,cols));
+
+  // attempt construct from data nullptr, should throw
+  complex16 * nulldata = nullptr;
+  tmp = nullptr;
+  ASSERT_ANY_THROW(tmp = new OGComplexSparseMatrix(colPtr,rowIdx,nulldata,rows,cols));
+  
+  // attempt construct from bad rows
+  tmp = nullptr;
+  ASSERT_ANY_THROW(tmp = new OGComplexSparseMatrix(colPtr,rowIdx,data,-1,cols));
+
+  // attempt construct from bad cols
+  tmp = nullptr;
+  ASSERT_ANY_THROW(tmp = new OGComplexSparseMatrix(colPtr,rowIdx,data,rows,-1));
+  
+  // attempt construct from ok data
+  tmp = nullptr;
+  tmp = new OGComplexSparseMatrix(colPtr,rowIdx,data,rows,cols);
+  // check ctor worked
+  ASSERT_NE(tmp, nullptr);
+  
+  // check getRows
+  ASSERT_EQ(tmp->getRows(), rows);
+  
+  // check getCols
+  ASSERT_EQ(tmp->getCols(), cols);
+
+  // check getDatalen
+  ASSERT_EQ(tmp->getDatalen(), colPtr[cols]);
+
+  // check getData
+  ASSERT_TRUE(ArrayEquals(tmp->getData(),data,tmp->getDatalen()));
+  
+  // check getColPtr
+  ASSERT_TRUE(ArrayEquals(tmp->getColPtr(),colPtr,6));
+
+  // check getRowIdx
+  ASSERT_TRUE(ArrayEquals(tmp->getRowIdx(),rowIdx,12));  
+  
+  // wire up array for ArrOfArr test
+  complex16 expectedtmp[20] = {
+    {1,10},{2,20},{0,30},{0,0},
+    {5,0},{0,60},{7,70},{0,0},
+    {0,90},{10,100},{11,0},{0,120},
+    {0,0},{0,0},{15,0},{0,160},
+    {0,0},{0,0},{0,0},{0,0}
+  };
+  complex16 ** expected = new complex16  * [rows];
+  for(int i = 0; i < rows; i++){
+    expected[i] = &(expectedtmp[i*cols]);
+  }
+  
+  // check toArrayOfArrays()
+  complex16 ** computed = tmp->toArrayOfArrays(); 
+  ASSERT_TRUE(ArrayOfArraysEquals<complex16>(expected,computed,rows,cols));
+  for(int i = 0; i < rows; i++){
+    delete [] computed[i];
+  }
+  delete [] computed;
+
+  // check toComplex16ArrayOfArrays()
+  computed = tmp->toComplex16ArrayOfArrays();
+  ASSERT_TRUE(ArrayOfArraysEquals<complex16>(expected,computed,rows,cols));
+  for(int i = 0; i < rows; i++){
+    delete [] computed[i];
+  }
+  delete [] computed;
+  delete [] expected;
+   
+  // check toReal16ArrayOfArrays, expect throw
+  ASSERT_ANY_THROW(tmp->toReal16ArrayOfArrays());
+
+  // check visitor
+  FakeVisitor * v = new FakeVisitor();
+  tmp->accept(*v);
+  ASSERT_TRUE(v->hasBeenVisited());
+  delete v;  
+  
+  // check copy and asOGComplexSparseMatrix
+  OGNumeric * copy = tmp->copy();
+  ASSERT_EQ(tmp->getData(),copy->asOGComplexSparseMatrix()->getData());
+  ASSERT_TRUE(ArrayEquals(tmp->getData(),copy->asOGComplexSparseMatrix()->getData(),tmp->getDatalen()));
+  ASSERT_EQ(tmp->getRows(),copy->asOGComplexSparseMatrix()->getRows());
+  ASSERT_EQ(tmp->getCols(),copy->asOGComplexSparseMatrix()->getCols());
+  ASSERT_EQ(tmp->getRowIdx(),copy->asOGComplexSparseMatrix()->getRowIdx());
+  ASSERT_TRUE(ArrayEquals(tmp->getRowIdx(),copy->asOGComplexSparseMatrix()->getRowIdx(),12));
+  ASSERT_EQ(tmp->getColPtr(),copy->asOGComplexSparseMatrix()->getColPtr());
+  ASSERT_TRUE(ArrayEquals(tmp->getColPtr(),copy->asOGComplexSparseMatrix()->getColPtr(),6));
+  ASSERT_EQ(copy,copy->asOGComplexSparseMatrix());
   
   // clean up
   delete copy;

--- a/src/librdag/test/check_terminals.cc
+++ b/src/librdag/test/check_terminals.cc
@@ -4,7 +4,9 @@
  * Please see distribution for license.
  */
 
-#include "expression.hh"
+#include "terminal.hh"
+#include "visitor.hh"
+#include "exceptions.hh"
 #include "gtest/gtest.h"
 #include "warningmacros.h"
 


### PR DESCRIPTION
This PR does:
- Refactoring of `expression.hh` to remove terminal types into `terminal.hh` and the `OGNumeric` base class into `numeric.hh`
- Implements sparse matrix `toArrayOfArrays()` method
- Tests the C++ terminal types, ctors, methods etc.

BB PASS: http://devmaths-lx-1:8011/builders/nyqwk2-testing/builds/187
