### PR TITLE
Add ExecutionList creation and traversal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,7 +135,10 @@ if (CMAKE_BUILD_TYPE MATCHES "Debug" AND NOT WIN32)
                     COMMENT "Generating coverage report")
 endif()
 
-
+# Whether we want noisy debug messages
+if (DEBUGMESSAGES)
+  add_definitions(-DDEBUGMESSAGES)
+endif()
 
 add_subdirectory(src)
 

--- a/include/debug.h
+++ b/include/debug.h
@@ -6,7 +6,7 @@
 
 #include "warningmacros.h"
 
-#ifdef DEBUG
+#ifdef DEBUGMESSAGES
 #define DEBUG_PRINT(...) fprintf(stderr, __VA_ARGS__)
 #else
 #define DEBUG_PRINT(...) do {} while(0)

--- a/include/dispatch.hh
+++ b/include/dispatch.hh
@@ -183,43 +183,43 @@ T eval(RegContainer SUPPRESS_UNUSED * reg0, OGTerminal const *arg0, OGTerminal c
         switch(arg1ID)
         {
           case REAL_SPARSE_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGRealSparseMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGRealSparseMatrix());\n");
               run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGRealSparseMatrix());
               break;
           case REAL_SCALAR_ENUM:
-              cout << "running with run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGRealScalar());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGRealScalar());\n");
               run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGRealScalar());
               break;
           case REAL_DIAGONAL_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGRealDiagonalMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGRealDiagonalMatrix());\n");
               run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGRealDiagonalMatrix());
               break;
           case INTEGER_SCALAR_ENUM:
-              cout << "running with run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGIntegerScalar());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGIntegerScalar());\n");
               run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGIntegerScalar());
               break;
           case COMPLEX_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGComplexMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGComplexMatrix());\n");
               run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGComplexMatrix());
               break;
           case COMPLEX_DIAGONAL_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGComplexDiagonalMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGComplexDiagonalMatrix());\n");
               run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGComplexDiagonalMatrix());
               break;
           case COMPLEX_SCALAR_ENUM:
-              cout << "running with run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGComplexScalar());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGComplexScalar());\n");
               run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGComplexScalar());
               break;
           case LOGICAL_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGLogicalMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGLogicalMatrix());\n");
               run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGLogicalMatrix());
               break;
           case REAL_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGRealMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGRealMatrix());\n");
               run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGRealMatrix());
               break;
           case COMPLEX_SPARSE_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGComplexSparseMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGComplexSparseMatrix());\n");
               run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGComplexSparseMatrix());
               break;
           default:
@@ -230,43 +230,43 @@ T eval(RegContainer SUPPRESS_UNUSED * reg0, OGTerminal const *arg0, OGTerminal c
         switch(arg1ID)
         {
           case REAL_SPARSE_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGRealScalar(), arg1->asOGRealSparseMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGRealScalar(), arg1->asOGRealSparseMatrix());\n");
               run(reg0, arg0->asOGRealScalar(), arg1->asOGRealSparseMatrix());
               break;
           case REAL_SCALAR_ENUM:
-              cout << "running with run(reg0, arg0->asOGRealScalar(), arg1->asOGRealScalar());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGRealScalar(), arg1->asOGRealScalar());\n");
               run(reg0, arg0->asOGRealScalar(), arg1->asOGRealScalar());
               break;
           case REAL_DIAGONAL_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGRealScalar(), arg1->asOGRealDiagonalMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGRealScalar(), arg1->asOGRealDiagonalMatrix());\n");
               run(reg0, arg0->asOGRealScalar(), arg1->asOGRealDiagonalMatrix());
               break;
           case INTEGER_SCALAR_ENUM:
-              cout << "running with run(reg0, arg0->asOGRealScalar(), arg1->asOGIntegerScalar());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGRealScalar(), arg1->asOGIntegerScalar());\n");
               run(reg0, arg0->asOGRealScalar(), arg1->asOGIntegerScalar());
               break;
           case COMPLEX_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGRealScalar(), arg1->asOGComplexMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGRealScalar(), arg1->asOGComplexMatrix());\n");
               run(reg0, arg0->asOGRealScalar(), arg1->asOGComplexMatrix());
               break;
           case COMPLEX_DIAGONAL_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGRealScalar(), arg1->asOGComplexDiagonalMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGRealScalar(), arg1->asOGComplexDiagonalMatrix());\n");
               run(reg0, arg0->asOGRealScalar(), arg1->asOGComplexDiagonalMatrix());
               break;
           case COMPLEX_SCALAR_ENUM:
-              cout << "running with run(reg0, arg0->asOGRealScalar(), arg1->asOGComplexScalar());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGRealScalar(), arg1->asOGComplexScalar());\n");
               run(reg0, arg0->asOGRealScalar(), arg1->asOGComplexScalar());
               break;
           case LOGICAL_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGRealScalar(), arg1->asOGLogicalMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGRealScalar(), arg1->asOGLogicalMatrix());\n");
               run(reg0, arg0->asOGRealScalar(), arg1->asOGLogicalMatrix());
               break;
           case REAL_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGRealScalar(), arg1->asOGRealMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGRealScalar(), arg1->asOGRealMatrix());\n");
               run(reg0, arg0->asOGRealScalar(), arg1->asOGRealMatrix());
               break;
           case COMPLEX_SPARSE_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGRealScalar(), arg1->asOGComplexSparseMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGRealScalar(), arg1->asOGComplexSparseMatrix());\n");
               run(reg0, arg0->asOGRealScalar(), arg1->asOGComplexSparseMatrix());
               break;
           default:
@@ -277,43 +277,43 @@ T eval(RegContainer SUPPRESS_UNUSED * reg0, OGTerminal const *arg0, OGTerminal c
         switch(arg1ID)
         {
           case REAL_SPARSE_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGRealSparseMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGRealSparseMatrix());\n");
               run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGRealSparseMatrix());
               break;
           case REAL_SCALAR_ENUM:
-              cout << "running with run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGRealScalar());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGRealScalar());\n");
               run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGRealScalar());
               break;
           case REAL_DIAGONAL_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGRealDiagonalMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGRealDiagonalMatrix());\n");
               run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGRealDiagonalMatrix());
               break;
           case INTEGER_SCALAR_ENUM:
-              cout << "running with run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGIntegerScalar());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGIntegerScalar());\n");
               run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGIntegerScalar());
               break;
           case COMPLEX_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGComplexMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGComplexMatrix());\n");
               run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGComplexMatrix());
               break;
           case COMPLEX_DIAGONAL_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGComplexDiagonalMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGComplexDiagonalMatrix());\n");
               run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGComplexDiagonalMatrix());
               break;
           case COMPLEX_SCALAR_ENUM:
-              cout << "running with run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGComplexScalar());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGComplexScalar());\n");
               run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGComplexScalar());
               break;
           case LOGICAL_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGLogicalMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGLogicalMatrix());\n");
               run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGLogicalMatrix());
               break;
           case REAL_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGRealMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGRealMatrix());\n");
               run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGRealMatrix());
               break;
           case COMPLEX_SPARSE_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGComplexSparseMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGComplexSparseMatrix());\n");
               run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGComplexSparseMatrix());
               break;
           default:
@@ -324,43 +324,43 @@ T eval(RegContainer SUPPRESS_UNUSED * reg0, OGTerminal const *arg0, OGTerminal c
         switch(arg1ID)
         {
           case REAL_SPARSE_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGIntegerScalar(), arg1->asOGRealSparseMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGIntegerScalar(), arg1->asOGRealSparseMatrix());\n");
               run(reg0, arg0->asOGIntegerScalar(), arg1->asOGRealSparseMatrix());
               break;
           case REAL_SCALAR_ENUM:
-              cout << "running with run(reg0, arg0->asOGIntegerScalar(), arg1->asOGRealScalar());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGIntegerScalar(), arg1->asOGRealScalar());\n");
               run(reg0, arg0->asOGIntegerScalar(), arg1->asOGRealScalar());
               break;
           case REAL_DIAGONAL_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGIntegerScalar(), arg1->asOGRealDiagonalMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGIntegerScalar(), arg1->asOGRealDiagonalMatrix());\n");
               run(reg0, arg0->asOGIntegerScalar(), arg1->asOGRealDiagonalMatrix());
               break;
           case INTEGER_SCALAR_ENUM:
-              cout << "running with run(reg0, arg0->asOGIntegerScalar(), arg1->asOGIntegerScalar());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGIntegerScalar(), arg1->asOGIntegerScalar());\n");
               run(reg0, arg0->asOGIntegerScalar(), arg1->asOGIntegerScalar());
               break;
           case COMPLEX_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGIntegerScalar(), arg1->asOGComplexMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGIntegerScalar(), arg1->asOGComplexMatrix());\n");
               run(reg0, arg0->asOGIntegerScalar(), arg1->asOGComplexMatrix());
               break;
           case COMPLEX_DIAGONAL_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGIntegerScalar(), arg1->asOGComplexDiagonalMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGIntegerScalar(), arg1->asOGComplexDiagonalMatrix());\n");
               run(reg0, arg0->asOGIntegerScalar(), arg1->asOGComplexDiagonalMatrix());
               break;
           case COMPLEX_SCALAR_ENUM:
-              cout << "running with run(reg0, arg0->asOGIntegerScalar(), arg1->asOGComplexScalar());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGIntegerScalar(), arg1->asOGComplexScalar());\n");
               run(reg0, arg0->asOGIntegerScalar(), arg1->asOGComplexScalar());
               break;
           case LOGICAL_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGIntegerScalar(), arg1->asOGLogicalMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGIntegerScalar(), arg1->asOGLogicalMatrix());\n");
               run(reg0, arg0->asOGIntegerScalar(), arg1->asOGLogicalMatrix());
               break;
           case REAL_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGIntegerScalar(), arg1->asOGRealMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGIntegerScalar(), arg1->asOGRealMatrix());\n");
               run(reg0, arg0->asOGIntegerScalar(), arg1->asOGRealMatrix());
               break;
           case COMPLEX_SPARSE_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGIntegerScalar(), arg1->asOGComplexSparseMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGIntegerScalar(), arg1->asOGComplexSparseMatrix());\n");
               run(reg0, arg0->asOGIntegerScalar(), arg1->asOGComplexSparseMatrix());
               break;
           default:
@@ -371,43 +371,43 @@ T eval(RegContainer SUPPRESS_UNUSED * reg0, OGTerminal const *arg0, OGTerminal c
         switch(arg1ID)
         {
           case REAL_SPARSE_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGComplexMatrix(), arg1->asOGRealSparseMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexMatrix(), arg1->asOGRealSparseMatrix());\n");
               run(reg0, arg0->asOGComplexMatrix(), arg1->asOGRealSparseMatrix());
               break;
           case REAL_SCALAR_ENUM:
-              cout << "running with run(reg0, arg0->asOGComplexMatrix(), arg1->asOGRealScalar());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexMatrix(), arg1->asOGRealScalar());\n");
               run(reg0, arg0->asOGComplexMatrix(), arg1->asOGRealScalar());
               break;
           case REAL_DIAGONAL_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGComplexMatrix(), arg1->asOGRealDiagonalMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexMatrix(), arg1->asOGRealDiagonalMatrix());\n");
               run(reg0, arg0->asOGComplexMatrix(), arg1->asOGRealDiagonalMatrix());
               break;
           case INTEGER_SCALAR_ENUM:
-              cout << "running with run(reg0, arg0->asOGComplexMatrix(), arg1->asOGIntegerScalar());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexMatrix(), arg1->asOGIntegerScalar());\n");
               run(reg0, arg0->asOGComplexMatrix(), arg1->asOGIntegerScalar());
               break;
           case COMPLEX_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGComplexMatrix(), arg1->asOGComplexMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexMatrix(), arg1->asOGComplexMatrix());\n");
               run(reg0, arg0->asOGComplexMatrix(), arg1->asOGComplexMatrix());
               break;
           case COMPLEX_DIAGONAL_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGComplexMatrix(), arg1->asOGComplexDiagonalMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexMatrix(), arg1->asOGComplexDiagonalMatrix());\n");
               run(reg0, arg0->asOGComplexMatrix(), arg1->asOGComplexDiagonalMatrix());
               break;
           case COMPLEX_SCALAR_ENUM:
-              cout << "running with run(reg0, arg0->asOGComplexMatrix(), arg1->asOGComplexScalar());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexMatrix(), arg1->asOGComplexScalar());\n");
               run(reg0, arg0->asOGComplexMatrix(), arg1->asOGComplexScalar());
               break;
           case LOGICAL_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGComplexMatrix(), arg1->asOGLogicalMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexMatrix(), arg1->asOGLogicalMatrix());\n");
               run(reg0, arg0->asOGComplexMatrix(), arg1->asOGLogicalMatrix());
               break;
           case REAL_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGComplexMatrix(), arg1->asOGRealMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexMatrix(), arg1->asOGRealMatrix());\n");
               run(reg0, arg0->asOGComplexMatrix(), arg1->asOGRealMatrix());
               break;
           case COMPLEX_SPARSE_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGComplexMatrix(), arg1->asOGComplexSparseMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexMatrix(), arg1->asOGComplexSparseMatrix());\n");
               run(reg0, arg0->asOGComplexMatrix(), arg1->asOGComplexSparseMatrix());
               break;
           default:
@@ -418,43 +418,43 @@ T eval(RegContainer SUPPRESS_UNUSED * reg0, OGTerminal const *arg0, OGTerminal c
         switch(arg1ID)
         {
           case REAL_SPARSE_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGRealSparseMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGRealSparseMatrix());\n");
               run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGRealSparseMatrix());
               break;
           case REAL_SCALAR_ENUM:
-              cout << "running with run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGRealScalar());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGRealScalar());\n");
               run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGRealScalar());
               break;
           case REAL_DIAGONAL_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGRealDiagonalMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGRealDiagonalMatrix());\n");
               run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGRealDiagonalMatrix());
               break;
           case INTEGER_SCALAR_ENUM:
-              cout << "running with run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGIntegerScalar());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGIntegerScalar());\n");
               run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGIntegerScalar());
               break;
           case COMPLEX_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGComplexMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGComplexMatrix());\n");
               run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGComplexMatrix());
               break;
           case COMPLEX_DIAGONAL_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGComplexDiagonalMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGComplexDiagonalMatrix());\n");
               run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGComplexDiagonalMatrix());
               break;
           case COMPLEX_SCALAR_ENUM:
-              cout << "running with run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGComplexScalar());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGComplexScalar());\n");
               run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGComplexScalar());
               break;
           case LOGICAL_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGLogicalMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGLogicalMatrix());\n");
               run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGLogicalMatrix());
               break;
           case REAL_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGRealMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGRealMatrix());\n");
               run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGRealMatrix());
               break;
           case COMPLEX_SPARSE_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGComplexSparseMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGComplexSparseMatrix());\n");
               run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGComplexSparseMatrix());
               break;
           default:
@@ -465,43 +465,43 @@ T eval(RegContainer SUPPRESS_UNUSED * reg0, OGTerminal const *arg0, OGTerminal c
         switch(arg1ID)
         {
           case REAL_SPARSE_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGComplexScalar(), arg1->asOGRealSparseMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexScalar(), arg1->asOGRealSparseMatrix());\n");
               run(reg0, arg0->asOGComplexScalar(), arg1->asOGRealSparseMatrix());
               break;
           case REAL_SCALAR_ENUM:
-              cout << "running with run(reg0, arg0->asOGComplexScalar(), arg1->asOGRealScalar());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexScalar(), arg1->asOGRealScalar());\n");
               run(reg0, arg0->asOGComplexScalar(), arg1->asOGRealScalar());
               break;
           case REAL_DIAGONAL_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGComplexScalar(), arg1->asOGRealDiagonalMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexScalar(), arg1->asOGRealDiagonalMatrix());\n");
               run(reg0, arg0->asOGComplexScalar(), arg1->asOGRealDiagonalMatrix());
               break;
           case INTEGER_SCALAR_ENUM:
-              cout << "running with run(reg0, arg0->asOGComplexScalar(), arg1->asOGIntegerScalar());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexScalar(), arg1->asOGIntegerScalar());\n");
               run(reg0, arg0->asOGComplexScalar(), arg1->asOGIntegerScalar());
               break;
           case COMPLEX_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGComplexScalar(), arg1->asOGComplexMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexScalar(), arg1->asOGComplexMatrix());\n");
               run(reg0, arg0->asOGComplexScalar(), arg1->asOGComplexMatrix());
               break;
           case COMPLEX_DIAGONAL_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGComplexScalar(), arg1->asOGComplexDiagonalMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexScalar(), arg1->asOGComplexDiagonalMatrix());\n");
               run(reg0, arg0->asOGComplexScalar(), arg1->asOGComplexDiagonalMatrix());
               break;
           case COMPLEX_SCALAR_ENUM:
-              cout << "running with run(reg0, arg0->asOGComplexScalar(), arg1->asOGComplexScalar());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexScalar(), arg1->asOGComplexScalar());\n");
               run(reg0, arg0->asOGComplexScalar(), arg1->asOGComplexScalar());
               break;
           case LOGICAL_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGComplexScalar(), arg1->asOGLogicalMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexScalar(), arg1->asOGLogicalMatrix());\n");
               run(reg0, arg0->asOGComplexScalar(), arg1->asOGLogicalMatrix());
               break;
           case REAL_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGComplexScalar(), arg1->asOGRealMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexScalar(), arg1->asOGRealMatrix());\n");
               run(reg0, arg0->asOGComplexScalar(), arg1->asOGRealMatrix());
               break;
           case COMPLEX_SPARSE_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGComplexScalar(), arg1->asOGComplexSparseMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexScalar(), arg1->asOGComplexSparseMatrix());\n");
               run(reg0, arg0->asOGComplexScalar(), arg1->asOGComplexSparseMatrix());
               break;
           default:
@@ -512,43 +512,43 @@ T eval(RegContainer SUPPRESS_UNUSED * reg0, OGTerminal const *arg0, OGTerminal c
         switch(arg1ID)
         {
           case REAL_SPARSE_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGRealSparseMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGRealSparseMatrix());\n");
               run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGRealSparseMatrix());
               break;
           case REAL_SCALAR_ENUM:
-              cout << "running with run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGRealScalar());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGRealScalar());\n");
               run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGRealScalar());
               break;
           case REAL_DIAGONAL_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGRealDiagonalMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGRealDiagonalMatrix());\n");
               run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGRealDiagonalMatrix());
               break;
           case INTEGER_SCALAR_ENUM:
-              cout << "running with run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGIntegerScalar());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGIntegerScalar());\n");
               run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGIntegerScalar());
               break;
           case COMPLEX_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGComplexMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGComplexMatrix());\n");
               run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGComplexMatrix());
               break;
           case COMPLEX_DIAGONAL_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGComplexDiagonalMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGComplexDiagonalMatrix());\n");
               run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGComplexDiagonalMatrix());
               break;
           case COMPLEX_SCALAR_ENUM:
-              cout << "running with run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGComplexScalar());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGComplexScalar());\n");
               run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGComplexScalar());
               break;
           case LOGICAL_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGLogicalMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGLogicalMatrix());\n");
               run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGLogicalMatrix());
               break;
           case REAL_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGRealMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGRealMatrix());\n");
               run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGRealMatrix());
               break;
           case COMPLEX_SPARSE_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGComplexSparseMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGComplexSparseMatrix());\n");
               run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGComplexSparseMatrix());
               break;
           default:
@@ -559,43 +559,43 @@ T eval(RegContainer SUPPRESS_UNUSED * reg0, OGTerminal const *arg0, OGTerminal c
         switch(arg1ID)
         {
           case REAL_SPARSE_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGRealMatrix(), arg1->asOGRealSparseMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGRealMatrix(), arg1->asOGRealSparseMatrix());\n");
               run(reg0, arg0->asOGRealMatrix(), arg1->asOGRealSparseMatrix());
               break;
           case REAL_SCALAR_ENUM:
-              cout << "running with run(reg0, arg0->asOGRealMatrix(), arg1->asOGRealScalar());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGRealMatrix(), arg1->asOGRealScalar());\n");
               run(reg0, arg0->asOGRealMatrix(), arg1->asOGRealScalar());
               break;
           case REAL_DIAGONAL_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGRealMatrix(), arg1->asOGRealDiagonalMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGRealMatrix(), arg1->asOGRealDiagonalMatrix());\n");
               run(reg0, arg0->asOGRealMatrix(), arg1->asOGRealDiagonalMatrix());
               break;
           case INTEGER_SCALAR_ENUM:
-              cout << "running with run(reg0, arg0->asOGRealMatrix(), arg1->asOGIntegerScalar());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGRealMatrix(), arg1->asOGIntegerScalar());\n");
               run(reg0, arg0->asOGRealMatrix(), arg1->asOGIntegerScalar());
               break;
           case COMPLEX_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGRealMatrix(), arg1->asOGComplexMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGRealMatrix(), arg1->asOGComplexMatrix());\n");
               run(reg0, arg0->asOGRealMatrix(), arg1->asOGComplexMatrix());
               break;
           case COMPLEX_DIAGONAL_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGRealMatrix(), arg1->asOGComplexDiagonalMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGRealMatrix(), arg1->asOGComplexDiagonalMatrix());\n");
               run(reg0, arg0->asOGRealMatrix(), arg1->asOGComplexDiagonalMatrix());
               break;
           case COMPLEX_SCALAR_ENUM:
-              cout << "running with run(reg0, arg0->asOGRealMatrix(), arg1->asOGComplexScalar());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGRealMatrix(), arg1->asOGComplexScalar());\n");
               run(reg0, arg0->asOGRealMatrix(), arg1->asOGComplexScalar());
               break;
           case LOGICAL_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGRealMatrix(), arg1->asOGLogicalMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGRealMatrix(), arg1->asOGLogicalMatrix());\n");
               run(reg0, arg0->asOGRealMatrix(), arg1->asOGLogicalMatrix());
               break;
           case REAL_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGRealMatrix(), arg1->asOGRealMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGRealMatrix(), arg1->asOGRealMatrix());\n");
               run(reg0, arg0->asOGRealMatrix(), arg1->asOGRealMatrix());
               break;
           case COMPLEX_SPARSE_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGRealMatrix(), arg1->asOGComplexSparseMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGRealMatrix(), arg1->asOGComplexSparseMatrix());\n");
               run(reg0, arg0->asOGRealMatrix(), arg1->asOGComplexSparseMatrix());
               break;
           default:
@@ -606,43 +606,43 @@ T eval(RegContainer SUPPRESS_UNUSED * reg0, OGTerminal const *arg0, OGTerminal c
         switch(arg1ID)
         {
           case REAL_SPARSE_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGRealSparseMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGRealSparseMatrix());\n");
               run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGRealSparseMatrix());
               break;
           case REAL_SCALAR_ENUM:
-              cout << "running with run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGRealScalar());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGRealScalar());\n");
               run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGRealScalar());
               break;
           case REAL_DIAGONAL_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGRealDiagonalMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGRealDiagonalMatrix());\n");
               run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGRealDiagonalMatrix());
               break;
           case INTEGER_SCALAR_ENUM:
-              cout << "running with run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGIntegerScalar());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGIntegerScalar());\n");
               run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGIntegerScalar());
               break;
           case COMPLEX_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGComplexMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGComplexMatrix());\n");
               run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGComplexMatrix());
               break;
           case COMPLEX_DIAGONAL_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGComplexDiagonalMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGComplexDiagonalMatrix());\n");
               run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGComplexDiagonalMatrix());
               break;
           case COMPLEX_SCALAR_ENUM:
-              cout << "running with run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGComplexScalar());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGComplexScalar());\n");
               run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGComplexScalar());
               break;
           case LOGICAL_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGLogicalMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGLogicalMatrix());\n");
               run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGLogicalMatrix());
               break;
           case REAL_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGRealMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGRealMatrix());\n");
               run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGRealMatrix());
               break;
           case COMPLEX_SPARSE_MATRIX_ENUM:
-              cout << "running with run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGComplexSparseMatrix());" << std::endl;
+              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGComplexSparseMatrix());\n");
               run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGComplexSparseMatrix());
               break;
           default:

--- a/src/java/src/test/java/com/opengamma/longdog/materialisers/TestPlusMaterialise.java
+++ b/src/java/src/test/java/com/opengamma/longdog/materialisers/TestPlusMaterialise.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (C) 2013 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+package com.opengamma.longdog.materialisers;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.opengamma.longdog.datacontainers.OGNumeric;
+import com.opengamma.longdog.datacontainers.scalar.OGRealScalar;
+import com.opengamma.longdog.exceptions.MathsException;
+import com.opengamma.longdog.nodes.PLUS;
+import com.opengamma.longdog.testhelpers.ArraysHelpers;
+
+public class TestPlusMaterialise {
+
+  @DataProvider
+  public Object[][] dataContainer() {
+    Object[][] obj = new Object[3][2];
+
+
+    obj[0][0] = new PLUS(new OGRealScalar(2.0), new OGRealScalar(3.0));
+    obj[0][1] = new OGRealScalar(2.0 + 3.0);
+
+    obj[1][0] = new PLUS(new PLUS(new OGRealScalar(1.0), new OGRealScalar(2.0)), new OGRealScalar(3.0));
+    obj[1][1] = new OGRealScalar(1.0 + 2.0 + 3.0);
+
+    OGNumeric bigtree = new OGRealScalar(0.0);
+    double sum = 0.0;
+    for (int i = 1; i < 2500; i++) {
+      if (i%2 == 0) {
+        bigtree = new PLUS(new OGRealScalar(i), bigtree);
+      }
+      else {
+        bigtree = new PLUS(bigtree, new OGRealScalar(i));
+      }
+      sum += i;
+    }
+
+    obj[2][0] = bigtree;
+    obj[2][1] = new OGRealScalar(sum);
+
+    return obj;
+  };
+
+  @Test(dataProvider = "dataContainer")
+  public void materialiseToJDoubleArray(OGNumeric input, OGRealScalar expected) {
+    double[][] answer = Materialisers.toDoubleArrayOfArrays(input);
+    if (!ArraysHelpers.ArraysEquals(new double[][] {expected.getData()}, answer)) {
+      throw new MathsException("Arrays not equal");
+    }
+  }
+
+  @Test(dataProvider = "dataContainer")
+  public void materialiseToOGTerminal(OGNumeric input, OGRealScalar expected) {
+    OGRealScalar answer = (OGRealScalar) Materialisers.toOGTerminal(input);
+    if (answer.getData()[0] != expected.getData()[0]) {
+      throw new MathsException("Arrays not equal");
+    }
+  }
+
+}

--- a/src/librdag/dispatch.cc
+++ b/src/librdag/dispatch.cc
@@ -57,7 +57,7 @@ NegateRunner::run(RegContainer *reg, const OGRealMatrix *arg) const
 }
 
 void
-NegateRunner::run(RegContainer SUPPRESS_UNUSED *reg, const OGComplexMatrix SUPPRESS_UNUSED *arg) const
+NegateRunner::run(RegContainer *reg, const OGComplexMatrix *arg) const
 {
   complex16* data = arg->getData();
   int datalen = arg->getDatalen();
@@ -66,7 +66,7 @@ NegateRunner::run(RegContainer SUPPRESS_UNUSED *reg, const OGComplexMatrix SUPPR
   {
     newData[i] = -data[i];
   }
-  reg->push_back(new OGComplexMatrix(data, arg->getRows(), arg->getCols()));
+  reg->push_back(new OGComplexMatrix(newData, arg->getRows(), arg->getCols()));
 }
 
 Dispatcher::Dispatcher()
@@ -223,7 +223,12 @@ void Dispatcher::dispatch(NEGATE const SUPPRESS_UNUSED *thing) const {
       const ArgContainer* args = thing->getArgs();
       const RegContainer* regs = thing->getRegs();
       const OGNumeric *arg = (*args)[0];
-      _NegateRunner->eval(const_cast<RegContainer *>(regs), arg->asOGTerminal());
+      const OGTerminal *argt = arg->asOGTerminal();
+      if (argt == nullptr)
+      {
+        argt = (*(arg->asOGExpr()->getRegs()))[0]->asOGTerminal();
+      }
+      _NegateRunner->eval(const_cast<RegContainer *>(regs), argt);
 }
 
 void Dispatcher::dispatch(COPY const SUPPRESS_UNUSED *thing) const {

--- a/src/librdag/dispatch.cc
+++ b/src/librdag/dispatch.cc
@@ -207,7 +207,17 @@ void Dispatcher::dispatch(PLUS const *thing) const {
       const RegContainer * regs = thing->getRegs();
       const OGNumeric * arg0 = (*args)[0];
       const OGNumeric * arg1 = (*args)[1];
-      this->_PlusRunner->eval(const_cast<RegContainer *>(regs), arg0->asOGTerminal(), arg1->asOGTerminal());
+      const OGTerminal* arg0t = arg0->asOGTerminal();
+      const OGTerminal* arg1t = arg1->asOGTerminal();
+      if (arg0t == nullptr)
+      {
+        arg0t = (*(arg0->asOGExpr()->getRegs()))[0]->asOGTerminal();
+      }
+      if (arg1t == nullptr)
+      {
+        arg1t = (*(arg1->asOGExpr()->getRegs()))[0]->asOGTerminal();
+      }
+      this->_PlusRunner->eval(const_cast<RegContainer *>(regs), arg0t, arg1t);
 }
 
 void Dispatcher::dispatch(NEGATE const SUPPRESS_UNUSED *thing) const {

--- a/src/librdag/dispatch.cc
+++ b/src/librdag/dispatch.cc
@@ -30,7 +30,7 @@ void PlusRunner::run(RegContainer SUPPRESS_UNUSED * reg0, OGRealMatrix const SUP
 void PlusRunner::run(RegContainer* reg0, OGRealScalar const * arg0, OGRealScalar const * arg1) const
 {
   // impl convert and run for types OGRealScalar and OGRealScalar 
-  cout << "In virtual overridden PlusRunner T run() REAL REAL " << std::endl;
+  DEBUG_PRINT("In virtual overridden PlusRunner T run() REAL REAL \n");
   const OGRealScalar * ret = new OGRealScalar(arg0->getValue()+arg1->getValue());
   reg0->push_back(ret);
 }
@@ -38,7 +38,7 @@ void PlusRunner::run(RegContainer* reg0, OGRealScalar const * arg0, OGRealScalar
 void
 NegateRunner::run(RegContainer* reg, const OGRealScalar* arg) const
 {
-  cout << "IN Negate runner." << endl;
+  DEBUG_PRINT("IN Negate runner.\n");
   const OGRealScalar* ret = new OGRealScalar(-(arg->getValue()));
   reg->push_back(ret);
 }
@@ -83,18 +83,16 @@ Dispatcher::~Dispatcher(){
   
 void Dispatcher::dispatch(OGNumeric const *thing) const
 {
-    cout << "Dispatching..." << std::endl;
+    DEBUG_PRINT("Dispatching...\n");
     ExprType_t ID = thing->getType();
-    cout << "TYPE IS" << ID << std::endl;
+    DEBUG_PRINT("TYPE IS %d\n", ID);
     bool isTerminalType = false;
     if(ID&IS_NODE_MASK){
-      cout << "is node..." << std::endl;
-      thing->debug_print();
+      DEBUG_PRINT("is node...\n");
       thing->asOGExpr();
     } else {
       isTerminalType = true;      
-      cout << "is terminal..." << std::endl;
-      thing->debug_print();       
+      DEBUG_PRINT("is terminal...\n");
     }
 
     // branch switch on isTerminalType?
@@ -132,7 +130,7 @@ void Dispatcher::dispatch(OGNumeric const *thing) const
           dispatch(thing->asOGIntegerScalar());
           break;          
         default:
-          cout << "NO SPECIFIC TYPE " << std::endl;
+          DEBUG_PRINT("NO SPECIFIC TYPE \n");
       }     
     }
     else
@@ -155,7 +153,7 @@ void Dispatcher::dispatch(OGNumeric const *thing) const
           dispatch(thing->asSELECTRESULT());
           break;
         default:
-          cout << "NO SPECIFIC TYPE " << std::endl;
+          DEBUG_PRINT("NO SPECIFIC TYPE \n");
       }
     }
 }
@@ -202,7 +200,7 @@ void Dispatcher::dispatch(OGComplexSparseMatrix const SUPPRESS_UNUSED * thing) c
 }
   
 void Dispatcher::dispatch(PLUS const *thing) const {
-      cout << "ABOUT TO DISPATCH A PLUS OP" << std::endl;
+      DEBUG_PRINT("ABOUT TO DISPATCH A PLUS OP\n");
       const ArgContainer * args = thing->getArgs();
       const RegContainer * regs = thing->getRegs();
       const OGNumeric * arg0 = (*args)[0];
@@ -221,7 +219,7 @@ void Dispatcher::dispatch(PLUS const *thing) const {
 }
 
 void Dispatcher::dispatch(NEGATE const SUPPRESS_UNUSED *thing) const {
-      cout << "ABOUT TO DISPATCH A NEGATE OP" << std::endl;
+      DEBUG_PRINT("ABOUT TO DISPATCH A NEGATE OP\n");
       const ArgContainer* args = thing->getArgs();
       const RegContainer* regs = thing->getRegs();
       const OGNumeric *arg = (*args)[0];
@@ -229,15 +227,15 @@ void Dispatcher::dispatch(NEGATE const SUPPRESS_UNUSED *thing) const {
 }
 
 void Dispatcher::dispatch(COPY const SUPPRESS_UNUSED *thing) const {
-      cout << "ABOUT TO DISPATCH A COPY OP" << std::endl;
+      DEBUG_PRINT("ABOUT TO DISPATCH A COPY OP\n");
 }
 
 void Dispatcher::dispatch(SVD const SUPPRESS_UNUSED *thing) const {
-      cout << "ABOUT TO DISPATCH A SVD OP" << std::endl;
+      DEBUG_PRINT("ABOUT TO DISPATCH A SVD OP\n");
 }
 
 void Dispatcher::dispatch(SELECTRESULT const SUPPRESS_UNUSED *thing) const {
-      cout << "ABOUT TO DISPATCH A SELECTRESULT OP" << std::endl;
+      DEBUG_PRINT("ABOUT TO DISPATCH A SELECTRESULT OP\n");
 }
   
   

--- a/src/librdag/entrypt.cc
+++ b/src/librdag/entrypt.cc
@@ -146,7 +146,7 @@ entrypt(const OGNumeric* expr)
     ExecutionList* el = new ExecutionList(expr);
     Dispatcher * disp = new Dispatcher();
     
-    printf("Dispatching from entrypt\n");
+    DEBUG_PRINT("Dispatching from entrypt\n");
 
     for (auto it = el->begin(); it != el->end(); ++it)
     {
@@ -161,7 +161,6 @@ entrypt(const OGNumeric* expr)
     
     // Make a copy of the result because it gets blown away by the deletion of the tree
     const OGNumeric * answer = (*reg)[0]->copy();
-    answer->debug_print();
     const OGTerminal * returnTerm = answer->asOGTerminal();
     
     if(returnTerm==nullptr)

--- a/src/librdag/entrypt.cc
+++ b/src/librdag/entrypt.cc
@@ -133,12 +133,6 @@ void Walker::talkandwalk(librdag::OGNumeric const * numeric_expr_types)
 const OGTerminal*
 entrypt(const OGNumeric* expr)
 {
-  /* Return a copy of the node that was passed. The reason for doing this is that we eventually
-   * expect entrypt to return the register for the result. For now, returning a copy of the tree
-   * means that if a terminal is passed in, we don't get a surprise when we delete both the result
-   * and the terminal that was passed in (because they would be the same thing if we just returned
-   * the tree as-is).
-   */
   const OGTerminal* asTerminal = expr->asOGTerminal();
   if (asTerminal!=nullptr)
   {

--- a/src/librdag/test/check_entrypt.cc
+++ b/src/librdag/test/check_entrypt.cc
@@ -29,30 +29,17 @@ TEST_P(EntryptOneNodeTest, TerminalTypes)
 INSTANTIATE_TEST_CASE_P(ValueParam, EntryptOneNodeTest, ::testing::ValuesIn(terminals));
 
 /**
- * Very simple test that entrypt is "working", as in it returns something not null that is sane.
+ * Entrypt with NEGATE nodes
  */
-TEST(EntryptTest, ExprResultNull)
-{
-  ArgContainer *args = new ArgContainer();
-  args->push_back(new OGRealScalar(2));
-  args->push_back(new OGRealScalar(3));
-  OGExpr *plus = new PLUS(args);
-  const OGTerminal* result = entrypt(plus);
-  EXPECT_EQ(result->asOGRealScalar()->getValue(), 5);
-  delete result;
-  delete plus;
-}
-
 class EntryptNegateTest: public ::testing::TestWithParam<std::pair<const OGNumeric*, const OGNumeric*> > {};
 
 TEST_P(EntryptNegateTest, Running)
 {
-  const NEGATE* node = GetParam().first->asNEGATE();
-  const OGRealScalar* expectedResult = GetParam().second->asOGRealScalar();
-  const OGNumeric *result = entrypt(node);
-  const OGRealScalar* resultScalar = result->asOGRealScalar();
-  ASSERT_NE(resultScalar, nullptr);
-  EXPECT_EQ(resultScalar->getValue(), expectedResult->getValue());
+  const OGNumeric* node = GetParam().first;
+  const OGTerminal* expectedResult = GetParam().second->asOGTerminal();
+  const OGTerminal *result = entrypt(node)->asOGTerminal();
+  ASSERT_NE(result, nullptr);
+  EXPECT_TRUE((*result)==(*expectedResult));
   delete node;
   delete expectedResult;
   delete result;
@@ -83,3 +70,74 @@ pair<const OGNumeric*, const OGNumeric*> negaterealmatrix()
 pair<const OGNumeric*, const OGNumeric*> negates[] = { negatepair(1.0), negatepair(-1.0), negatepair(0.0) };
 
 INSTANTIATE_TEST_CASE_P(ValueParam, EntryptNegateTest, ::testing::ValuesIn(negates));
+
+/**
+ * Entrypt with PLUS nodes
+ */
+class EntryptPlusTest: public ::testing::TestWithParam<std::pair<const OGNumeric*, const OGNumeric*> > {} ;
+
+TEST_P(EntryptPlusTest, Running)
+{
+  const OGNumeric* node = GetParam().first;
+  const OGTerminal* expectedResult = GetParam().second->asOGTerminal();
+  const OGTerminal *result = entrypt(node)->asOGTerminal();
+  ASSERT_NE(result, nullptr);
+  EXPECT_TRUE((*result)==(*expectedResult));
+  delete node;
+  delete expectedResult;
+  delete result;
+}
+
+pair<const OGNumeric*, const OGNumeric*> plustestsimple()
+{
+  ArgContainer* args = new ArgContainer();
+  args->push_back(new OGRealScalar(2.0));
+  args->push_back(new OGRealScalar(3.0));
+  const OGNumeric* plus = new PLUS(args);
+  const OGNumeric* expected = new OGRealScalar(2.0+3.0);
+  return pair<const OGNumeric*, const OGNumeric*>(plus, expected);
+}
+
+pair<const OGNumeric*, const OGNumeric*> plustesttwoplus()
+{
+  ArgContainer* args = new ArgContainer();
+  args->push_back(new OGRealScalar(2.0));
+  args->push_back(new OGRealScalar(3.0));
+  const OGNumeric* plus = new PLUS(args);
+  args = new ArgContainer();
+  args->push_back(new OGRealScalar(1.0));
+  args->push_back(plus);
+  plus = new PLUS(args);
+  const OGNumeric* expected = new OGRealScalar(1.0+2.0+3.0);
+  return pair<const OGNumeric*, const OGNumeric*>(plus, expected);
+}
+
+pair<const OGNumeric*, const OGNumeric*> plustestbigtree()
+{
+  const OGNumeric* bigtree = new OGRealScalar(0.0);
+  double sum = 0.0;
+  for (int i = 0; i < 5000; ++i)
+  {
+    sum += i;
+    ArgContainer* args = new ArgContainer();
+
+    if (i%2 == 0)
+    {
+      args->push_back(new OGRealScalar(i));
+      args->push_back(bigtree);
+    }
+    else
+    {
+      args->push_back(bigtree);
+      args->push_back(new OGRealScalar(i));
+    }
+    bigtree = new PLUS(args);
+  }
+
+  return pair<const OGNumeric*, const OGNumeric*>(bigtree, new OGRealScalar(sum));
+}
+
+pair<const OGNumeric*, const OGNumeric*> pluses[] = { plustestsimple(), plustesttwoplus(), plustestbigtree() };
+
+INSTANTIATE_TEST_CASE_P(ValueParam, EntryptPlusTest, ::testing::ValuesIn(pluses));
+


### PR DESCRIPTION
This adds execution list creation and traversal in entrypt.

The plus node runner has been changed slightly so that if its args are not terminals, it gets the register from its arguments so it is operating on the correct data.

The tree walker has also been disabled - it produces a large amount of output, and it is becoming less relevant as we being implementing actual execution. (It was also not much of a rigorous test of anything anyway).

Buildbot pass: http://devmaths-lx-1:8011/builders/nyqwk2-testing/builds/382
Librdag coverage: 81% (dropped due to not calling the walker to print out the tree)
jshim coverage: 20.6% (same as master)
