### PR TITLE
Add sparse materialisers

### DIFF
--- a/include/fake_jni.h
+++ b/include/fake_jni.h
@@ -137,6 +137,10 @@ class JNIEnv_
     {
       
     }
+    virtual void SetIntArrayRegion(jintArray SUPPRESS_UNUSED array, jsize SUPPRESS_UNUSED start, jsize SUPPRESS_UNUSED len, const jint SUPPRESS_UNUSED *buf)
+    {
+
+    }
     virtual void SetObjectArrayElement(jobjectArray SUPPRESS_UNUSED array, SUPPRESS_UNUSED jsize index, SUPPRESS_UNUSED jobject val)
     {
       
@@ -188,6 +192,10 @@ class JNIEnv_
       return nullptr;
     }
     virtual jdoubleArray NewDoubleArray(jsize SUPPRESS_UNUSED len)
+    {
+      return nullptr;
+    }
+    virtual jintArray NewIntArray(jsize SUPPRESS_UNUSED len)
     {
       return nullptr;
     }

--- a/include/jvmmanager.hh
+++ b/include/jvmmanager.hh
@@ -21,6 +21,11 @@
 namespace convert {
 
 /*
+ * Check for exception
+ */
+void checkEx(JNIEnv* env);
+
+/*
  * Caches static classes methods, fields and the JVM pointer.
  * The JVM Manager gets initialized when JNI_OnLoad() is called.
  */
@@ -44,12 +49,16 @@ class JVMManager {
     DLLEXPORT_C static jclass getOGComplexDenseMatrixClazz();
     DLLEXPORT_C static jclass getOGRealDiagonalMatrixClazz();
     DLLEXPORT_C static jclass getOGComplexDiagonalMatrixClazz();
+    DLLEXPORT_C static jclass getOGRealSparseMatrixClazz();
+    DLLEXPORT_C static jclass getOGComplexSparseMatrixClazz();
     DLLEXPORT_C static jmethodID getOGRealScalarClazz_init();
     DLLEXPORT_C static jmethodID getOGComplexScalarClazz_init();
     DLLEXPORT_C static jmethodID getOGRealDenseMatrixClazz_init();
     DLLEXPORT_C static jmethodID getOGComplexDenseMatrixClazz_init();
     DLLEXPORT_C static jmethodID getOGRealDiagonalMatrixClazz_init();
     DLLEXPORT_C static jmethodID getOGComplexDiagonalMatrixClazz_init();
+    DLLEXPORT_C static jmethodID getOGRealSparseMatrixClazz_init();
+    DLLEXPORT_C static jmethodID getOGComplexSparseMatrixClazz_init();
     DLLEXPORT_C static jmethodID getOGTerminalClazz_getData();
     DLLEXPORT_C static jmethodID getOGNumericClazz_getType();
     DLLEXPORT_C static jmethodID getOGExprClazz_getExprs();
@@ -62,6 +71,7 @@ class JVMManager {
     DLLEXPORT_C static jfieldID  getOGExprTypeEnumClazz__hashdefined();
     // Wrappers for JNIEnv and JavaVM methods
     DLLEXPORT_C static jobjectArray newObjectArray(JNIEnv *env, jsize len, jclass clazz, jobject init);
+    DLLEXPORT_C static jintArray newIntArray(JNIEnv *env, jsize len);
     DLLEXPORT_C static jdoubleArray newDoubleArray(JNIEnv *env, jsize len);
     DLLEXPORT_C static jobject newDouble(JNIEnv* env, jdouble v);
     DLLEXPORT_C static void getEnv(void **penv);
@@ -90,6 +100,8 @@ class JVMManager {
     static jclass _OGComplexDenseMatrixClazz;
     static jclass _OGRealDiagonalMatrixClazz;
     static jclass _OGComplexDiagonalMatrixClazz;
+    static jclass _OGRealSparseMatrixClazz;
+    static jclass _OGComplexSparseMatrixClazz;
     static jmethodID _DoubleClazz_init;
     static jmethodID _OGRealScalarClazz_init;
     static jmethodID _OGComplexScalarClazz_init;
@@ -97,6 +109,8 @@ class JVMManager {
     static jmethodID _OGComplexDenseMatrixClazz_init;
     static jmethodID _OGRealDiagonalMatrixClazz_init;
     static jmethodID _OGComplexDiagonalMatrixClazz_init;
+    static jmethodID _OGRealSparseMatrixClazz_init;
+    static jmethodID _OGComplexSparseMatrixClazz_init;
     static jmethodID _OGTerminalClazz_getData;
     static jmethodID _OGNumericClazz_getType;
     static jmethodID _OGExprClazz_getExprs;

--- a/include/terminal.hh
+++ b/include/terminal.hh
@@ -80,7 +80,8 @@ class OGIntegerScalar: public OGScalar<int>
 template <typename T> class OGArray: public OGTerminal
 {
   public:
-    T * getData() const;
+    T * getData() const; // Returns a pointer to the underlying data
+    T * toArray() const; // Returns a pointer to a copy of the underlying data
     int getRows() const;
     int getCols() const;
     int getDatalen() const;
@@ -149,7 +150,6 @@ template <typename T> class OGDiagonalMatrix: public OGArray<T>
   public:
     OGDiagonalMatrix(T * data, int rows, int cols);
     virtual void accept(Visitor &v) const override;
-    T* toArray() const;
     T** toArrayOfArrays() const;
   protected:
     OGDiagonalMatrix(int rows, int cols);
@@ -210,6 +210,7 @@ class OGRealSparseMatrix: public OGSparseMatrix<real16>
   public:
     using OGSparseMatrix::OGSparseMatrix;
     virtual void debug_print() const override;
+    virtual real16* toReal16Array() const override;
     virtual real16** toReal16ArrayOfArrays() const override;
     virtual OGNumeric* copy() const override;
     virtual const OGRealSparseMatrix* asOGRealSparseMatrix() const override;
@@ -221,6 +222,7 @@ class OGComplexSparseMatrix: public OGSparseMatrix<complex16>
   public:
     using OGSparseMatrix::OGSparseMatrix;
     virtual void debug_print() const override;
+    virtual complex16* toComplex16Array() const override;
     virtual complex16** toComplex16ArrayOfArrays() const override;
     virtual OGNumeric* copy() const override;
     virtual const OGComplexSparseMatrix* asOGComplexSparseMatrix() const override;

--- a/src/java/src/test/java/com/opengamma/longdog/materialisers/TestOGComplexSparseMatrixMaterialise.java
+++ b/src/java/src/test/java/com/opengamma/longdog/materialisers/TestOGComplexSparseMatrixMaterialise.java
@@ -18,7 +18,7 @@ public class TestOGComplexSparseMatrixMaterialise {
 
   @DataProvider
   public Object[][] dataContainer() {
-    Object[][] obj = new Object[2][6];
+    Object[][] obj = new Object[3][6];
 
     obj[0][0] = new int[] {0, 1};
     obj[0][1] = new int[] {0};
@@ -34,12 +34,19 @@ public class TestOGComplexSparseMatrixMaterialise {
     obj[1][4] = 2;
     obj[1][5] = 2;
 
+    obj[2][0] = new int[] {0, 3, 6, 10, 12, 12};
+    obj[2][1] = new int[] {0, 1, 2, 0, 1, 2, 0, 1, 2, 3, 2, 3};
+    obj[2][2] = new double[] { 1.0, 5.0,  0.0,  2.0,  0.0,  10.0,  0.0,  7.0, 11.0, 15.0,   0.0,   0.0};
+    obj[2][3] = new double[] {10.0, 0.0, 90.0, 20.0, 60.0, 100.0, 30.0, 70.0,  0.0,  0.0, 120.0, 160.0};
+    obj[2][4] = 4;
+    obj[2][5] = 5;
+
     return obj;
   };
 
   @Test(dataProvider = "dataContainer")
-  public void materialiseToOGTerminal(int[] colIdx, int[] rowPtr, double[] realpart, double[] imagpart, int rows, int cols) {
-    OGComplexSparseMatrix tmp = new OGComplexSparseMatrix(colIdx, rowPtr, realpart, imagpart, rows, cols);
+  public void materialiseToOGTerminal(int[] colPtr, int[] rowIdx, double[] realpart, double[] imagpart, int rows, int cols) {
+    OGComplexSparseMatrix tmp = new OGComplexSparseMatrix(colPtr, rowIdx, realpart, imagpart, rows, cols);
     OGComplexSparseMatrix answer = (OGComplexSparseMatrix) Materialisers.toOGTerminal(tmp);
     if (!Arrays.equals(tmp.getData(), answer.getData())) {
       throw new MathsException("Arrays are not equal");

--- a/src/java/src/test/java/com/opengamma/longdog/materialisers/TestOGComplexSparseMatrixMaterialise.java
+++ b/src/java/src/test/java/com/opengamma/longdog/materialisers/TestOGComplexSparseMatrixMaterialise.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (C) 2013 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+package com.opengamma.longdog.materialisers;
+
+import java.util.Arrays;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.opengamma.longdog.datacontainers.matrix.OGComplexSparseMatrix;
+import com.opengamma.longdog.exceptions.MathsException;
+
+public class TestOGComplexSparseMatrixMaterialise {
+
+  @DataProvider
+  public Object[][] dataContainer() {
+    Object[][] obj = new Object[2][6];
+
+    obj[0][0] = new int[] {0, 1};
+    obj[0][1] = new int[] {0};
+    obj[0][2] = new double[] {5.0};
+    obj[0][3] = new double[] {50.0};
+    obj[0][4] = 1;
+    obj[0][5] = 1;
+
+    obj[1][0] = new int[] {0, 2, 2};
+    obj[1][1] = new int[] {0, 1};
+    obj[1][2] = new double[] {1.0, 2.0};
+    obj[1][3] = new double[] {10.0, 20.0};
+    obj[1][4] = 2;
+    obj[1][5] = 2;
+
+    return obj;
+  };
+
+  @Test(dataProvider = "dataContainer")
+  public void materialiseToOGTerminal(int[] colIdx, int[] rowPtr, double[] realpart, double[] imagpart, int rows, int cols) {
+    OGComplexSparseMatrix tmp = new OGComplexSparseMatrix(colIdx, rowPtr, realpart, imagpart, rows, cols);
+    OGComplexSparseMatrix answer = (OGComplexSparseMatrix) Materialisers.toOGTerminal(tmp);
+    if (!Arrays.equals(tmp.getData(), answer.getData())) {
+      throw new MathsException("Arrays are not equal");
+    }
+    if (tmp.getRows() != answer.getRows()) {
+      throw new MathsException("Rows are not equal");
+    }
+    if (tmp.getCols() != answer.getCols()) {
+      throw new MathsException("Cols are not equal");
+    }
+  }
+
+}

--- a/src/java/src/test/java/com/opengamma/longdog/materialisers/TestOGRealSparseMatrixMaterialise.java
+++ b/src/java/src/test/java/com/opengamma/longdog/materialisers/TestOGRealSparseMatrixMaterialise.java
@@ -18,7 +18,7 @@ public class TestOGRealSparseMatrixMaterialise {
 
   @DataProvider
   public Object[][] dataContainer() {
-    Object[][] obj = new Object[2][5];
+    Object[][] obj = new Object[3][5];
 
     obj[0][0] = new int[] {0, 1};
     obj[0][1] = new int[] {0};
@@ -32,12 +32,18 @@ public class TestOGRealSparseMatrixMaterialise {
     obj[1][3] = 2;
     obj[1][4] = 2;
 
+    obj[2][0] = new int[] {0, 3, 6, 10, 12, 12};
+    obj[2][1] = new int[] {0, 1, 2, 0, 1, 2, 0, 1, 2, 3, 2, 3};
+    obj[2][2] = new double[] { 1.0, 5.0, 90.0, 2.0, 60.0, 10.0, 30.0, 7.0, 11.0, 15.0, 120.0, 160.0};
+    obj[2][3] = 4;
+    obj[2][4] = 5;
+
     return obj;
   };
 
   @Test(dataProvider = "dataContainer")
-  public void materialiseToOGTerminal(int[] colIdx, int[] rowPtr, double[] values, int rows, int cols) {
-    OGRealSparseMatrix tmp = new OGRealSparseMatrix(colIdx, rowPtr, values, rows, cols);
+  public void materialiseToOGTerminal(int[] colPtr, int[] rowIdx, double[] values, int rows, int cols) {
+    OGRealSparseMatrix tmp = new OGRealSparseMatrix(colPtr, rowIdx, values, rows, cols);
     OGRealSparseMatrix answer = (OGRealSparseMatrix) Materialisers.toOGTerminal(tmp);
     if (!Arrays.equals(tmp.getData(), answer.getData())) {
       throw new MathsException("Arrays are not equal");

--- a/src/java/src/test/java/com/opengamma/longdog/materialisers/TestOGRealSparseMatrixMaterialise.java
+++ b/src/java/src/test/java/com/opengamma/longdog/materialisers/TestOGRealSparseMatrixMaterialise.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2013 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+package com.opengamma.longdog.materialisers;
+
+import java.util.Arrays;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.opengamma.longdog.datacontainers.matrix.OGRealSparseMatrix;
+import com.opengamma.longdog.exceptions.MathsException;
+
+public class TestOGRealSparseMatrixMaterialise {
+
+  @DataProvider
+  public Object[][] dataContainer() {
+    Object[][] obj = new Object[2][5];
+
+    obj[0][0] = new int[] {0, 1};
+    obj[0][1] = new int[] {0};
+    obj[0][2] = new double[] {5.0};
+    obj[0][3] = 1;
+    obj[0][4] = 1;
+
+    obj[1][0] = new int[] {0, 2, 2};
+    obj[1][1] = new int[] {0, 1};
+    obj[1][2] = new double[] {1.0, 2.0};
+    obj[1][3] = 2;
+    obj[1][4] = 2;
+
+    return obj;
+  };
+
+  @Test(dataProvider = "dataContainer")
+  public void materialiseToOGTerminal(int[] colIdx, int[] rowPtr, double[] values, int rows, int cols) {
+    OGRealSparseMatrix tmp = new OGRealSparseMatrix(colIdx, rowPtr, values, rows, cols);
+    OGRealSparseMatrix answer = (OGRealSparseMatrix) Materialisers.toOGTerminal(tmp);
+    if (!Arrays.equals(tmp.getData(), answer.getData())) {
+      throw new MathsException("Arrays are not equal");
+    }
+    if (tmp.getRows() != answer.getRows()) {
+      throw new MathsException("Rows are not equal");
+    }
+    if (tmp.getCols() != answer.getCols()) {
+      throw new MathsException("Cols are not equal");
+    }
+  }
+
+}

--- a/src/jshim/jdispatch.cc
+++ b/src/jshim/jdispatch.cc
@@ -401,18 +401,32 @@ DispatchToOGTerminal::visit(librdag::OGDiagonalMatrix<complex16> const *thing)
   setObject(newobject);
 }
 
+jint* makeCJintArray(const int* arr, int len)
+{
+  jint* jintArr = new jint[len];
+  for (int i = 0; i < len; ++i)
+  {
+    jintArr[i] = arr[i];
+  }
+  return jintArr;
+}
+
 void
 DispatchToOGTerminal::visit(librdag::OGSparseMatrix<real16> const *thing)
 {
   // Column pointer
   int colPtrLen = thing->getRows() + 1;
   jintArray jColPtr = JVMManager::newIntArray(_env, colPtrLen);
-  _env->SetIntArrayRegion(jColPtr, 0, colPtrLen, thing->getColPtr());
+  jint* colPtr = makeCJintArray(thing->getColPtr(), colPtrLen);
+  _env->SetIntArrayRegion(jColPtr, 0, colPtrLen, colPtr);
+  delete[] colPtr;
 
   // Row index
   int datalen = thing->getDatalen();
   jintArray jRowIdx = JVMManager::newIntArray(_env, datalen);
-  _env->SetIntArrayRegion(jRowIdx, 0, datalen, thing->getRowIdx());
+  jint* rowIdx = makeCJintArray(thing->getRowIdx(), datalen);
+  _env->SetIntArrayRegion(jRowIdx, 0, datalen, rowIdx);
+  delete[] rowIdx;
 
   // Values
   jdoubleArray values = convertCreal16Arr2JDoubleArr(_env, thing->toReal16Array(), datalen);
@@ -432,12 +446,16 @@ DispatchToOGTerminal::visit(librdag::OGSparseMatrix<complex16> const *thing)
   // Column pointer
   int colPtrLen = thing->getRows() + 1;
   jintArray jColPtr = JVMManager::newIntArray(_env, colPtrLen);
-  _env->SetIntArrayRegion(jColPtr, 0, colPtrLen, thing->getColPtr());
+  jint* colPtr = makeCJintArray(thing->getColPtr(), colPtrLen);
+  _env->SetIntArrayRegion(jColPtr, 0, colPtrLen, colPtr);
+  delete[] colPtr;
 
   // Row index
   int datalen = thing->getDatalen();
   jintArray jRowIdx = JVMManager::newIntArray(_env, datalen);
-  _env->SetIntArrayRegion(jRowIdx, 0, datalen, thing->getRowIdx());
+  jint* rowIdx = makeCJintArray(thing->getRowIdx(), datalen);
+  _env->SetIntArrayRegion(jRowIdx, 0, datalen, rowIdx);
+  delete[] rowIdx;
 
   // Values
   complex16* values = thing->toComplex16Array();

--- a/src/jshim/jdispatch.cc
+++ b/src/jshim/jdispatch.cc
@@ -415,7 +415,7 @@ void
 DispatchToOGTerminal::visit(librdag::OGSparseMatrix<real16> const *thing)
 {
   // Column pointer
-  int colPtrLen = thing->getRows() + 1;
+  int colPtrLen = thing->getCols() + 1;
   jintArray jColPtr = JVMManager::newIntArray(_env, colPtrLen);
   jint* colPtr = makeCJintArray(thing->getColPtr(), colPtrLen);
   _env->SetIntArrayRegion(jColPtr, 0, colPtrLen, colPtr);
@@ -444,7 +444,7 @@ void
 DispatchToOGTerminal::visit(librdag::OGSparseMatrix<complex16> const *thing)
 {
   // Column pointer
-  int colPtrLen = thing->getRows() + 1;
+  int colPtrLen = thing->getCols() + 1;
   jintArray jColPtr = JVMManager::newIntArray(_env, colPtrLen);
   jint* colPtr = makeCJintArray(thing->getColPtr(), colPtrLen);
   _env->SetIntArrayRegion(jColPtr, 0, colPtrLen, colPtr);

--- a/src/jshim/jshim.cc
+++ b/src/jshim/jshim.cc
@@ -18,21 +18,6 @@
 
 using namespace convert;
 
-/*
- * Check for exception
- */
-void checkEx(JNIEnv* env)
-{
-
-  jthrowable e = env->ExceptionOccurred();
-  if (e)
-  {
-    env->ExceptionDescribe();
-    throw convert_error("Java exception thrown in JNI.");
-  }
-}
-
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/jshim/jvmmanager.cc
+++ b/src/jshim/jvmmanager.cc
@@ -14,6 +14,19 @@
 
 namespace convert {
 
+/*
+ * Check for exception
+ */
+void checkEx(JNIEnv* env)
+{
+  jthrowable e = env->ExceptionOccurred();
+  if (e)
+  {
+    env->ExceptionDescribe();
+    throw convert_error("Java exception thrown in JNI.");
+  }
+}
+
 /**
  * JNI_OnLoad
  */
@@ -82,6 +95,8 @@ JVMManager::registerReferences()
   registerGlobalClassReference("com/opengamma/longdog/datacontainers/matrix/OGComplexDenseMatrix", &_OGComplexDenseMatrixClazz);
   registerGlobalClassReference("com/opengamma/longdog/datacontainers/matrix/OGRealDiagonalMatrix", &_OGRealDiagonalMatrixClazz);
   registerGlobalClassReference("com/opengamma/longdog/datacontainers/matrix/OGComplexDiagonalMatrix", &_OGComplexDiagonalMatrixClazz);
+  registerGlobalClassReference("com/opengamma/longdog/datacontainers/matrix/OGRealSparseMatrix", &_OGRealSparseMatrixClazz);
+  registerGlobalClassReference("com/opengamma/longdog/datacontainers/matrix/OGComplexSparseMatrix", &_OGComplexSparseMatrixClazz);
 
   //
   // REGISTER METHOD REFERENCES
@@ -103,6 +118,8 @@ JVMManager::registerReferences()
   registerGlobalMethodReference(&_OGComplexDenseMatrixClazz, &_OGComplexDenseMatrixClazz_init, "<init>", "([[D[[D)V");
   registerGlobalMethodReference(&_OGRealDiagonalMatrixClazz, &_OGRealDiagonalMatrixClazz_init, "<init>", "([DII)V");
   registerGlobalMethodReference(&_OGComplexDiagonalMatrixClazz, &_OGComplexDiagonalMatrixClazz_init, "<init>", "([D[DII)V");
+  registerGlobalMethodReference(&_OGRealSparseMatrixClazz, &_OGRealSparseMatrixClazz_init, "<init>", "([I[I[DII)V");
+  registerGlobalMethodReference(&_OGComplexSparseMatrixClazz, &_OGComplexSparseMatrixClazz_init, "<init>", "([I[I[D[DII)V");
 
   //
   // REGISTER FIELD REFERENCES
@@ -207,6 +224,10 @@ jclass JVMManager::getOGRealDiagonalMatrixClazz()
 { return _OGRealDiagonalMatrixClazz; }
 jclass JVMManager::getOGComplexDiagonalMatrixClazz()
 { return _OGComplexDiagonalMatrixClazz; }
+jclass JVMManager::getOGRealSparseMatrixClazz()
+{ return _OGRealSparseMatrixClazz; }
+jclass JVMManager::getOGComplexSparseMatrixClazz()
+{ return _OGComplexSparseMatrixClazz; }
 jclass JVMManager::getOGExprTypeEnumClazz()
 { return _OGExprTypeEnumClazz; }
 jmethodID JVMManager::getOGRealScalarClazz_init()
@@ -221,6 +242,10 @@ jmethodID JVMManager::getOGRealDiagonalMatrixClazz_init()
 { return _OGRealDiagonalMatrixClazz_init; }
 jmethodID JVMManager::getOGComplexDiagonalMatrixClazz_init()
 { return _OGComplexDiagonalMatrixClazz_init; }
+jmethodID JVMManager::getOGRealSparseMatrixClazz_init()
+{ return _OGRealSparseMatrixClazz_init; }
+jmethodID JVMManager::getOGComplexSparseMatrixClazz_init()
+{ return _OGComplexSparseMatrixClazz_init; }
 jmethodID JVMManager::getOGTerminalClazz_getData()
 { return _OGTerminalClazz_getData; }
 jmethodID JVMManager::getOGNumericClazz_getType()
@@ -263,6 +288,8 @@ jclass JVMManager::_OGRealDenseMatrixClazz = nullptr;
 jclass JVMManager::_OGComplexDenseMatrixClazz = nullptr;
 jclass JVMManager::_OGRealDiagonalMatrixClazz = nullptr;
 jclass JVMManager::_OGComplexDiagonalMatrixClazz = nullptr;
+jclass JVMManager::_OGRealSparseMatrixClazz = nullptr;
+jclass JVMManager::_OGComplexSparseMatrixClazz = nullptr;
 jmethodID JVMManager::_DoubleClazz_init = nullptr;
 jmethodID JVMManager::_OGRealScalarClazz_init = nullptr;
 jmethodID JVMManager::_OGComplexScalarClazz_init = nullptr;
@@ -270,6 +297,8 @@ jmethodID JVMManager::_OGRealDenseMatrixClazz_init = nullptr;
 jmethodID JVMManager::_OGComplexDenseMatrixClazz_init = nullptr;
 jmethodID JVMManager::_OGRealDiagonalMatrixClazz_init = nullptr;
 jmethodID JVMManager::_OGComplexDiagonalMatrixClazz_init = nullptr;
+jmethodID JVMManager::_OGRealSparseMatrixClazz_init = nullptr;
+jmethodID JVMManager::_OGComplexSparseMatrixClazz_init = nullptr;
 jmethodID JVMManager::_OGTerminalClazz_getData = nullptr;
 jmethodID JVMManager::_OGNumericClazz_getType = nullptr;
 jmethodID JVMManager::_OGExprClazz_getExprs = nullptr;
@@ -281,7 +310,6 @@ jmethodID JVMManager::_OGSparseMatrixClazz_getRowIdx = nullptr;
 jmethodID JVMManager::_ComplexArrayContainerClazz_ctor_DAoA_DAoA = nullptr;
 jfieldID  JVMManager::_OGExprTypeEnumClazz__hashdefined = nullptr;
 
-
 // Wrappers to JavaVM and JNIEnv methods
 
 
@@ -292,6 +320,17 @@ JVMManager::newObjectArray(JNIEnv *env, jsize len, jclass clazz, jobject init)
   if (!ret)
   {
     throw convert_error("NewObjectArray call failed.");
+  }
+  return ret;
+}
+
+jintArray
+JVMManager::newIntArray(JNIEnv *env, jsize len)
+{
+  jintArray ret = env->NewIntArray(len);
+  if (!ret)
+  {
+    throw convert_error("NewIntArray call failed.");
   }
   return ret;
 }

--- a/src/librdag/terminal.cc
+++ b/src/librdag/terminal.cc
@@ -197,6 +197,18 @@ OGArray<T>::getData() const
 }
 
 template<typename T>
+T*
+OGArray<T>::toArray() const
+{
+  T* tmp = new T[_datalen];
+  for (int i = 0; i < _datalen; i++)
+  {
+    tmp[i] = _data[i];
+  }
+  return tmp;
+}
+
+template<typename T>
 int
 OGArray<T>::getRows() const
 {
@@ -433,20 +445,6 @@ void
 OGDiagonalMatrix<T>::accept(Visitor &v) const
 {
   v.visit(this);
-}
-
-template<typename T>
-T*
-OGDiagonalMatrix<T>::toArray() const
-{
-  int datalen = this->getDatalen();
-  T* data = this->getData();
-  T* tmp = new T[datalen];
-  for (int i = 0; i < datalen; i++)
-  {
-    tmp[i] = data[i];
-  }
-  return tmp;
 }
 
 template<typename T>
@@ -717,6 +715,12 @@ OGRealSparseMatrix::debug_print() const
   }
 }
 
+real16*
+OGRealSparseMatrix::toReal16Array() const
+{
+  return this->toArray();
+}
+
 real16**
 OGRealSparseMatrix::toReal16ArrayOfArrays() const
 {
@@ -761,6 +765,12 @@ OGComplexSparseMatrix::debug_print() const
       printf("(%d,%d) = %6.4f + %6.4fi \n",this->getRowIdx()[i],ir,this->getData()[i].real(),this->getData()[i].imag());
     }
   }
+}
+
+complex16*
+OGComplexSparseMatrix::toComplex16Array() const
+{
+  return this->toArray();
 }
 
 complex16**

--- a/src/librdag/terminal.cc
+++ b/src/librdag/terminal.cc
@@ -201,10 +201,7 @@ T*
 OGArray<T>::toArray() const
 {
   T* tmp = new T[_datalen];
-  for (int i = 0; i < _datalen; i++)
-  {
-    tmp[i] = _data[i];
-  }
+  memcpy (tmp, _data, sizeof(T)*_datalen );
   return tmp;
 }
 

--- a/src/librdag/test/check_terminals.cc
+++ b/src/librdag/test/check_terminals.cc
@@ -823,8 +823,6 @@ TEST(TerminalsTest, OGRealSparseMatrix) {
  */
 TEST(TerminalsTest, OGComplexSparseMatrix) {
   // data
-//   double[][] realData = { { 1, 2, 0, 0 }, { 5, 0, 7, 0 }, { 0, 10, 11, 0 }, { 0, 0, 15, 0 } };
-//   double[][] imagData = { { 10, 20, 30, 0 }, { 0, 60, 70, 0 }, { 90, 100, 0, 120 }, { 0, 0, 0, 160 } };
   complex16 data [12] = { {1, 10}, {5, 0}, {0, 90}, {2, 20}, {0, 60}, {10, 100}, {0, 30}, {7, 70}, {11, 0}, {15, 0}, {0, 120}, {0, 160} };
   int colPtr [6] = { 0, 3, 6, 10, 12, 12 };
   int rowIdx [12] = { 0, 1, 2, 0, 1, 2, 0, 1, 2, 3, 2, 3 };
@@ -897,13 +895,13 @@ TEST(TerminalsTest, OGComplexSparseMatrix) {
   
   // check toArray()
   complex16* arr = tmp->toArray();
-  for (int i = 0; i < 7; i++)
+  for (int i = 0; i < 12; i++)
     EXPECT_EQ(arr[i], data[i]);
   delete[] arr;
 
   // check toComplex16Array()
   arr = tmp->toComplex16Array();
-  for (int i = 0; i < 7; i++)
+  for (int i = 0; i < 12; i++)
     EXPECT_EQ(arr[i], data[i]);
   delete[] arr;
 

--- a/src/librdag/test/check_terminals.cc
+++ b/src/librdag/test/check_terminals.cc
@@ -629,7 +629,8 @@ TEST(TerminalsTest, OGComplexDiagonalMatrix) {
   for(int i = 0; i < rows; i++){
     expected[i] = &(expectedtmp[i*cols]);
   }
-   // check toArray()
+
+  // check toArray()
   complex16* arr = tmp->toArray();
   for (int i = 0; i < 3; i++)
     EXPECT_TRUE(arr[i] == expectedarr[i]);
@@ -758,6 +759,18 @@ TEST(TerminalsTest, OGRealSparseMatrix) {
     expected[i] = &(expectedtmp[i*cols]);
   }
   
+  // check toArray()
+  real16* arr = tmp->toArray();
+  for (int i = 0; i < 7; i++)
+    EXPECT_EQ(arr[i], data[i]);
+  delete[] arr;
+
+  // check toReal16Array()
+  arr = tmp->toReal16Array();
+  for (int i = 0; i < 7; i++)
+    EXPECT_EQ(arr[i], data[i]);
+  delete[] arr;
+
   // check toArrayOfArrays()
   real16 ** computed = tmp->toArrayOfArrays(); 
   ASSERT_TRUE(ArrayOfArraysEquals<real16>(expected,computed,rows,cols));
@@ -882,6 +895,18 @@ TEST(TerminalsTest, OGComplexSparseMatrix) {
     expected[i] = &(expectedtmp[i*cols]);
   }
   
+  // check toArray()
+  complex16* arr = tmp->toArray();
+  for (int i = 0; i < 7; i++)
+    EXPECT_EQ(arr[i], data[i]);
+  delete[] arr;
+
+  // check toComplex16Array()
+  arr = tmp->toComplex16Array();
+  for (int i = 0; i < 7; i++)
+    EXPECT_EQ(arr[i], data[i]);
+  delete[] arr;
+
   // check toArrayOfArrays()
   complex16 ** computed = tmp->toArrayOfArrays(); 
   ASSERT_TRUE(ArrayOfArraysEquals<complex16>(expected,computed,rows,cols));


### PR DESCRIPTION
Addition of sparse materialisers and tests. 

toArray is moved up to OGArray in librdag so that it can be accessed by diagonal and sparse matrices.

Buildbot pass: http://devmaths-lx-1:8011/builders/nyqwk2-testing/builds/362

Librdag coverage: 99.4% (needs another commit to get up to 100%)
jshim coverage: 20.7%
