### PR TITLE
Dispatch for unary operations

### DIFF
--- a/include/dispatch.hh
+++ b/include/dispatch.hh
@@ -132,19 +132,9 @@ public:
     // impl convert and run for type OGIntegerScalar
   };
 
-  virtual T run(RegContainer SUPPRESS_UNUSED * reg, OGRealMatrix const SUPPRESS_UNUSED * arg) const
-  {
-    // impl convert and run for type OGRealMatrix
-  };
-
   virtual T run(RegContainer SUPPRESS_UNUSED * reg, OGLogicalMatrix const SUPPRESS_UNUSED * arg) const
   {
     // impl convert and run for type OGLogicalMatrix
-  };
-
-  virtual T run(RegContainer SUPPRESS_UNUSED * reg, OGComplexMatrix const SUPPRESS_UNUSED * arg) const
-  {
-    // impl convert and run for type OGComplexMatrix
   };
 
   virtual T run(RegContainer SUPPRESS_UNUSED * reg, OGRealDiagonalMatrix const SUPPRESS_UNUSED * arg) const
@@ -166,6 +156,10 @@ public:
   {
     // impl convert and run for type OGComplexSparseMatrix
   };
+
+  // Backstop methods for generic implementation
+  virtual T run(RegContainer * reg, OGRealMatrix const * arg) const = 0;
+  virtual T run(RegContainer * reg, OGComplexMatrix const * arg) const = 0;
 };
 
 
@@ -1182,6 +1176,8 @@ class NegateRunner: public DispatchVoidUnaryOp, private Uncopyable
 {
   public:
     virtual void run(RegContainer* reg, const OGRealScalar* arg) const override;
+    virtual void run(RegContainer* reg, const OGRealMatrix* arg) const override;
+    virtual void run(RegContainer* reg, const OGComplexMatrix* arg) const override;
 };
 
 } // namespace librdag

--- a/include/dispatch.hh
+++ b/include/dispatch.hh
@@ -14,14 +14,15 @@
 #include "warningmacros.h"
 #include "jvmmanager.hh"
 #include "exceptions.hh"
-
+#include "debug.h"
 
 
 namespace librdag {
 
 // fwd decl
 class PlusRunner;
-  
+class NegateRunner;
+
 /**
  * The class for dispatching execution based on OGNumeric type
  */
@@ -53,7 +54,118 @@ public:
   
 private:
   PlusRunner * _PlusRunner;
+  NegateRunner* _NegateRunner;
   
+};
+
+/**
+ * For dispatching operations of the form "T foo(Register * register1, OGTerminal * arg)"
+ */
+template<typename T> class  DispatchUnaryOp
+{
+public:
+  virtual ~DispatchUnaryOp(){};
+
+  // will run the operation
+  T eval(RegContainer SUPPRESS_UNUSED * reg, OGTerminal const * arg) const
+  {
+    ExprType_t argID = arg->getType();
+    switch(argID)
+    {
+      case REAL_SPARSE_MATRIX_ENUM:
+        DEBUG_PRINT("running with run(reg, arg->asOGRealSparseMatrix());\n");
+        run(reg, arg->asOGRealSparseMatrix());
+        break;
+      case REAL_SCALAR_ENUM:
+        DEBUG_PRINT("running with run(reg, arg->asOGRealScalar());\n");
+        run(reg, arg->asOGRealScalar());
+        break;
+      case REAL_DIAGONAL_MATRIX_ENUM:
+        DEBUG_PRINT("running with run(reg, arg->asOGRealDiagonalMatrix());\n");
+        run(reg, arg->asOGRealDiagonalMatrix());
+        break;
+      case INTEGER_SCALAR_ENUM:
+        DEBUG_PRINT("running with run(reg, arg->asOGIntegerScalar());\n");
+        run(reg, arg->asOGIntegerScalar());
+        break;
+      case COMPLEX_MATRIX_ENUM:
+        DEBUG_PRINT("running with run(reg, arg->asOGComplexMatrix());\n");
+        run(reg, arg->asOGComplexMatrix());
+        break;
+      case COMPLEX_DIAGONAL_MATRIX_ENUM:
+        DEBUG_PRINT("running with run(reg, arg->asOGComplexDiagonalMatrix());\n");
+        run(reg, arg->asOGComplexDiagonalMatrix());
+        break;
+      case COMPLEX_SCALAR_ENUM:
+        DEBUG_PRINT("running with run(reg, arg->asOGComplexScalar());\n");
+        run(reg, arg->asOGComplexScalar());
+        break;
+      case LOGICAL_MATRIX_ENUM:
+        DEBUG_PRINT("running with run(reg, arg->asOGLogicalMatrix());\n");
+        run(reg, arg->asOGLogicalMatrix());
+        break;
+      case REAL_MATRIX_ENUM:
+        DEBUG_PRINT("running with run(reg, arg->asOGRealMatrix());\n");
+        run(reg, arg->asOGRealMatrix());
+        break;
+      case COMPLEX_SPARSE_MATRIX_ENUM:
+        DEBUG_PRINT("running with run(reg, arg->asOGComplexSparseMatrix());\n");
+        run(reg, arg->asOGComplexSparseMatrix());
+        break;
+      default:
+          throw rdag_error("Unknown type in dispatch on arg");
+    }
+  }
+
+  virtual T run(RegContainer SUPPRESS_UNUSED * reg, OGRealScalar const SUPPRESS_UNUSED * arg) const
+  {
+    // impl convert and run for type OGRealScalar
+  };
+
+  virtual T run(RegContainer SUPPRESS_UNUSED * reg, OGComplexScalar const SUPPRESS_UNUSED * arg) const
+  {
+    // impl convert and run for type OGComplexScalar
+  };
+
+  virtual T run(RegContainer SUPPRESS_UNUSED * reg, OGIntegerScalar const SUPPRESS_UNUSED * arg) const
+  {
+    // impl convert and run for type OGIntegerScalar
+  };
+
+  virtual T run(RegContainer SUPPRESS_UNUSED * reg, OGRealMatrix const SUPPRESS_UNUSED * arg) const
+  {
+    // impl convert and run for type OGRealMatrix
+  };
+
+  virtual T run(RegContainer SUPPRESS_UNUSED * reg, OGLogicalMatrix const SUPPRESS_UNUSED * arg) const
+  {
+    // impl convert and run for type OGLogicalMatrix
+  };
+
+  virtual T run(RegContainer SUPPRESS_UNUSED * reg, OGComplexMatrix const SUPPRESS_UNUSED * arg) const
+  {
+    // impl convert and run for type OGComplexMatrix
+  };
+
+  virtual T run(RegContainer SUPPRESS_UNUSED * reg, OGRealDiagonalMatrix const SUPPRESS_UNUSED * arg) const
+  {
+    // impl convert and run for type OGRealDiagonalMatrix
+  };
+
+  virtual T run(RegContainer SUPPRESS_UNUSED * reg, OGComplexDiagonalMatrix const SUPPRESS_UNUSED * arg) const
+  {
+    // impl convert and run for type OGComplexDiagonalMatrix
+  };
+
+  virtual T run(RegContainer SUPPRESS_UNUSED * reg, OGRealSparseMatrix const SUPPRESS_UNUSED * arg) const
+  {
+    // impl convert and run for type OGRealSparseMatrix
+  };
+
+  virtual T run(RegContainer SUPPRESS_UNUSED * reg, OGComplexSparseMatrix const SUPPRESS_UNUSED * arg) const
+  {
+    // impl convert and run for type OGComplexSparseMatrix
+  };
 };
 
 
@@ -66,7 +178,7 @@ public:
 virtual ~DispatchBinaryOp(){};
  
 // will run the operation
-T eval(RegContainer SUPPRESS_UNUSED * reg0, OGTerminal const SUPPRESS_UNUSED * arg0, OGTerminal const SUPPRESS_UNUSED * arg1) const
+T eval(RegContainer SUPPRESS_UNUSED * reg0, OGTerminal const *arg0, OGTerminal const *arg1) const
 {
   ExprType_t arg0ID = arg0->getType();
   ExprType_t arg1ID = arg1->getType();
@@ -1061,6 +1173,15 @@ public:
   virtual void run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexMatrix const SUPPRESS_UNUSED * arg0, OGComplexMatrix const SUPPRESS_UNUSED * arg1) const override;
   virtual void run(RegContainer SUPPRESS_UNUSED * reg0, OGRealMatrix const SUPPRESS_UNUSED * arg0, OGRealMatrix const SUPPRESS_UNUSED * arg1) const override;
   virtual void run(RegContainer SUPPRESS_UNUSED * reg0, OGRealScalar const SUPPRESS_UNUSED * arg0, OGRealScalar const SUPPRESS_UNUSED * arg1) const override;
+};
+
+// typedef the void dispatch of a unary operation
+typedef DispatchUnaryOp<void> DispatchVoidUnaryOp;
+
+class NegateRunner: public DispatchVoidUnaryOp, private Uncopyable
+{
+  public:
+    virtual void run(RegContainer* reg, const OGRealScalar* arg) const override;
 };
 
 } // namespace librdag

--- a/src/java/src/main/java/com/opengamma/longdog/materialisers/Materialisers.java
+++ b/src/java/src/main/java/com/opengamma/longdog/materialisers/Materialisers.java
@@ -44,11 +44,6 @@ public class Materialisers {
    */
   public static double[][] toDoubleArrayOfArrays(OGNumeric arg0) {
     Catchers.catchNullFromArgList(arg0, 1);
-    System.out.println("tree walking");
-    StringBuffer buf = new StringBuffer();
-    printTree(arg0, buf, 0);
-    System.out.println(buf.toString());
-    System.out.println("tree walking done");
     return materialiseToJDoubleArrayOfArrays(arg0);
   }
 

--- a/src/java/src/test/java/com/opengamma/longdog/materialisers/TestNegateMaterialise.java
+++ b/src/java/src/test/java/com/opengamma/longdog/materialisers/TestNegateMaterialise.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) 2013 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+package com.opengamma.longdog.materialisers;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.opengamma.longdog.datacontainers.OGNumeric;
+import com.opengamma.longdog.datacontainers.scalar.OGRealScalar;
+import com.opengamma.longdog.exceptions.MathsException;
+import com.opengamma.longdog.nodes.NEGATE;
+import com.opengamma.longdog.testhelpers.ArraysHelpers;
+
+public class TestNegateMaterialise {
+
+  @DataProvider
+  public Object[][] dataContainer() {
+    Object[][] obj = new Object[3][2];
+
+
+    obj[0][0] = new NEGATE(new OGRealScalar(1.0));
+    obj[0][1] = new OGRealScalar(-1.0);
+
+    obj[1][0] = new NEGATE(new OGRealScalar(-1.0));
+    obj[1][1] = new OGRealScalar(1.0);
+
+    obj[2][0] = new NEGATE(new OGRealScalar(0.0));
+    obj[2][1] = new OGRealScalar(-0.0);
+
+    return obj;
+  };
+
+  @Test(dataProvider = "dataContainer")
+  public void materialiseToJDoubleArray(OGNumeric input, OGRealScalar expected) {
+    double[][] answer = Materialisers.toDoubleArrayOfArrays(input);
+    if (!ArraysHelpers.ArraysEquals(new double[][] {expected.getData()}, answer)) {
+      throw new MathsException("Arrays not equal");
+    }
+  }
+
+  @Test(dataProvider = "dataContainer")
+  public void materialiseToOGTerminal(OGNumeric input, OGRealScalar expected) {
+    OGRealScalar answer = (OGRealScalar) Materialisers.toOGTerminal(input);
+    if (answer.getData().length != 1) {
+      throw new MathsException("Scalar holding more than one value");
+    }
+    if (answer.getData()[0] != expected.getData()[0]) {
+      throw new MathsException("Arrays not equal");
+    }
+  }
+
+}

--- a/src/librdag/dispatch.cc
+++ b/src/librdag/dispatch.cc
@@ -14,6 +14,7 @@
 
 namespace librdag {
 
+template class DispatchUnaryOp<void>;
 template class DispatchBinaryOp<void>;
 
 void PlusRunner::run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexMatrix const SUPPRESS_UNUSED * arg0, OGComplexMatrix const SUPPRESS_UNUSED * arg1) const
@@ -26,7 +27,7 @@ void PlusRunner::run(RegContainer SUPPRESS_UNUSED * reg0, OGRealMatrix const SUP
   
 }
 
-void PlusRunner::run(RegContainer SUPPRESS_UNUSED * reg0, OGRealScalar const SUPPRESS_UNUSED * arg0, OGRealScalar const SUPPRESS_UNUSED * arg1) const 
+void PlusRunner::run(RegContainer* reg0, OGRealScalar const * arg0, OGRealScalar const * arg1) const
 {
   // impl convert and run for types OGRealScalar and OGRealScalar 
   cout << "In virtual overridden PlusRunner T run() REAL REAL " << std::endl;
@@ -34,19 +35,26 @@ void PlusRunner::run(RegContainer SUPPRESS_UNUSED * reg0, OGRealScalar const SUP
   reg0->push_back(ret);
 }
   
-
+void NegateRunner::run(RegContainer* reg, const OGRealScalar* arg) const
+{
+  cout << "IN Negate runner." << endl;
+  const OGRealScalar* ret = new OGRealScalar(-(arg->getValue()));
+  reg->push_back(ret);
+}
 
 Dispatcher::Dispatcher()
 {
-    this->_PlusRunner = new PlusRunner();     
+    _PlusRunner = new PlusRunner();
+    _NegateRunner = new NegateRunner();
 }
   
   
 Dispatcher::~Dispatcher(){
-  delete this->_PlusRunner;
+  delete _PlusRunner;
+  delete _NegateRunner;
 }
   
-void Dispatcher::dispatch(OGNumeric const SUPPRESS_UNUSED *thing) const
+void Dispatcher::dispatch(OGNumeric const *thing) const
 {
     cout << "Dispatching..." << std::endl;
     ExprType_t ID = thing->getType();
@@ -166,7 +174,7 @@ void Dispatcher::dispatch(OGComplexSparseMatrix const SUPPRESS_UNUSED * thing) c
   
 }
   
-void Dispatcher::dispatch(PLUS const SUPPRESS_UNUSED *thing) const {
+void Dispatcher::dispatch(PLUS const *thing) const {
       cout << "ABOUT TO DISPATCH A PLUS OP" << std::endl;
       const ArgContainer * args = thing->getArgs();
       const RegContainer * regs = thing->getRegs();
@@ -177,6 +185,10 @@ void Dispatcher::dispatch(PLUS const SUPPRESS_UNUSED *thing) const {
 
 void Dispatcher::dispatch(NEGATE const SUPPRESS_UNUSED *thing) const {
       cout << "ABOUT TO DISPATCH A NEGATE OP" << std::endl;
+      const ArgContainer* args = thing->getArgs();
+      const RegContainer* regs = thing->getRegs();
+      const OGNumeric *arg = (*args)[0];
+      _NegateRunner->eval(const_cast<RegContainer *>(regs), arg->asOGTerminal());
 }
 
 void Dispatcher::dispatch(COPY const SUPPRESS_UNUSED *thing) const {

--- a/src/librdag/dispatch.cc
+++ b/src/librdag/dispatch.cc
@@ -35,11 +35,38 @@ void PlusRunner::run(RegContainer* reg0, OGRealScalar const * arg0, OGRealScalar
   reg0->push_back(ret);
 }
   
-void NegateRunner::run(RegContainer* reg, const OGRealScalar* arg) const
+void
+NegateRunner::run(RegContainer* reg, const OGRealScalar* arg) const
 {
   cout << "IN Negate runner." << endl;
   const OGRealScalar* ret = new OGRealScalar(-(arg->getValue()));
   reg->push_back(ret);
+}
+
+void
+NegateRunner::run(RegContainer *reg, const OGRealMatrix *arg) const
+{
+  real16* data = arg->getData();
+  int datalen = arg->getDatalen();
+  real16* newData = new real16[datalen];
+  for (int i = 0; i < datalen; ++i)
+  {
+    newData[i] = -data[i];
+  }
+  reg->push_back(new OGRealMatrix(newData, arg->getRows(), arg->getCols()));
+}
+
+void
+NegateRunner::run(RegContainer SUPPRESS_UNUSED *reg, const OGComplexMatrix SUPPRESS_UNUSED *arg) const
+{
+  complex16* data = arg->getData();
+  int datalen = arg->getDatalen();
+  complex16* newData = new complex16[datalen];
+  for (int i = 0; i < datalen; ++i)
+  {
+    newData[i] = -data[i];
+  }
+  reg->push_back(new OGComplexMatrix(data, arg->getRows(), arg->getCols()));
 }
 
 Dispatcher::Dispatcher()

--- a/src/librdag/entrypt.cc
+++ b/src/librdag/entrypt.cc
@@ -133,11 +133,6 @@ void Walker::talkandwalk(librdag::OGNumeric const * numeric_expr_types)
 const OGTerminal*
 entrypt(const OGNumeric* expr)
 {
-  printf("Accessing DAG walker.\n");
-  Walker * walker = new Walker();
-  walker->walk((librdag::OGNumeric *) expr);
-  delete walker;
-  printf("Returning from DAG walker.\n");
   /* Return a copy of the node that was passed. The reason for doing this is that we eventually
    * expect entrypt to return the register for the result. For now, returning a copy of the tree
    * means that if a terminal is passed in, we don't get a surprise when we delete both the result
@@ -155,10 +150,10 @@ entrypt(const OGNumeric* expr)
     // Expressions would have been null from the cast anyway
     const OGExpr * asOGExpr = expr->asOGExpr();
     Dispatcher * disp = new Dispatcher();
-    printf("Dispatching from entrypt\n");
     disp->dispatch(asOGExpr);
     const RegContainer * reg = asOGExpr->getRegs();
-    const OGNumeric * answer = (*reg)[0];
+    // Make a copy of the result because it gets blown away by the deletion of the tree
+    const OGNumeric * answer = (*reg)[0]->copy();
     answer->debug_print();
     const OGTerminal * returnTerm = answer->asOGTerminal();
     if(returnTerm==nullptr)
@@ -166,7 +161,6 @@ entrypt(const OGNumeric* expr)
       throw rdag_error("Evaluated terminal is not casting asOGTerminal correctly.");
     }
     delete disp;
-    printf("Dispatch deleted\n");
     return returnTerm;
   }
 }

--- a/src/librdag/test/check_entrypt.cc
+++ b/src/librdag/test/check_entrypt.cc
@@ -42,3 +42,31 @@ TEST(EntryptTest, ExprResultNull)
   delete result;
   delete plus;
 }
+
+class EntryptNegateTest: public ::testing::TestWithParam<std::pair<const OGNumeric*, const OGNumeric*> > {};
+
+TEST_P(EntryptNegateTest, Running)
+{
+  const NEGATE* node = GetParam().first->asNEGATE();
+  const OGRealScalar* expectedResult = GetParam().second->asOGRealScalar();
+  const OGNumeric *result = entrypt(node);
+  const OGRealScalar* resultScalar = result->asOGRealScalar();
+  ASSERT_NE(resultScalar, nullptr);
+  EXPECT_EQ(resultScalar->getValue(), expectedResult->getValue());
+  delete node;
+  delete expectedResult;
+  delete result;
+}
+
+pair<const OGNumeric*, const OGNumeric*> negatepair(double v)
+{
+  ArgContainer* args = new ArgContainer();
+  args->push_back(new OGRealScalar(v));
+  const OGNumeric* negate = new NEGATE(args);
+  const OGNumeric* expected = new OGRealScalar(-v);
+  return pair<const OGNumeric*, const OGNumeric*>(negate, expected);
+}
+
+pair<const OGNumeric*, const OGNumeric*> negates[] = { negatepair(1.0), negatepair(-1.0), negatepair(0.0) };
+
+INSTANTIATE_TEST_CASE_P(ValueParam, EntryptNegateTest, ::testing::ValuesIn(negates));

--- a/src/librdag/test/check_entrypt.cc
+++ b/src/librdag/test/check_entrypt.cc
@@ -39,5 +39,6 @@ TEST(EntryptTest, ExprResultNull)
   OGExpr *plus = new PLUS(args);
   const OGTerminal* result = entrypt(plus);
   EXPECT_EQ(result->asOGRealScalar()->getValue(), 5);
+  delete result;
   delete plus;
 }

--- a/src/librdag/test/check_entrypt.cc
+++ b/src/librdag/test/check_entrypt.cc
@@ -67,6 +67,19 @@ pair<const OGNumeric*, const OGNumeric*> negatepair(double v)
   return pair<const OGNumeric*, const OGNumeric*>(negate, expected);
 }
 
+double realData[6] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 };
+double realNegData[6] = { -1.0, -2.0, -3.0, -4.0, -5.0, -6.0 };
+
+pair<const OGNumeric*, const OGNumeric*> negaterealmatrix()
+{
+  const OGTerminal* ogrealmatrix = new OGRealMatrix(realData, 2, 3);
+  ArgContainer* arg = new ArgContainer();
+  arg->push_back(ogrealmatrix);
+  const OGNumeric* negate = new NEGATE(arg);
+  const OGTerminal* ogrealnegmatrix = new OGRealMatrix(realNegData, 2, 3);
+  return pair<const OGNumeric*, const OGNumeric*>(negate, ogrealnegmatrix);
+}
+
 pair<const OGNumeric*, const OGNumeric*> negates[] = { negatepair(1.0), negatepair(-1.0), negatepair(0.0) };
 
 INSTANTIATE_TEST_CASE_P(ValueParam, EntryptNegateTest, ::testing::ValuesIn(negates));


### PR DESCRIPTION
Dispatch for unary operations is modelled on the dispatch for binary operations.

Its use is demonstrated with the implementation of NEGATE materialisation which is tested from both Java and C++.

This PR contains some of the removal of code that prints out trees as the PR for MAT-228, also to quieten the output down now that we're beginning to execute trees rather than just looking at them.

Buildbot pass: http://devmaths-lx-1:8011/builders/nyqwk2-testing/builds/385
Librdag coverage: 90.3% (2% higher than current master)
jshim coverage: 20.6% (equal to current master)
