### PR TITLE
Mat 240

### DIFF
--- a/include/containers.hh
+++ b/include/containers.hh
@@ -25,16 +25,16 @@ class PtrVector
   public:
     PtrVector();
     virtual ~PtrVector();
-    typedef typename vector<T const *>::const_iterator citerator;
-    void push_back(T const * arg);
+    typedef typename vector<T>::const_iterator citerator;
+    void push_back(T arg);
     size_t size() const;
     citerator begin() const;
     citerator end() const;
-    const T* operator[](size_t n) const;
+    T operator[](size_t n) const;
     virtual PtrVector* copy() const = 0;
   private:
-    vector<T const *>* _vector;
-    void _check_arg(T const * arg);
+    vector<T>* _vector;
+    void _check_arg(T arg);
 };
 
 /*
@@ -63,10 +63,10 @@ class OwningPtrVector: public PtrVector<T>
 
 class OGNumeric;
 
-extern template class NonOwningPtrVector<int>;
-extern template class NonOwningPtrVector<OGNumeric>;
-extern template class OwningPtrVector<int>;
-extern template class OwningPtrVector<OGNumeric>;
+extern template class NonOwningPtrVector<const int*>;
+extern template class NonOwningPtrVector<const OGNumeric*>;
+extern template class OwningPtrVector<const int*>;
+extern template class OwningPtrVector<const OGNumeric*>;
 
 } // namespace librdag
 

--- a/include/containers.hh
+++ b/include/containers.hh
@@ -19,31 +19,31 @@ namespace librdag {
 /*
  * A vector that holds pointers. Null pointers are not allowed.
  */
-template<typename T>
+template<typename cTp>
 class PtrVector
 {
-  static_assert(is_pointer<T>::value && is_const<typename remove_pointer<T>::type>::value,
-                "Type T must be pointer to const type");
+  static_assert(is_pointer<cTp>::value && is_const<typename remove_pointer<cTp>::type>::value,
+                "Type cTp must be pointer to const type");
   public:
     PtrVector();
     virtual ~PtrVector();
-    typedef typename vector<T>::const_iterator citerator;
-    void push_back(T arg);
+    typedef typename vector<cTp>::const_iterator citerator;
+    void push_back(cTp arg);
     size_t size() const;
     citerator begin() const;
     citerator end() const;
-    T operator[](size_t n) const;
+    cTp operator[](size_t n) const;
     virtual PtrVector* copy() const = 0;
   private:
-    vector<T>* _vector;
-    void _check_arg(T arg);
+    vector<cTp>* _vector;
+    void _check_arg(cTp arg);
 };
 
 /*
  * A vector that holds pointers that point to data that it does not own.
  */
-template<typename T>
-class NonOwningPtrVector: public PtrVector<T>
+template<typename cTp>
+class NonOwningPtrVector: public PtrVector<cTp>
 {
   public:
     virtual NonOwningPtrVector* copy() const override;
@@ -55,8 +55,8 @@ class NonOwningPtrVector: public PtrVector<T>
  * Classes held in an OwningPtrVector must define a method copy() that returns
  * a pointer to a copy of itself.
  */
-template<typename T>
-class OwningPtrVector: public PtrVector<T>
+template<typename cTp>
+class OwningPtrVector: public PtrVector<cTp>
 {
   public:
     virtual ~OwningPtrVector() override;

--- a/include/containers.hh
+++ b/include/containers.hh
@@ -22,6 +22,8 @@ namespace librdag {
 template<typename T>
 class PtrVector
 {
+  static_assert(is_pointer<T>::value && is_const<typename remove_pointer<T>::type>::value,
+                "Type T must be pointer to const type");
   public:
     PtrVector();
     virtual ~PtrVector();

--- a/include/execution.hh
+++ b/include/execution.hh
@@ -15,7 +15,7 @@ namespace librdag {
 class OGNumeric;
 
 // Internal data structure for the ExecutionList.
-typedef NonOwningPtrVector<OGNumeric> _ExpressionList;
+typedef NonOwningPtrVector<const OGNumeric*> _ExpressionList;
 
 // An ExecutionList holds a list of expression nodes that are in order such that
 // no node has inputs that are computed by a node further down the list. Thus,

--- a/include/expression.hh
+++ b/include/expression.hh
@@ -31,7 +31,7 @@ namespace librdag
 /**
  * Container for expression arguments
  */
-typedef OwningPtrVector<OGNumeric> ArgContainer;
+typedef OwningPtrVector<const OGNumeric*> ArgContainer;
 
 /**
  *  Expr type

--- a/src/librdag/containers.cc
+++ b/src/librdag/containers.cc
@@ -17,7 +17,7 @@ namespace librdag {
 template<typename T>
 PtrVector<T>::PtrVector()
 {
-  _vector = new vector<T const *>();
+  _vector = new vector<T>();
 }
 
 template<typename T>
@@ -28,7 +28,7 @@ PtrVector<T>::~PtrVector()
 
 template<typename T>
 void
-PtrVector<T>::push_back(T const * arg)
+PtrVector<T>::push_back(T arg)
 {
   _check_arg(arg);
   _vector->push_back(arg);
@@ -56,7 +56,7 @@ PtrVector<T>::end() const
 }
 
 template<typename T>
-const T*
+T
 PtrVector<T>::operator[](size_t n) const
 {
   return (*_vector)[n];
@@ -64,7 +64,7 @@ PtrVector<T>::operator[](size_t n) const
 
 template<typename T>
 void
-PtrVector<T>::_check_arg(T const * arg)
+PtrVector<T>::_check_arg(T arg)
 {
   if (arg == nullptr)
   {
@@ -72,8 +72,8 @@ PtrVector<T>::_check_arg(T const * arg)
   }
 }
 
-template class PtrVector<int>;
-template class PtrVector<OGNumeric>;
+template class PtrVector<const int*>;
+template class PtrVector<const OGNumeric*>;
 
 /**
  * NonOwningPtrVector
@@ -91,8 +91,8 @@ NonOwningPtrVector<T>::copy() const
   return c;
 }
 
-template class NonOwningPtrVector<int>;
-template class NonOwningPtrVector<OGNumeric>;
+template class NonOwningPtrVector<const int*>;
+template class NonOwningPtrVector<const OGNumeric*>;
 
 /**
  * OwningPtrVector
@@ -117,7 +117,7 @@ namespace detail {
  * data.
  */
 
-template<typename T, bool Q = is_fundamental<T>::value >
+template<typename T, bool Q = is_fundamental<typename remove_pointer<T>::type>::value >
 struct owningptrvector_copy_impl;
 
 template<typename T>
@@ -142,7 +142,10 @@ struct owningptrvector_copy_impl<T, true>
     OwningPtrVector<T>* c = new OwningPtrVector<T>();
     for (auto it = src->begin(); it != src->end(); ++it)
     {
-      T* n = new T;
+      typedef typename remove_pointer<T>::type Tnoptr;
+      typedef typename remove_const<Tnoptr>::type Tnoptrnoconst;
+      typedef Tnoptrnoconst* Tptr;
+      Tptr n = new Tnoptrnoconst;
       *n = **it;
       c->push_back(n);
     }
@@ -159,7 +162,7 @@ OwningPtrVector<T>::copy() const
   return detail::owningptrvector_copy_impl<T>()(this);
 }
 
-template class OwningPtrVector<int>;
-template class OwningPtrVector<OGNumeric>;
+template class OwningPtrVector<const int*>;
+template class OwningPtrVector<const OGNumeric*>;
 
 } // namespace librdag

--- a/src/librdag/containers.cc
+++ b/src/librdag/containers.cc
@@ -14,57 +14,57 @@ namespace librdag {
  * PtrVector
  */
 
-template<typename T>
-PtrVector<T>::PtrVector()
+template<typename cTp>
+PtrVector<cTp>::PtrVector()
 {
-  _vector = new vector<T>();
+  _vector = new vector<cTp>();
 }
 
-template<typename T>
-PtrVector<T>::~PtrVector()
+template<typename cTp>
+PtrVector<cTp>::~PtrVector()
 {
   delete _vector;
 }
 
-template<typename T>
+template<typename cTp>
 void
-PtrVector<T>::push_back(T arg)
+PtrVector<cTp>::push_back(cTp arg)
 {
   _check_arg(arg);
   _vector->push_back(arg);
 }
 
-template<typename T>
+template<typename cTp>
 size_t
-PtrVector<T>::size() const
+PtrVector<cTp>::size() const
 {
   return _vector->size();
 }
 
-template<typename T>
-typename PtrVector<T>::citerator
-PtrVector<T>::begin() const
+template<typename cTp>
+typename PtrVector<cTp>::citerator
+PtrVector<cTp>::begin() const
 {
   return _vector->begin();
 }
 
-template<typename T>
-typename PtrVector<T>::citerator
-PtrVector<T>::end() const
+template<typename cTp>
+typename PtrVector<cTp>::citerator
+PtrVector<cTp>::end() const
 {
   return _vector->end();
 }
 
-template<typename T>
-T
-PtrVector<T>::operator[](size_t n) const
+template<typename cTp>
+cTp
+PtrVector<cTp>::operator[](size_t n) const
 {
   return (*_vector)[n];
 }
 
-template<typename T>
+template<typename cTp>
 void
-PtrVector<T>::_check_arg(T arg)
+PtrVector<cTp>::_check_arg(cTp arg)
 {
   if (arg == nullptr)
   {
@@ -79,9 +79,9 @@ template class PtrVector<const OGNumeric*>;
  * NonOwningPtrVector
  */
 
-template<typename T>
-NonOwningPtrVector<T>*
-NonOwningPtrVector<T>::copy() const
+template<typename cTp>
+NonOwningPtrVector<cTp>*
+NonOwningPtrVector<cTp>::copy() const
 {
   NonOwningPtrVector* c = new NonOwningPtrVector();
   for (auto it = this->begin(); it != this->end(); ++it)
@@ -98,8 +98,8 @@ template class NonOwningPtrVector<const OGNumeric*>;
  * OwningPtrVector
  */
 
-template<typename T>
-OwningPtrVector<T>::~OwningPtrVector()
+template<typename cTp>
+OwningPtrVector<cTp>::~OwningPtrVector()
 {
   for (auto it = this->begin(); it != this->end(); ++it)
   {
@@ -117,15 +117,15 @@ namespace detail {
  * data.
  */
 
-template<typename T, bool Q = is_fundamental<typename remove_pointer<T>::type>::value >
+template<typename cTp, bool Q = is_fundamental<typename remove_pointer<cTp>::type>::value >
 struct owningptrvector_copy_impl;
 
-template<typename T>
-struct owningptrvector_copy_impl<T, false>
+template<typename cTp>
+struct owningptrvector_copy_impl<cTp, false>
 {
-  OwningPtrVector<T>* operator()(const OwningPtrVector<T>* src)
+  OwningPtrVector<cTp>* operator()(const OwningPtrVector<cTp>* src)
   {
-    OwningPtrVector<T>* c = new OwningPtrVector<T>();
+    OwningPtrVector<cTp>* c = new OwningPtrVector<cTp>();
     for (auto it = src->begin(); it != src->end(); ++it)
     {
       c->push_back((*it)->copy());
@@ -134,18 +134,18 @@ struct owningptrvector_copy_impl<T, false>
   }
 };
 
-template<typename T>
-struct owningptrvector_copy_impl<T, true>
+template<typename cTp>
+struct owningptrvector_copy_impl<cTp, true>
 {
-  OwningPtrVector<T>* operator()(const OwningPtrVector<T>* src)
+  OwningPtrVector<cTp>* operator()(const OwningPtrVector<cTp>* src)
   {
-    OwningPtrVector<T>* c = new OwningPtrVector<T>();
+    OwningPtrVector<cTp>* c = new OwningPtrVector<cTp>();
     for (auto it = src->begin(); it != src->end(); ++it)
     {
-      typedef typename remove_pointer<T>::type Tnoptr;
-      typedef typename remove_const<Tnoptr>::type Tnoptrnoconst;
-      typedef Tnoptrnoconst* Tptr;
-      Tptr n = new Tnoptrnoconst;
+      typedef typename remove_pointer<cTp>::type cT;
+      typedef typename remove_const<cT>::type T;
+      typedef T* Tp;
+      Tp n = new T;
       *n = **it;
       c->push_back(n);
     }
@@ -155,11 +155,11 @@ struct owningptrvector_copy_impl<T, true>
 
 } // namespace detail
 
-template<typename T>
-OwningPtrVector<T>*
-OwningPtrVector<T>::copy() const
+template<typename cTp>
+OwningPtrVector<cTp>*
+OwningPtrVector<cTp>::copy() const
 {
-  return detail::owningptrvector_copy_impl<T>()(this);
+  return detail::owningptrvector_copy_impl<cTp>()(this);
 }
 
 template class OwningPtrVector<const int*>;

--- a/src/librdag/test/check_containers.cc
+++ b/src/librdag/test/check_containers.cc
@@ -16,7 +16,7 @@ using namespace librdag;
  */
 TEST(ContainerTest, OwningPtrVectorTest) {
   // Default constructor
-  OwningPtrVector<int> *pv1 = new OwningPtrVector<int>();
+  OwningPtrVector<const int*> *pv1 = new OwningPtrVector<const int*>();
   EXPECT_EQ(0, pv1->size());
 
   // Add elements
@@ -51,10 +51,10 @@ TEST(ContainerTest, OwningPtrVectorTest) {
   EXPECT_EQ(5, i);
 
   // Copy the OwningPtrVector
-  OwningPtrVector<int> *pv2 = pv1->copy();
+  OwningPtrVector<const int*> *pv2 = pv1->copy();
 
   // Test the copy is the same as the original
-  OwningPtrVector<int>::citerator it1, it2;
+  OwningPtrVector<const int*>::citerator it1, it2;
   for (it1 = pv1->begin(), it2 = pv2->begin(); it1 != pv1->end(), it2 != pv2->end(); ++it1, ++it2)
   {
     EXPECT_EQ(**it1, **it2);


### PR DESCRIPTION
Declaring PtrVector<T> to get a container of const T\* was seriously confusing. This PR redefines it so that you instead define PtrVector<const T*> to get a container of const T*.

A compile-time check enforces the types that can be used with the containers.

I can't get a full pass because of buildbot steps that have since been added, but this is what it does do: http://devmaths-lx-1:8011/builders/nyqwk2-testing/builds/262
