### PR TITLE
Mat 220 attemptedfix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,15 +44,17 @@ set(longdog_VERSION
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules ${CMAKE_MODULE_PATH})
 
 # tweak flags
+set(FFAST_MATH_SAFE "-fno-math-errno -ffinite-math-only -fno-rounding-math -fno-signaling-nans -fcx-limited-range") # -funsafe-math-optimizations is missing as it messes with the FPU control word which can cause segfaults when running through the JNI interface 
+
 set(CMAKE_C_FLAGS "-std=c99 -Wall -Werror -Wextra -pedantic ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_C_FLAGS}")
 set(CMAKE_C_FLAGS_DEBUG "-DDEBUG ${CMAKE_C_FLAGS_DEBUG}")
-set(CMAKE_C_FLAGS_RELEASE "-ffast-math -O2 -march=core2 -funroll-loops -DNDEBUG")
-set(CMAKE_C_FLAGS_RELWITHDEBINFO "-ffast-math -march=core2 -funroll-loops ${CMAKE_C_FLAGS_RELWITHDEBINFO}")
+set(CMAKE_C_FLAGS_RELEASE "${FFAST_MATH_SAFE} -O2 -march=core2 -funroll-loops -DNDEBUG")
+set(CMAKE_C_FLAGS_RELWITHDEBINFO "${FFAST_MATH_SAFE} -march=core2 -funroll-loops ${CMAKE_C_FLAGS_RELWITHDEBINFO}")
 
 set(CMAKE_CXX_FLAGS "-std=c++11 -Wall -Werror -Wextra -pedantic ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_CXX_FLAGS}")
 set(CMAKE_CXX_FLAGS_DEBUG "-DDEBUG ${CMAKE_CXX_FLAGS_DEBUG}")
-set(CMAKE_CXX_FLAGS_RELEASE "-ffast-math -O2 -march=core2 -funroll-loops -DNDEBUG")
-set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-ffast-math -march=core2 -funroll-loops ${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+set(CMAKE_CXX_FLAGS_RELEASE "${FFAST_MATH_SAFE}-O2 -march=core2 -funroll-loops -DNDEBUG")
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${FFAST_MATH_SAFE} -march=core2 -funroll-loops ${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
 
 
 # Add Java
@@ -147,7 +149,7 @@ if (WIN32)
   set_tests_properties(${TESTNG_TEST} PROPERTIES ENVIRONMENT "CLASSPATH=${CLASSPATH}")
 else()
   set(JAVA_CP ${CMAKE_JAVA_INCLUDE_PATH}:${LONGDOGJAR}:${LONGDOGTESTJAR})
-  set(JAVA_TESTNG_ARGS -Xcheck:jni -XX:+RestoreMXCSROnJNICalls -verbose -cp ${JAVA_CP} org.testng.TestNG -testjar jars/${LONGDOG}-tests.jar)
+  set(JAVA_TESTNG_ARGS -Xcheck:jni -verbose -cp ${JAVA_CP} org.testng.TestNG -testjar jars/${LONGDOG}-tests.jar)
   add_test(${TESTNG_TEST} ${Java_JAVA_EXECUTABLE} ${JAVA_TESTNG_ARGS})
   set(JACOCOJAR $ENV{JACOCOJAR})
   add_custom_target(jacocorun

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,9 +26,13 @@ if (PYTHONINTERP_FOUND)
   message(STATUS "Using Python version ${PYTHON_VERSION_STRING}")
 endif()
 
-# Use threads - we force -pthread in preference to -lpthread
-set(THREADS_HAVE_PTHREAD_ARG "THREADS_HAVE_PTHREAD_ARG")
-find_package(Threads)
+if(WIN32)
+  set(CMAKE_THREAD_LIBS_INIT -mthreads)
+else()
+  # we force -pthread in preference to -lpthread because it sets -D_REENTRANT
+  set(THREADS_HAVE_PTHREAD_ARG "THREADS_HAVE_PTHREAD_ARG")
+  find_package(Threads)
+endif()
 
 set(longdog_VERSION_MAJOR 0)
 set(longdog_VERSION_MINOR 0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,7 +147,7 @@ if (WIN32)
   set_tests_properties(${TESTNG_TEST} PROPERTIES ENVIRONMENT "CLASSPATH=${CLASSPATH}")
 else()
   set(JAVA_CP ${CMAKE_JAVA_INCLUDE_PATH}:${LONGDOGJAR}:${LONGDOGTESTJAR})
-  set(JAVA_TESTNG_ARGS -verbose -cp ${JAVA_CP} org.testng.TestNG -testjar jars/${LONGDOG}-tests.jar)
+  set(JAVA_TESTNG_ARGS -Xcheck:jni -verbose -cp ${JAVA_CP} org.testng.TestNG -testjar jars/${LONGDOG}-tests.jar)
   add_test(${TESTNG_TEST} ${Java_JAVA_EXECUTABLE} ${JAVA_TESTNG_ARGS})
   set(JACOCOJAR $ENV{JACOCOJAR})
   add_custom_target(jacocorun

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,9 @@ if (PYTHONINTERP_FOUND)
   message(STATUS "Using Python version ${PYTHON_VERSION_STRING}")
 endif()
 
+# Use threads - we force -pthread in preference to -lpthread
+set(THREADS_HAVE_PTHREAD_ARG "THREADS_HAVE_PTHREAD_ARG")
+find_package(Threads)
 
 set(longdog_VERSION_MAJOR 0)
 set(longdog_VERSION_MINOR 0)
@@ -37,12 +40,12 @@ set(longdog_VERSION
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules ${CMAKE_MODULE_PATH})
 
 # tweak flags
-set(CMAKE_C_FLAGS "-std=c99 -Wall -Werror -Wextra -pedantic ${CMAKE_C_FLAGS}")
+set(CMAKE_C_FLAGS "-std=c99 -Wall -Werror -Wextra -pedantic ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_C_FLAGS}")
 set(CMAKE_C_FLAGS_DEBUG "-DDEBUG ${CMAKE_C_FLAGS_DEBUG}")
 set(CMAKE_C_FLAGS_RELEASE "-ffast-math -O2 -march=core2 -funroll-loops -DNDEBUG")
 set(CMAKE_C_FLAGS_RELWITHDEBINFO "-ffast-math -march=core2 -funroll-loops ${CMAKE_C_FLAGS_RELWITHDEBINFO}")
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -Wall -Werror -Wextra -pedantic ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "-std=c++11 -Wall -Werror -Wextra -pedantic ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_CXX_FLAGS}")
 set(CMAKE_CXX_FLAGS_DEBUG "-DDEBUG ${CMAKE_CXX_FLAGS_DEBUG}")
 set(CMAKE_CXX_FLAGS_RELEASE "-ffast-math -O2 -march=core2 -funroll-loops -DNDEBUG")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-ffast-math -march=core2 -funroll-loops ${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
@@ -176,5 +179,7 @@ message("
   Java Compiler flags........: " ${CMAKE_Java_COMPILE_FLAGS} "
   JavaH Tool.................: " ${Java_JAVAH_EXECUTABLE} "
   Jar Tool...................: " ${Java_JAR_EXECUTABLE} "
+  Java Library...............: " ${JAVA_JVM_LIBRARY} "
   Python executable..........: " ${PYTHON_EXECUTABLE} "
+  Threads flag..............:: " ${CMAKE_THREAD_LIBS_INIT} "
   ")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,7 +147,7 @@ if (WIN32)
   set_tests_properties(${TESTNG_TEST} PROPERTIES ENVIRONMENT "CLASSPATH=${CLASSPATH}")
 else()
   set(JAVA_CP ${CMAKE_JAVA_INCLUDE_PATH}:${LONGDOGJAR}:${LONGDOGTESTJAR})
-  set(JAVA_TESTNG_ARGS -Xcheck:jni -verbose -cp ${JAVA_CP} org.testng.TestNG -testjar jars/${LONGDOG}-tests.jar)
+  set(JAVA_TESTNG_ARGS -Xcheck:jni -XX:+RestoreMXCSROnJNICalls -verbose -cp ${JAVA_CP} org.testng.TestNG -testjar jars/${LONGDOG}-tests.jar)
   add_test(${TESTNG_TEST} ${Java_JAVA_EXECUTABLE} ${JAVA_TESTNG_ARGS})
   set(JACOCOJAR $ENV{JACOCOJAR})
   add_custom_target(jacocorun

--- a/include/dispatch.hh
+++ b/include/dispatch.hh
@@ -4,29 +4,75 @@
  * Please see distribution for license.
  */
 
-/**
- * Holds references to data needed to construct a terminal type
- */
-
-#include "numerictypes.hh"
+#ifndef _DISPATCH_HH
+#define _DISPATCH_HH
+#include "visitor.hh"
+#include "warningmacros.h"
 
 namespace librdag {
-class OGTerminal;
+  class OGNumeric;
+  class OGTerminal;
 }
 
 namespace convert {
 
-template <typename T> struct OGTerminalPtrContainer_t
+using namespace librdag;  
+  
+class DispatchToReal16ArrayOfArrays: public librdag::Visitor
 {
-  T** data;
-  int rows;
-  int cols;
-  int * colPtr;
-  int * rowIdx;
+  public:
+    virtual ~DispatchToReal16ArrayOfArrays();
+    virtual void visit(librdag::OGExpr const SUPPRESS_UNUSED *thing);
+    virtual void visit(librdag::OGScalar<real16> const *thing);
+    virtual void visit(librdag::OGScalar<complex16> const SUPPRESS_UNUSED *thing);
+    virtual void visit(librdag::OGScalar<int> const SUPPRESS_UNUSED *thing);
+    virtual void visit(librdag::OGMatrix<real16> const *thing);
+    virtual void visit(librdag::OGMatrix<complex16> const SUPPRESS_UNUSED *thing);
+    virtual void visit(librdag::OGDiagonalMatrix<real16> const *thing);
+    virtual void visit(librdag::OGDiagonalMatrix<complex16> const SUPPRESS_UNUSED *thing);
+    virtual void visit(librdag::OGSparseMatrix<real16> const *thing);
+    virtual void visit(librdag::OGSparseMatrix<complex16> const SUPPRESS_UNUSED *thing);
+    void setData(real16 ** data);
+    void setRows(int rows);
+    void setCols(int cols);
+    real16 ** getData();
+    int getRows();
+    int getCols();
+  private:
+    real16 ** _data = nullptr;
+    int rows;
+    int cols;
+    
 };
 
-OGTerminalPtrContainer_t<real16>* dispatchToReal16ArrayOfArrays(const librdag::OGTerminal* terminal);
-OGTerminalPtrContainer_t<complex16>* dispatchToComplex16ArrayOfArrays(const librdag::OGTerminal* terminal);
 
 
+class DispatchToComplex16ArrayOfArrays: public librdag::Visitor
+{
+  public:
+    virtual ~DispatchToComplex16ArrayOfArrays();
+    virtual void visit(librdag::OGExpr const SUPPRESS_UNUSED *thing);
+    virtual void visit(librdag::OGScalar<real16> const *thing);
+    virtual void visit(librdag::OGScalar<complex16> const SUPPRESS_UNUSED *thing);
+    virtual void visit(librdag::OGScalar<int> const SUPPRESS_UNUSED *thing);
+    virtual void visit(librdag::OGMatrix<real16> const *thing);
+    virtual void visit(librdag::OGMatrix<complex16> const SUPPRESS_UNUSED *thing);
+    virtual void visit(librdag::OGDiagonalMatrix<real16> const *thing);
+    virtual void visit(librdag::OGDiagonalMatrix<complex16> const SUPPRESS_UNUSED *thing);
+    virtual void visit(librdag::OGSparseMatrix<real16> const *thing);
+    virtual void visit(librdag::OGSparseMatrix<complex16> const SUPPRESS_UNUSED *thing);
+    void setData(complex16 ** data);
+    void setRows(int rows);
+    void setCols(int cols);
+    complex16 ** getData();
+    int getRows();
+    int getCols();
+  private:
+    complex16 ** _data = nullptr;
+    int rows;
+    int cols;    
+};
+  
 } // namespace convert
+
+#endif // _DISPATCH_HH

--- a/include/entrypt.hh
+++ b/include/entrypt.hh
@@ -6,6 +6,7 @@
 
 #ifndef _ENTRYPT_H
 #define _ENTRYPT_H
+#include "terminal.hh"
 
 namespace librdag {
 

--- a/src/java/src/test/java/com/opengamma/longdog/materialisers/TestThreadedOGRealScalarMaterialise.java
+++ b/src/java/src/test/java/com/opengamma/longdog/materialisers/TestThreadedOGRealScalarMaterialise.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2013 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+package com.opengamma.longdog.materialisers;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.opengamma.longdog.datacontainers.scalar.OGRealScalar;
+import com.opengamma.longdog.exceptions.MathsException;
+import com.opengamma.longdog.testhelpers.ArraysHelpers;
+
+import java.lang.Runnable;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.Random;
+
+public class TestThreadedOGRealScalarMaterialise {
+
+  private final int NTASKS = 128;
+
+  private static class Zergling implements Runnable {
+
+    private static final int NITERATIONS = 512;
+
+    @Override
+    public void run() {
+      double v = new Random().nextDouble();
+      double[][] vaa = new double[][] {{v}};
+      OGRealScalar input = new OGRealScalar(v);
+      for (int i = 0; i < NITERATIONS; i++) {
+        double[][] answer = Materialisers.toDoubleArrayOfArrays(input);
+        if (!ArraysHelpers.ArraysEquals(answer, vaa)) {
+          throw new MathsException("Output not equal to input, got: " + answer[0][0] + ", expected: " + v);
+        }
+      }
+    }
+  }
+
+  @Test
+  public void materialiseToJDoubleArray() throws Exception {
+    ScheduledThreadPoolExecutor stpe = new ScheduledThreadPoolExecutor(NTASKS);
+    Future<?> futures[] = new Future[NTASKS];
+    for (int i = 0; i < NTASKS; i++) {
+      futures[i] = stpe.submit(new Zergling());
+    }
+    for (int i = 0; i < NTASKS; i++) {
+      futures[i].get();
+    }
+  }
+}

--- a/src/java/src/test/java/com/opengamma/longdog/materialisers/TestThreadedOGRealScalarMaterialise.java
+++ b/src/java/src/test/java/com/opengamma/longdog/materialisers/TestThreadedOGRealScalarMaterialise.java
@@ -6,17 +6,15 @@
 
 package com.opengamma.longdog.materialisers;
 
-import org.testng.annotations.DataProvider;
+import java.util.Random;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+
 import org.testng.annotations.Test;
 
 import com.opengamma.longdog.datacontainers.scalar.OGRealScalar;
 import com.opengamma.longdog.exceptions.MathsException;
 import com.opengamma.longdog.testhelpers.ArraysHelpers;
-
-import java.lang.Runnable;
-import java.util.concurrent.Future;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.Random;
 
 public class TestThreadedOGRealScalarMaterialise {
 

--- a/src/jshim/dispatch.cc
+++ b/src/jshim/dispatch.cc
@@ -10,225 +10,195 @@
 #include "terminal.hh"
 #include "expression.hh"
 
-namespace convert {
+namespace convert
+{
 
 using namespace librdag;
 
-class DispatchToReal16ArrayOfArrays: public librdag::Visitor
+DispatchToReal16ArrayOfArrays::~DispatchToReal16ArrayOfArrays()
 {
-  public:
-    virtual ~DispatchToReal16ArrayOfArrays() override
+    real16 ** arr = this->getData();
+    if(arr)
     {
-      real16 ** arr = this->getData();
-      if(arr)
-      {
 
         for(int i=0; i<this->getRows(); i++)
         {
-          delete arr[i];
+            delete arr[i];
         }
         delete arr;
-      }
     }
-    virtual void visit(librdag::OGExpr const SUPPRESS_UNUSED *thing) override
-    {
-      throw std::runtime_error("DispatchToReal16ArrayOfArrays::visit(librdag::OGExpr)");
-    };
-    virtual void visit(librdag::OGScalar<real16> const *thing) override
-    {
-      this->setData(thing->toReal16ArrayOfArrays());
-      this->setRows(1);
-      this->setCols(1);
-    }
-    virtual void visit(librdag::OGScalar<complex16> const SUPPRESS_UNUSED *thing) override
-    {
-      throw std::runtime_error("DispatchToReal16ArrayOfArrays::visit(librdag::OGScalar<complex16>)");
-    }
-    virtual void visit(librdag::OGScalar<int> const SUPPRESS_UNUSED *thing) override
-    {
-      throw std::runtime_error("DispatchToReal16ArrayOfArrays::visit(librdag::OGScalar<int>)");
-    }
-    virtual void visit(librdag::OGMatrix<real16> const *thing) override
-    {
-      this->setData(thing->toReal16ArrayOfArrays());
-      this->setRows(thing->getRows());
-      this->setCols(thing->getCols());
-    }
-    virtual void visit(librdag::OGMatrix<complex16> const SUPPRESS_UNUSED *thing) override
-    {
-      throw std::runtime_error("DispatchToReal16ArrayOfArrays::visit(librdag::OGMatrix<complex16>)");
-    }
-    virtual void visit(librdag::OGDiagonalMatrix<real16> const *thing) override
-    {
-      this->setData(thing->toReal16ArrayOfArrays());
-      this->setRows(thing->getRows());
-      this->setCols(thing->getCols());
-    }
-    virtual void visit(librdag::OGDiagonalMatrix<complex16> const SUPPRESS_UNUSED *thing) override
-    {
-      throw std::runtime_error("DispatchToReal16ArrayOfArrays::visit(librdag::OGMatrix<complex16>)");
-    }
-    virtual void visit(librdag::OGSparseMatrix<real16> const *thing) override
-    {
-      this->setData(thing->toReal16ArrayOfArrays());
-      this->setRows(thing->getRows());
-      this->setCols(thing->getCols());
-    }
-    virtual void visit(librdag::OGSparseMatrix<complex16> const SUPPRESS_UNUSED *thing) override
-    {
-      throw std::runtime_error("DispatchToReal16ArrayOfArrays::visit(librdag::OGMatrix<complex16>)");
-    }
-    void setData(real16 ** data)
-    {
-      this->_data = data;
-    }
-    void setRows(int rows)
-    {
-      this->rows = rows;
-    }
-    void setCols(int cols)
-    {
-      this->cols = cols;
-    }
-    real16 ** getData()
-    {
-      return this->_data;
-    }
-    int getRows()
-    {
-      return this->rows;
-    }
-    int getCols()
-    {
-      return this->cols;
-    }
-  private:
-    real16 ** _data = NULL;
-    int rows;
-    int cols;
-};
+}
 
-class DispatchToComplex16ArrayOfArrays: public librdag::Visitor
+void DispatchToReal16ArrayOfArrays::visit(librdag::OGExpr const SUPPRESS_UNUSED *thing)
 {
-  public:
-    virtual ~DispatchToComplex16ArrayOfArrays() override
+    throw std::runtime_error("DispatchToReal16ArrayOfArrays::visit(librdag::OGExpr)");
+}
+
+void DispatchToReal16ArrayOfArrays::visit(librdag::OGScalar<real16> const  *thing)
+{
+    this->setData(thing->toReal16ArrayOfArrays());
+    this->setRows(1);
+    this->setCols(1);
+}
+
+void DispatchToReal16ArrayOfArrays::visit(librdag::OGScalar<complex16> const SUPPRESS_UNUSED  *thing)
+{
+    throw std::runtime_error("DispatchToReal16ArrayOfArrays::visit(librdag::OGScalar<complex16>)");
+}
+void DispatchToReal16ArrayOfArrays::visit(librdag::OGScalar<int> const SUPPRESS_UNUSED  *thing)
+{
+    throw std::runtime_error("DispatchToReal16ArrayOfArrays::visit(librdag::OGScalar<int>)");
+}
+
+void DispatchToReal16ArrayOfArrays::visit(librdag::OGMatrix<real16> const *thing)
+{
+    this->setData(thing->toReal16ArrayOfArrays());
+    this->setRows(thing->getRows());
+    this->setCols(thing->getCols());
+}
+
+void DispatchToReal16ArrayOfArrays::visit(librdag::OGMatrix<complex16> const SUPPRESS_UNUSED *thing)
+{
+    throw std::runtime_error("DispatchToReal16ArrayOfArrays::visit(librdag::OGMatrix<complex16>)");
+}
+void DispatchToReal16ArrayOfArrays::visit(librdag::OGDiagonalMatrix<real16> const *thing)
+{
+    this->setData(thing->toReal16ArrayOfArrays());
+    this->setRows(thing->getRows());
+    this->setCols(thing->getCols());
+}
+void DispatchToReal16ArrayOfArrays::visit(librdag::OGDiagonalMatrix<complex16> const SUPPRESS_UNUSED  *thing)
+{
+    throw std::runtime_error("DispatchToReal16ArrayOfArrays::visit(librdag::OGDiagonalMatrix<complex16>)");
+}
+
+void DispatchToReal16ArrayOfArrays::visit(librdag::OGSparseMatrix<real16> const *thing)
+{
+    this->setData(thing->toReal16ArrayOfArrays());
+    this->setRows(thing->getRows());
+    this->setCols(thing->getCols());
+}
+void DispatchToReal16ArrayOfArrays::visit(librdag::OGSparseMatrix<complex16> const SUPPRESS_UNUSED  *thing)
+{
+    throw std::runtime_error("DispatchToReal16ArrayOfArrays::visit(librdag::OGSparseMatrix<complex16>)");
+}
+
+void DispatchToReal16ArrayOfArrays::setData(real16 ** data)
+{
+    this->_data = data;
+}
+
+void DispatchToReal16ArrayOfArrays::setRows(int rows)
+{
+    this->rows = rows;
+}
+
+void DispatchToReal16ArrayOfArrays::setCols(int cols)
+{
+    this->cols = cols;
+}
+
+real16 ** DispatchToReal16ArrayOfArrays::getData()
+{
+    return this->_data;
+}
+
+int DispatchToReal16ArrayOfArrays::getRows()
+{
+    return this->rows;
+}
+
+int DispatchToReal16ArrayOfArrays::getCols()
+{
+    return this->cols;
+}
+
+DispatchToComplex16ArrayOfArrays::~DispatchToComplex16ArrayOfArrays()
+{
+    complex16 ** arr = this->getData();
+    if(arr)
     {
-      complex16 ** arr = this->getData();
-      if(arr)
-      {
 
         for(int i=0; i<this->getRows(); i++)
         {
-          delete arr[i];
+            delete arr[i];
         }
         delete arr;
-      }
     }
-    virtual void visit(librdag::OGExpr const SUPPRESS_UNUSED *thing) override
-    {
-      throw std::runtime_error("DispatchToReal16ArrayOfArrays::visit(librdag::OGExpr)");
-    };
-    virtual void visit(librdag::OGScalar<complex16> const *thing) override
-    {
-      this->setData(thing->toComplex16ArrayOfArrays());
-      this->setRows(1);
-      this->setCols(1);
-    }
-    virtual void visit(librdag::OGScalar<real16> const SUPPRESS_UNUSED *thing) override
-    {
-      throw std::runtime_error("DispatchToReal16ArrayOfArrays::visit(librdag::OGScalar<real16>)");
-    }
-    virtual void visit(librdag::OGScalar<int> const SUPPRESS_UNUSED *thing) override
-    {
-      throw std::runtime_error("DispatchToReal16ArrayOfArrays::visit(librdag::OGScalar<int>)");
-    }
-    virtual void visit(librdag::OGMatrix<complex16> const *thing) override
-    {
-      printf("Visitor: librdag::OGMatrix<complex16> branch\n");
-      this->setData(thing->toComplex16ArrayOfArrays());
-      this->setRows(thing->getRows());
-      this->setCols(thing->getCols());
-    }
-    virtual void visit(librdag::OGMatrix<real16> const SUPPRESS_UNUSED *thing) override
-    {
-      throw std::runtime_error("DispatchToReal16ArrayOfArrays::visit(librdag::OGMatrix<real16>)");
-    }
-    virtual void visit(librdag::OGDiagonalMatrix<complex16> const *thing) override
-    {
-      printf("Visitor: librdag::OGMatrix<complex16> branch\n");
-      this->setData(thing->toComplex16ArrayOfArrays());
-      this->setRows(thing->getRows());
-      this->setCols(thing->getCols());
-    }
-    virtual void visit(librdag::OGDiagonalMatrix<real16> const SUPPRESS_UNUSED *thing) override
-    {
-      throw std::runtime_error("DispatchToReal16ArrayOfArrays::visit(librdag::OGMatrix<real16>)");
-    }
-    virtual void visit(librdag::OGSparseMatrix<complex16> const *thing) override
-    {
-      printf("Visitor: librdag::OGMatrix<complex16> branch\n");
-      this->setData(thing->toComplex16ArrayOfArrays());
-      this->setRows(thing->getRows());
-      this->setCols(thing->getCols());
-    }
-    virtual void visit(librdag::OGSparseMatrix<real16> const SUPPRESS_UNUSED *thing) override
-    {
-      throw std::runtime_error("DispatchToReal16ArrayOfArrays::visit(librdag::OGMatrix<real16>)");
-    }
-    void setData(complex16 ** data)
-    {
-      this->_data = data;
-    }
-    void setRows(int rows)
-    {
-      this->rows = rows;
-    }
-    void setCols(int cols)
-    {
-      this->cols = cols;
-    }
-    complex16 ** getData()
-    {
-      return this->_data;
-    }
-    int getRows()
-    {
-      return this->rows;
-    }
-    int getCols()
-    {
-      return this->cols;
-    }
-  private:
-    complex16 ** _data = NULL;
-    int rows;
-    int cols;
-};
-
-OGTerminalPtrContainer_t<real16>* dispatchToReal16ArrayOfArrays(const librdag::OGTerminal* terminal)
-{
-  DispatchToReal16ArrayOfArrays *visitor = new DispatchToReal16ArrayOfArrays();
-  terminal->accept(*visitor);
-  OGTerminalPtrContainer_t<real16>* result = new OGTerminalPtrContainer_t<real16>();
-  result->data = visitor->getData();
-  result->rows = visitor->getRows();
-  result->cols = visitor->getCols();
-  result->colPtr = nullptr;
-  result->rowIdx = nullptr;
-  return result;
 }
-
-OGTerminalPtrContainer_t<complex16>* dispatchToComplex16ArrayOfArrays(const librdag::OGTerminal* terminal)
+void DispatchToComplex16ArrayOfArrays::visit(librdag::OGExpr const SUPPRESS_UNUSED *thing)
 {
-  DispatchToComplex16ArrayOfArrays *visitor = new DispatchToComplex16ArrayOfArrays();
-  terminal->accept(*visitor);
-  OGTerminalPtrContainer_t<complex16>* result = new OGTerminalPtrContainer_t<complex16>();
-  result->data = visitor->getData();
-  result->rows = visitor->getRows();
-  result->cols = visitor->getCols();
-  result->colPtr = nullptr;
-  result->rowIdx = nullptr;
-  return result;
+    throw std::runtime_error("DispatchToComplex16ArrayOfArrays::visit(librdag::OGExpr)");
 }
-
+void DispatchToComplex16ArrayOfArrays::visit(librdag::OGScalar<complex16> const *thing)
+{
+    this->setData(thing->toComplex16ArrayOfArrays());
+    this->setRows(1);
+    this->setCols(1);
+}
+void DispatchToComplex16ArrayOfArrays::visit(librdag::OGScalar<real16> const SUPPRESS_UNUSED  *thing)
+{
+    throw std::runtime_error("DispatchToComplex16ArrayOfArrays::visit(librdag::OGScalar<real16>)");
+}
+void DispatchToComplex16ArrayOfArrays::visit(librdag::OGScalar<int> const SUPPRESS_UNUSED *thing)
+{
+    throw std::runtime_error("DispatchToComplex16ArrayOfArrays::visit(librdag::OGScalar<int>)");
+}
+void DispatchToComplex16ArrayOfArrays::visit(librdag::OGMatrix<complex16> const *thing)
+{
+    printf("Visitor: librdag::OGMatrix<complex16> branch\n");
+    this->setData(thing->toComplex16ArrayOfArrays());
+    this->setRows(thing->getRows());
+    this->setCols(thing->getCols());
+}
+void DispatchToComplex16ArrayOfArrays::visit(librdag::OGMatrix<real16> const SUPPRESS_UNUSED *thing)
+{
+    throw std::runtime_error("DispatchToComplex16ArrayOfArrays::visit(librdag::OGMatrix<real16>)");
+}
+void DispatchToComplex16ArrayOfArrays::visit(librdag::OGDiagonalMatrix<complex16> const *thing)
+{
+    printf("Visitor: librdag::OGMatrix<complex16> branch\n");
+    this->setData(thing->toComplex16ArrayOfArrays());
+    this->setRows(thing->getRows());
+    this->setCols(thing->getCols());
+}
+void DispatchToComplex16ArrayOfArrays::visit(librdag::OGDiagonalMatrix<real16> const SUPPRESS_UNUSED *thing)
+{
+    throw std::runtime_error("DispatchToComplex16ArrayOfArrays::visit(librdag::OGDiagonalMatrix<real16>)");
+}
+void DispatchToComplex16ArrayOfArrays::visit(librdag::OGSparseMatrix<complex16> const *thing)
+{
+    printf("Visitor: librdag::OGMatrix<complex16> branch\n");
+    this->setData(thing->toComplex16ArrayOfArrays());
+    this->setRows(thing->getRows());
+    this->setCols(thing->getCols());
+}
+void DispatchToComplex16ArrayOfArrays::visit(librdag::OGSparseMatrix<real16> const SUPPRESS_UNUSED *thing)
+{
+    throw std::runtime_error("DispatchToComplex16ArrayOfArrays::visit(librdag::OGSparseMatrix<real16>)");
+}
+void DispatchToComplex16ArrayOfArrays::setData(complex16 ** data)
+{
+    this->_data = data;
+}
+void DispatchToComplex16ArrayOfArrays::setRows(int rows)
+{
+    this->rows = rows;
+}
+void DispatchToComplex16ArrayOfArrays::setCols(int cols)
+{
+    this->cols = cols;
+}
+complex16 ** DispatchToComplex16ArrayOfArrays::getData()
+{
+    return this->_data;
+}
+int DispatchToComplex16ArrayOfArrays::getRows()
+{
+    return this->rows;
+}
+int DispatchToComplex16ArrayOfArrays::getCols()
+{
+    return this->cols;
+}
 } // namespace convert


### PR DESCRIPTION
This PR is a joint effort, it:
- Adds in native thread library support.
- Enables reentrant core C libraries.
- Refactors the dispatch code by removing the `OGTerminalPtrContainer_t` buffers, the visitor contains the state and pointers already, the original code was a result of legacy decisions.
- Fixes a couple of blatant leaks arising from the non-deletion of `OGTerminalPtrContainer_t`.
- Addresses [MAT-254] by replacing the -ffast-math flag with a safer set of optimisations that don't mangle the MXCSR register to which the JVM objects.

BB PASS: [http://devmaths-lx-1:8011/builders/nyqwk2-testing/builds/299](http://devmaths-lx-1:8011/builders/nyqwk2-testing/builds/299)
