### PR TITLE
[MAT-247] Add target to run Jacoco.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,7 @@ if (CMAKE_BUILD_TYPE MATCHES "Debug" AND NOT WIN32)
 endif()
 
 
+
 add_subdirectory(src)
 
 add_gtest_report()
@@ -139,7 +140,20 @@ if (WIN32)
   set_tests_properties(${TESTNG_TEST} PROPERTIES ENVIRONMENT "CLASSPATH=${CLASSPATH}")
 else()
   set(JAVA_CP ${CMAKE_JAVA_INCLUDE_PATH}:${LONGDOGJAR}:${LONGDOGTESTJAR})
-  add_test(${TESTNG_TEST} ${Java_JAVA_EXECUTABLE} -verbose -cp ${JAVA_CP} org.testng.TestNG -testjar jars/${LONGDOG}-tests.jar)
+  set(JAVA_TESTNG_ARGS -verbose -cp ${JAVA_CP} org.testng.TestNG -testjar jars/${LONGDOG}-tests.jar)
+  add_test(${TESTNG_TEST} ${Java_JAVA_EXECUTABLE} ${JAVA_TESTNG_ARGS})
+  set(JACOCOJAR $ENV{JACOCOJAR})
+  add_custom_target(jacocorun
+                    COMMAND ${Java_JAVA_EXECUTABLE} -javaagent:${JACOCOJAR} ${JAVA_TESTNG_ARGS}
+                    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+                    COMMENT "Gathering Java test coverage information")
+  add_custom_target(jacoco
+                    COMMAND ${Java_JAVA_EXECUTABLE} com.opengamma.jacocoreporter.ReportGenerator jacoco.exec
+                            ${JARDIR}/CMakeFiles/${LONGDOG}.dir ${CMAKE_SOURCE_DIR}/src/java/src/main/java
+                            coveragereport
+                    DEPENDS jacocorun
+                    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+                    COMMENT "Generating Java test coverage report")
 endif()
 
 


### PR DESCRIPTION
This invokes the tests with the Jacoco agent and then generates
a test report. It can be run with:

  make jacoco

The $JACOCOJAR environment variable must be set to tell CMake
where to find the Jacoco agent.

The report generation requires reporter-0.0.1-SNAPSHOT.jar,
org.jacoco.report-0.6.3.201306030806.jar,
org.jacoco.core-0.6.3.201306030806.jar, and asm-all-4.1.jar.

Buildbot pass: http://devmaths-lx-1:8011/builders/nyqwk2-testing/builds/287

Example code coverage report: http://devmaths-lx-1:8011/javacoverage/nyqwk2-testing-osx-Debug-291/
