### PR TITLE
[MAT-251] Code done. Quitened equals method debug statements. Added tests.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,9 @@ set(longdog_VERSION
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules ${CMAKE_MODULE_PATH})
 
 # tweak flags
-set(FFAST_MATH_SAFE "-fno-math-errno -ffinite-math-only -fno-rounding-math -fno-signaling-nans -fcx-limited-range") # -funsafe-math-optimizations is missing as it messes with the FPU control word which can cause segfaults when running through the JNI interface 
+set(FFAST_MATH_SAFE "-fno-math-errno  -fno-rounding-math -fno-signaling-nans -fcx-limited-range")
+# -funsafe-math-optimizations is missing as it messes with the FPU control word which can cause segfaults when running through the JNI interface
+# -ffinite-math-only is missing as it messes with NaN and Inf in ways that break comparison behaviours
 
 set(CMAKE_C_FLAGS "-std=c99 -Wall -Werror -Wextra -pedantic ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_C_FLAGS}")
 set(CMAKE_C_FLAGS_DEBUG "-DDEBUG ${CMAKE_C_FLAGS_DEBUG}")

--- a/include/equals.hh
+++ b/include/equals.hh
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2013 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+#ifndef _EQUALS_HH
+#define _EQUALS_HH
+#include <cfloat>
+#include "numerictypes.hh"
+
+namespace librdag {
+
+/**
+ * Bitwise equals, equals via memcmp()
+ */
+template <typename T>
+bool ArrayBitEquals(T * arr1, T * arr2, int count);
+
+extern template bool
+ArrayBitEquals(real16 * arr1, real16 * arr2, int count);
+
+extern template bool
+ArrayBitEquals(complex16 * arr1, complex16 * arr2, int count);
+
+extern template bool
+ArrayBitEquals(int * arr1, int * arr2, int count);
+
+/**
+ * Fuzzy equals, equals within tolerance specified
+ */
+template<typename T>
+bool ArrayFuzzyEquals(T * arr1, T * arr2, int count, real16 maxabserror = DBL_EPSILON, real16 maxrelerror = 10*DBL_EPSILON);
+
+extern template bool
+ArrayFuzzyEquals(real16 * arr1, real16 * arr2, int count, real16 maxabserror, real16 maxrelerror);
+extern template bool
+ArrayFuzzyEquals(complex16 * arr1, complex16 * arr2, int count, real16 maxabserror, real16 maxrelerror);
+
+bool SingleValueFuzzyEquals(real16 val1, real16 val2, real16 maxabserror = 10*DBL_EPSILON, real16 maxrelerror = 10*DBL_EPSILON);
+bool SingleValueFuzzyEquals(complex16 val1, complex16 val2, real16 maxabserror = DBL_EPSILON, real16 maxrelerror = 10*DBL_EPSILON);
+
+}
+
+#endif // _EQUALS_HH

--- a/include/numerictypes.hh
+++ b/include/numerictypes.hh
@@ -16,5 +16,19 @@ typedef complex<float> complex8;
 typedef double real16;
 typedef float real8;
 
+namespace librdag {
+
+real16 getNaN();
+complex16 getComplexNaN();
+
+real16 getPosInf();
+real16 getNegInf();
+complex16 getPosPosComplexInf();
+complex16 getPosNegComplexInf();
+complex16 getNegPosComplexInf();
+complex16 getNegNegComplexInf();
+
+}
+
 
 #endif /* NUMERICTYPES_HH_ */

--- a/src/librdag/CMakeLists.txt
+++ b/src/librdag/CMakeLists.txt
@@ -10,7 +10,7 @@ SET(CMAKE_FC_FLAGS  "${CMAKE_FC_FLAGS} ${GCC_COVERAGE_COMPILE_FLAGS} -cpp" )
 SET(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -Wl,--no-undefined")
 SET(CMAKE_CC_FLAGS  "${CMAKE_CC_FLAGS} -Wl,--no-undefined -frepo")
  
-add_library(rdag SHARED entrypt.cc expression.cc execution.cc terminal.cc containers.cc numeric.cc register.cc dispatch.cc)
+add_library(rdag SHARED entrypt.cc expression.cc execution.cc terminal.cc containers.cc numeric.cc register.cc dispatch.cc equals.cc numerictypes.cc)
 
 set_target_properties(rdag PROPERTIES SOVERSION ${longdog_VERSION_MAJOR} VERSION ${longdog_VERSION})
 install(TARGETS rdag DESTINATION lib)

--- a/src/librdag/equals.cc
+++ b/src/librdag/equals.cc
@@ -57,18 +57,14 @@ bool SingleValueFuzzyEquals(real16 val1, real16 val2, real16 maxabserror, real16
 {
 
 #ifdef __LOCALDEBUG
-#ifdef DEBUG
   DEBUG_PRINT("FuzzyEquals: Comparing %24.16f and %24.16f\n", val1,val2);
-#endif
 #endif
 
   // IEEE754 nans not comparable, their relation is considered "unordered" sec 5.7.
   if(std::isnan(val1))
   {
 #ifdef __LOCALDEBUG
-#ifdef DEBUG
   DEBUG_PRINT("FuzzyEquals: Failed as value 1 is NaN\n");
-#endif
 #endif
     return false;
   }
@@ -76,9 +72,7 @@ bool SingleValueFuzzyEquals(real16 val1, real16 val2, real16 maxabserror, real16
   if(std::isnan(val2))
   {
 #ifdef __LOCALDEBUG
-#ifdef DEBUG
   DEBUG_PRINT("FuzzyEquals: Failed as value 2 is NaN\n");
-#endif
 #endif
     return false;
   }
@@ -115,16 +109,12 @@ bool SingleValueFuzzyEquals(real16 val1, real16 val2, real16 maxabserror, real16
   if(maxabserror>std::fabs(diff))
   {
 #ifdef __LOCALDEBUG
-#ifdef DEBUG
   DEBUG_PRINT("FuzzyEquals: Match as below diff bounds. maxabserror > diff. (%24.16f >  %24.16f)\n", maxabserror, std::abs(diff));
-#endif
 #endif
     return true;
   }
 #ifdef __LOCALDEBUG
-#ifdef DEBUG
   DEBUG_PRINT("FuzzyEquals: Failed as diff > maxabserror. (%24.16f >  %24.16f)\n", std::abs(diff), maxabserror);
-#endif
 #endif
 
   // check if they are within a relative error bound, div difference by largest of the 2
@@ -133,17 +123,13 @@ bool SingleValueFuzzyEquals(real16 val1, real16 val2, real16 maxabserror, real16
   if(maxrelerror > relerror)
   {
 #ifdef __LOCALDEBUG
-#ifdef DEBUG
   DEBUG_PRINT("FuzzyEquals: Match as maxrelerror > relerror. (%24.16f >  %24.16f)\n", maxrelerror, relerror);
-#endif
 #endif
     return true;
   };
 
 #ifdef __LOCALDEBUG
-#ifdef DEBUG
   DEBUG_PRINT("FuzzyEquals: Fail as relerror > maxrelerror. (%24.16f >  %24.16f)\n", relerror, maxrelerror);
-#endif
 #endif
 
   return false;

--- a/src/librdag/equals.cc
+++ b/src/librdag/equals.cc
@@ -83,7 +83,7 @@ bool SingleValueFuzzyEquals(real16 val1, real16 val2, real16 maxabserror, real16
     return false;
   }
 
-// deal with infs
+// deal with infs in debug mode
 #ifdef __LOCALDEBUG
 #ifdef DEBUG
   bool val1isinf = std::isinf(val1);
@@ -103,16 +103,12 @@ bool SingleValueFuzzyEquals(real16 val1, real16 val2, real16 maxabserror, real16
     return false;
   }
 #endif
-#else
-  if(val1 == val2)
-  {
-    return true; // (+/-)inf compares ==
-  }
 #endif
 
-  // check if they are both 0, else the rel error gets stuck with /0
-  if((val1==0.e0)&&(val2==0.e0)) return true;
-
+  if(val1 == val2)
+  {
+      return true; // (+/-)inf compares == as does (+/-)0.e0
+  }
 
   // check if they are below max absolute error bounds (i.e. small in the first place)
   real16 diff = (val1-val2);

--- a/src/librdag/equals.cc
+++ b/src/librdag/equals.cc
@@ -1,0 +1,164 @@
+/**
+ * Copyright (C) 2013 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+#include <assert.h>
+#include <string.h>
+#include "terminal.hh"
+#include "warningmacros.h"
+#include "equals.hh"
+#include "debug.h"
+#include <iostream>
+
+using namespace std;
+namespace librdag {
+
+template <typename T> bool ArrayBitEquals(T * arr1, T * arr2, int count)
+{
+  assert(count>=0);
+  size_t len = count*sizeof(T);
+  if(!memcmp(arr1,arr2,len))
+  {
+    return true;
+  }
+  return false;
+}
+
+template bool ArrayBitEquals(real16 * arr1, real16 * arr2, int count);
+template bool ArrayBitEquals(complex16 * arr1, complex16 * arr2, int count);
+template bool ArrayBitEquals(int * arr1, int * arr2, int count);
+
+template <typename T> bool ArrayFuzzyEquals(T * arr1, T * arr2, int count, real16 maxabserror, real16 maxrelerror)
+{
+  assert(count>=0);
+  for(int i=0;i<count;i++)
+  {
+    if(!SingleValueFuzzyEquals(arr1[i], arr2[i], maxabserror, maxrelerror)) return false;
+  }
+  // all data ok
+  return true;
+}
+
+template bool ArrayFuzzyEquals(real16 * arr1, real16 * arr2, int count, real16 maxabserror, real16 maxrelerror);
+template bool ArrayFuzzyEquals(complex16 * arr1, complex16 * arr2, int count, real16 maxabserror, real16 maxrelerror);
+
+
+/**
+ * Checks if two double precision floating point numbers are approximately "equal"
+ * The parameter "maxabserror" determines the minimum threshold for "equal" in terms
+ * of the two numbers being very small in magnitude.
+ * The parameter "maxrelerror" determines the minimum threshold for "equal" in terms
+ * of the relative magnitude of the numbers. i.e. invariant of the magnitude of the numbers
+ * what is the maximum level of magnitude difference acceptable.
+ */
+bool SingleValueFuzzyEquals(real16 val1, real16 val2, real16 maxabserror, real16 maxrelerror)
+{
+
+#ifdef __LOCALDEBUG
+#ifdef DEBUG
+  DEBUG_PRINT("FuzzyEquals: Comparing %24.16f and %24.16f\n", val1,val2);
+#endif
+#endif
+
+  // IEEE754 nans not comparable, their relation is considered "unordered" sec 5.7.
+  if(std::isnan(val1))
+  {
+#ifdef __LOCALDEBUG
+#ifdef DEBUG
+  DEBUG_PRINT("FuzzyEquals: Failed as value 1 is NaN\n");
+#endif
+#endif
+    return false;
+  }
+
+  if(std::isnan(val2))
+  {
+#ifdef __LOCALDEBUG
+#ifdef DEBUG
+  DEBUG_PRINT("FuzzyEquals: Failed as value 2 is NaN\n");
+#endif
+#endif
+    return false;
+  }
+
+// deal with infs
+#ifdef __LOCALDEBUG
+#ifdef DEBUG
+  bool val1isinf = std::isinf(val1);
+  bool val2isinf = std::isinf(val2);
+  if(val1isinf||val2isinf)
+  {
+    if(val1isinf&&val2isinf)
+    {
+      if(signbit(val2)==signbit(val1))
+      {
+        DEBUG_PRINT("FuzzyEquals: Inf Branch. Success as both inf of same sign\n");
+        return true;
+      }
+    }
+
+  DEBUG_PRINT("FuzzyEquals: Inf Branch. Fail, non matching infs\n");
+    return false;
+  }
+#endif
+#else
+  if(val1 == val2)
+  {
+    return true; // (+/-)inf compares ==
+  }
+#endif
+
+  // check if they are both 0, else the rel error gets stuck with /0
+  if((val1==0.e0)&&(val2==0.e0)) return true;
+
+
+  // check if they are below max absolute error bounds (i.e. small in the first place)
+  real16 diff = (val1-val2);
+  if(maxabserror>std::fabs(diff))
+  {
+#ifdef __LOCALDEBUG
+#ifdef DEBUG
+  DEBUG_PRINT("FuzzyEquals: Match as below diff bounds. maxabserror > diff. (%24.16f >  %24.16f)\n", maxabserror, std::abs(diff));
+#endif
+#endif
+    return true;
+  }
+#ifdef __LOCALDEBUG
+#ifdef DEBUG
+  DEBUG_PRINT("FuzzyEquals: Failed as diff > maxabserror. (%24.16f >  %24.16f)\n", std::abs(diff), maxabserror);
+#endif
+#endif
+
+  // check if they are within a relative error bound, div difference by largest of the 2
+  real16 divisor = std::fabs(val1) > std::fabs(val2) ? val1 : val2;
+  real16 relerror = std::fabs(diff/divisor);
+  if(maxrelerror > relerror)
+  {
+#ifdef __LOCALDEBUG
+#ifdef DEBUG
+  DEBUG_PRINT("FuzzyEquals: Match as maxrelerror > relerror. (%24.16f >  %24.16f)\n", maxrelerror, relerror);
+#endif
+#endif
+    return true;
+  };
+
+#ifdef __LOCALDEBUG
+#ifdef DEBUG
+  DEBUG_PRINT("FuzzyEquals: Fail as relerror > maxrelerror. (%24.16f >  %24.16f)\n", relerror, maxrelerror);
+#endif
+#endif
+
+  return false;
+}
+
+bool SingleValueFuzzyEquals(complex16 val1, complex16 val2, real16 maxabserror, real16 maxrelerror)
+{
+  if(!SingleValueFuzzyEquals(std::real(val1), std::real(val2) , maxabserror, maxrelerror)) return false;
+  if(!SingleValueFuzzyEquals(std::imag(val1), std::imag(val2) , maxabserror, maxrelerror)) return false;
+  // all ok
+  return true;
+}
+
+}

--- a/src/librdag/numerictypes.cc
+++ b/src/librdag/numerictypes.cc
@@ -1,0 +1,77 @@
+/**
+ * Copyright (C) 2013 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+#include "numerictypes.hh"
+
+using namespace std;
+
+namespace librdag {
+
+real16 getNaN()
+{
+  union {
+    real16 d;
+    unsigned long long int i;
+  } nanval;
+  nanval.i = 0x7FF1010101010101;
+  return nanval.d;
+}
+
+complex16 getComplexNaN()
+{
+  union {
+    real16 d;
+    unsigned long long int i;
+  } nanval1, nanval2;
+  nanval1.i = 0x7FFDEAD101010101;
+  nanval2.i = 0x7FFDEAD202020202;
+  return complex16(nanval1.d, nanval2.d);
+}
+
+real16 getPosInf()
+{
+  union {
+    real16 d;
+    unsigned long long int i;
+  } val;
+  val.i = 0x7FF0000000000000;
+  return val.d;
+}
+
+real16 getNegInf()
+{
+  union {
+    real16 d;
+    unsigned long long int i;
+  } val;
+  val.i = 0xFFF0000000000000;
+  return val.d;
+}
+
+complex16 getPosPosComplexInf()
+{
+ complex16 val = {getPosInf(), getPosInf()};
+ return val;
+}
+
+complex16 getPosNegComplexInf()
+{
+ complex16 val = {getPosInf(), getNegInf()};
+ return val;
+}
+
+complex16 getNegPosComplexInf()
+{
+ complex16 val = {getNegInf(), getPosInf()};
+ return val;
+}
+
+complex16 getNegNegComplexInf()
+{
+   complex16 val = {getNegInf(), getNegInf()};
+ return val;
+}
+
+}

--- a/src/librdag/register.cc
+++ b/src/librdag/register.cc
@@ -63,16 +63,6 @@ Register::decRef()
  * OGRealScalarRegister
  */
 
-real16 getNaN()
-{
-  union {
-    real16 d;
-    unsigned long long int i;
-  } nanval;
-  nanval.i = 0x7FF1010101010101;
-  return nanval.d;
-}
-
 OGRealScalarRegister::OGRealScalarRegister(): OGRealScalar(getNaN()), Register() {}
 
 void
@@ -90,18 +80,6 @@ OGRealScalarRegister::copy() const
 /**
  * OGComplexScalarRegister
  */
-
-complex16 getComplexNaN()
-{
-  union {
-    real16 d;
-    unsigned long long int i;
-  } nanval1, nanval2;
-  nanval1.i = 0x7FFDEAD101010101;
-  nanval2.i = 0x7FFDEAD202020202;
-  return complex16(nanval1.d, nanval2.d);
-}
-
 OGComplexScalarRegister::OGComplexScalarRegister(): OGComplexScalar(getComplexNaN()), Register() {}
 
 void

--- a/src/librdag/test/CMakeLists.txt
+++ b/src/librdag/test/CMakeLists.txt
@@ -9,7 +9,7 @@ SET(CMAKE_FC_FLAGS  "${CMAKE_FC_FLAGS} ${GCC_COVERAGE_COMPILE_FLAGS} -cpp" )
 
 link_directories(${longdog_BINARY_DIR}/src/librdag})
 
-set(TESTS check_expressions check_containers check_execution check_rtti check_terminals check_register check_entrypt check_dispatch)
+set(TESTS check_expressions check_containers check_execution check_rtti check_terminals check_register check_entrypt check_dispatch check_equals check_numerictypes)
 
 # Compile and link each test and add to the list of tests
 foreach(TEST ${TESTS})

--- a/src/librdag/test/check_equals.cc
+++ b/src/librdag/test/check_equals.cc
@@ -1,0 +1,540 @@
+/**
+ * Copyright (C) 2013 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+#include "gtest/gtest.h"
+#include "warningmacros.h"
+#include "equals.hh"
+#include "terminal.hh"
+#include "register.hh"
+#include <cfloat>
+#include <iostream>
+#include <cstdint>
+
+using namespace std;
+using namespace librdag;
+
+TEST(EqualsTest, SingleValueFuzzyEqualsReal16) {
+  real16 NaN = getNaN();
+  real16 pinf = getPosInf();
+  real16 ninf = getNegInf();
+
+  union
+  {
+    uint64_t i;
+    real16 d;
+  } neg0;
+
+  neg0.i = 8000000000000000;
+
+  // NaN branch
+  ASSERT_FALSE(SingleValueFuzzyEquals(NaN,NaN));
+  ASSERT_FALSE(SingleValueFuzzyEquals(NaN,1));
+  ASSERT_FALSE(SingleValueFuzzyEquals(1,NaN));
+
+  // Inf branches
+  ASSERT_TRUE(SingleValueFuzzyEquals(pinf,pinf));
+  ASSERT_TRUE(SingleValueFuzzyEquals(ninf,ninf));
+  ASSERT_FALSE(SingleValueFuzzyEquals(pinf,ninf));
+  ASSERT_FALSE(SingleValueFuzzyEquals(ninf,pinf));
+  ASSERT_FALSE(SingleValueFuzzyEquals(pinf,DBL_MAX));
+  ASSERT_FALSE(SingleValueFuzzyEquals(ninf,-DBL_MAX));
+
+  // val 0 branches
+  ASSERT_TRUE(SingleValueFuzzyEquals(0.e0,0.e0));
+  ASSERT_TRUE(SingleValueFuzzyEquals(0.e0,neg0.d));
+  ASSERT_TRUE(SingleValueFuzzyEquals(neg0.d,0.e0));
+  ASSERT_TRUE(SingleValueFuzzyEquals(neg0.d,neg0.d));
+
+  // same value as it trips the return true on "difference less than abs tol" branch
+  ASSERT_TRUE(SingleValueFuzzyEquals(DBL_EPSILON,2.e0*DBL_EPSILON));
+
+  // same value as it trips the return true on "difference less than relative error" branch
+  ASSERT_TRUE(SingleValueFuzzyEquals(1.e308,9.99999999999999e0*1.e307));
+
+  // fail, just plain different
+  ASSERT_FALSE(SingleValueFuzzyEquals(1.e0,2.e0));
+
+}
+
+TEST(EqualsTest, SingleValueFuzzyEqualsComplex16) {
+  ASSERT_TRUE(SingleValueFuzzyEquals({1,10},{1,10}));
+  ASSERT_FALSE(SingleValueFuzzyEquals({1,10},{5,10}));
+  ASSERT_FALSE(SingleValueFuzzyEquals({1,10},{1,50}));
+}
+
+
+TEST(EqualsTest, ArrayBitEquals_real16) {
+
+  int len = 4;
+  real16 * data1 = new real16[4] {1.0e0,2.0e0,3.0e0,4.0e0};
+  real16 * data2 = new real16[4] {1.0e0,2.0e0,3.0e0,4.0e0};
+  real16 * data3 = new real16[4] {-1.0e0,2.0e0,3.0e0,4.0e0};
+
+  ASSERT_TRUE(ArrayBitEquals(data1, data2, len));
+  ASSERT_FALSE(ArrayBitEquals(data1, data3, len));
+
+  delete [] data1;
+  delete [] data2;
+  delete [] data3;
+
+}
+
+TEST(EqualsTest, ArrayFuzzyEquals_real16) {
+
+  int len = 4;
+  real16 * data = new real16[4] {1.0e0,2.0e0,3.0e0,4.0e0};
+  real16 * same = new real16[4] {1.0e0,2.0e0,3.0e0,4.0e0};
+  real16 * diff  = new  real16[4]{-1.0e0,2.0e0,3.0e0,4.0e0};
+
+  ASSERT_FALSE(ArrayFuzzyEquals(data, diff, len));
+  ASSERT_TRUE(ArrayFuzzyEquals(data, same, len));
+
+  delete [] data;
+  delete [] same;
+  delete [] diff;
+
+}
+
+TEST(EqualsTest, ArrayBitEquals_complex16) {
+
+  int len = 4;
+  complex16 * data1 = new complex16[4] {{1.0e0,10.0e0},{2.0e0,20.0e0},{3.0e0,30.0e0},{4.0e0,40.0e0}};
+  complex16 * data2 = new complex16[4] {{1.0e0,10.0e0},{2.0e0,20.0e0},{3.0e0,30.0e0},{4.0e0,40.0e0}};
+  complex16 * data3 = new complex16[4] {{-1.0e0,10.0e0},{2.0e0,20.0e0},{3.0e0,30.0e0},{4.0e0,40.0e0}};
+
+  ASSERT_TRUE(ArrayBitEquals(data1, data2, len));
+  ASSERT_FALSE(ArrayBitEquals(data1, data3, len));
+
+  delete [] data1;
+  delete [] data2;
+  delete [] data3;
+
+}
+
+TEST(EqualsTest, ArrayFuzzyEquals_complex16) {
+
+  int len = 4;
+  complex16 * data1 = new complex16[4] {{1.0e0,10.0e0},{2.0e0,20.0e0},{3.0e0,30.0e0},{4.0e0,40.0e0}};
+  complex16 * data2 = new complex16[4] {{1.0e0,10.0e0},{2.0e0,20.0e0},{3.0e0,30.0e0},{4.0e0,40.0e0}};
+  complex16 * data3 = new complex16[4] {{-1.0e0,10.0e0},{2.0e0,20.0e0},{3.0e0,30.0e0},{4.0e0,40.0e0}};
+
+  ASSERT_TRUE(ArrayFuzzyEquals(data1, data2, len));
+  ASSERT_FALSE(ArrayFuzzyEquals(data1, data3, len));
+
+  delete [] data1;
+  delete [] data2;
+  delete [] data3;
+
+}
+
+TEST(EqualsTest, ArrayBitEquals_int) {
+
+  int len = 4;
+  int * data1 = new int[4] {1,2,3,4};
+  int * data2 = new int[4] {1,2,3,4};
+  int * data3 = new int[4] {-1,2,3,4};
+
+  ASSERT_TRUE(ArrayBitEquals(data1, data2, len));
+  ASSERT_FALSE(ArrayBitEquals(data1, data3, len));
+
+  delete [] data1;
+  delete [] data2;
+  delete [] data3;
+
+}
+
+
+TEST(EqualsTest, OGRealScalar) {
+
+  OGRealScalar * scalar = new OGRealScalar(1.0e0);
+  OGRealScalar * same = new OGRealScalar(1.0e0);
+  OGRealScalar * baddata = new OGRealScalar(2.0e0);
+  OGComplexScalar * badtype = new OGComplexScalar({1.0e0,2.0e0});
+
+  ASSERT_TRUE(scalar->equals(same));
+  ASSERT_TRUE(*scalar==*same);
+  ASSERT_FALSE(scalar->equals(baddata));
+  ASSERT_TRUE(*scalar!=*baddata);
+  ASSERT_FALSE(scalar->equals(badtype));
+  ASSERT_TRUE(*scalar!=*badtype);
+
+  ASSERT_TRUE(scalar->fuzzyequals(same));
+  ASSERT_TRUE(*scalar==~*same);
+  ASSERT_FALSE(scalar->fuzzyequals(baddata));
+  ASSERT_TRUE(*scalar!=~*baddata);
+  ASSERT_FALSE(scalar->fuzzyequals(badtype));
+  ASSERT_TRUE(*scalar!=~*badtype);
+
+  delete scalar;
+  delete same;
+  delete baddata;
+  delete badtype;
+}
+
+
+
+TEST(EqualsTest, OGComplexScalar) {
+
+  OGComplexScalar * scalar = new OGComplexScalar({1.0e0,2.0e0});
+  OGComplexScalar * same = new OGComplexScalar({1.0e0,2.0e0});
+  OGComplexScalar * baddata = new OGComplexScalar({-1.0e0,2.0e0});
+  OGRealScalar * badtype = new OGRealScalar(1.0e0);
+
+  ASSERT_TRUE(scalar->equals(same));
+  ASSERT_TRUE(*scalar==*same);
+  ASSERT_FALSE(scalar->equals(baddata));
+  ASSERT_TRUE(*scalar!=*baddata);
+  ASSERT_FALSE(scalar->equals(badtype));
+  ASSERT_TRUE(*scalar!=*badtype);
+
+  ASSERT_TRUE(scalar->fuzzyequals(same));
+  ASSERT_TRUE(*scalar==~*same);
+  ASSERT_FALSE(scalar->fuzzyequals(baddata));
+  ASSERT_TRUE(*scalar!=~*baddata);
+  ASSERT_FALSE(scalar->fuzzyequals(badtype));
+  ASSERT_TRUE(*scalar!=~*badtype);
+
+  delete scalar;
+  delete same;
+  delete baddata;
+  delete badtype;
+}
+
+TEST(EqualsTest, OGIntegerScalar) {
+
+  OGIntegerScalar * scalar = new OGIntegerScalar(1);
+  OGIntegerScalar * same = new OGIntegerScalar(1);
+  OGIntegerScalar * baddata = new OGIntegerScalar(2);
+  OGRealScalar * badtype = new OGRealScalar(1);
+
+  ASSERT_TRUE(scalar->equals(same));
+  ASSERT_TRUE(*scalar==*same);
+  ASSERT_FALSE(scalar->equals(baddata));
+  ASSERT_TRUE(*scalar!=*baddata);
+  ASSERT_FALSE(scalar->equals(badtype));
+  ASSERT_TRUE(*scalar!=*badtype);
+
+  ASSERT_TRUE(scalar->fuzzyequals(same));
+  ASSERT_TRUE(*scalar==~*same);
+  ASSERT_FALSE(scalar->fuzzyequals(baddata));
+  ASSERT_TRUE(*scalar!=~*baddata);
+  ASSERT_FALSE(scalar->fuzzyequals(badtype));
+  ASSERT_TRUE(*scalar!=~*badtype);
+
+  delete scalar;
+  delete same;
+  delete baddata;
+  delete badtype;
+}
+
+TEST(EqualsTest, OGRealMatrix) {
+  real16 * r_data1 = new real16[4] {1.0e0,2.0e0,3.0e0,4.0e0};
+  real16 * r_data2 = new real16[4] {-1.0e0,2.0e0,3.0e0,4.0e0};
+  complex16 * c_data1 = new complex16[4] {{1.0e0,10.0e0},{2.0e0,20.0e0},{3.0e0,30.0e0},{4.0e0,40.0e0}};
+  OGRealMatrix * matrix = new OGRealMatrix(r_data1,2,2);
+  OGRealMatrix * same = new OGRealMatrix(r_data1,2,2);
+  OGRealMatrix * badrows = new OGRealMatrix(r_data1,4,2);
+  OGRealMatrix * badcols = new OGRealMatrix(r_data1,2,4);
+  OGRealMatrix * baddata = new OGRealMatrix(r_data2,2,2);
+  OGComplexMatrix * badtype = new OGComplexMatrix(c_data1,2,2);
+
+  ASSERT_TRUE(matrix->equals(same));
+  ASSERT_TRUE(*matrix==*same);
+  ASSERT_FALSE(matrix->equals(badrows));
+  ASSERT_TRUE(*matrix!=*badrows);
+  ASSERT_FALSE(matrix->equals(badcols));
+  ASSERT_TRUE(*matrix!=*badcols);
+  ASSERT_FALSE(matrix->equals(baddata));
+  ASSERT_TRUE(*matrix!=*baddata);
+  ASSERT_FALSE(matrix->equals(badtype));
+  ASSERT_TRUE(*matrix!=*badtype);
+
+  ASSERT_TRUE(matrix->fuzzyequals(same));
+  ASSERT_TRUE(*matrix==~*same);
+  ASSERT_FALSE(matrix->fuzzyequals(badrows));
+  ASSERT_TRUE(*matrix!=~*badrows);
+  ASSERT_FALSE(matrix->fuzzyequals(badcols));
+  ASSERT_TRUE(*matrix!=~*badcols);
+  ASSERT_FALSE(matrix->fuzzyequals(baddata));
+  ASSERT_TRUE(*matrix!=~*baddata);
+  ASSERT_FALSE(matrix->fuzzyequals(badtype));
+  ASSERT_TRUE(*matrix!=~*badtype);
+
+  delete[] r_data1;
+  delete[] r_data2;
+  delete[] c_data1;
+  delete matrix;
+  delete same;
+  delete badrows;
+  delete badcols;
+  delete baddata;
+  delete badtype;
+
+}
+
+TEST(EqualsTest, OGComplexMatrix) {
+  complex16 * c_data1 = new complex16[4] {{1.0e0,10.0e0},{2.0e0,20.0e0},{3.0e0,30.0e0},{4.0e0,40.0e0}};
+  complex16 * c_data2 = new complex16[4] {{-1.0e0,10.0e0},{2.0e0,20.0e0},{3.0e0,30.0e0},{4.0e0,40.0e0}};
+  real16 * r_data1 = new real16[4] {1.0e0,2.0e0,3.0e0,4.0e0};
+  OGComplexMatrix * matrix = new OGComplexMatrix(c_data1,2,2);
+  OGComplexMatrix * same = new OGComplexMatrix(c_data1,2,2);
+  OGComplexMatrix * badrows = new OGComplexMatrix(c_data1,4,2);
+  OGComplexMatrix * badcols = new OGComplexMatrix(c_data1,2,4);
+  OGComplexMatrix * baddata = new OGComplexMatrix(c_data2,2,2);
+  OGRealMatrix * badtype = new OGRealMatrix(r_data1,2,2);
+
+  ASSERT_TRUE(matrix->equals(same));
+  ASSERT_TRUE(*matrix==*same);
+  ASSERT_FALSE(matrix->equals(badrows));
+  ASSERT_TRUE(*matrix!=*badrows);
+  ASSERT_FALSE(matrix->equals(badcols));
+  ASSERT_TRUE(*matrix!=*badcols);
+  ASSERT_FALSE(matrix->equals(baddata));
+  ASSERT_TRUE(*matrix!=*baddata);
+  ASSERT_FALSE(matrix->equals(badtype));
+  ASSERT_TRUE(*matrix!=*badtype);
+
+  ASSERT_TRUE(matrix->fuzzyequals(same));
+  ASSERT_TRUE(*matrix==~*same);
+  ASSERT_FALSE(matrix->fuzzyequals(badrows));
+  ASSERT_TRUE(*matrix!=~*badrows);
+  ASSERT_FALSE(matrix->fuzzyequals(badcols));
+  ASSERT_TRUE(*matrix!=~*badcols);
+  ASSERT_FALSE(matrix->fuzzyequals(baddata));
+  ASSERT_TRUE(*matrix!=~*baddata);
+  ASSERT_FALSE(matrix->fuzzyequals(badtype));
+  ASSERT_TRUE(*matrix!=~*badtype);
+
+  delete[] c_data1;
+  delete[] c_data2;
+  delete[] r_data1;
+  delete matrix;
+  delete same;
+  delete badrows;
+  delete badcols;
+  delete baddata;
+  delete badtype;
+
+}
+
+TEST(EqualsTest, OGRealSparseMatrix) {
+  real16 * r_data1 = new real16[7] {1.0e0, 3.0e0, 2.0e0, 5.0e0, 4.0e0, 6.0e0, 7.0e0 };
+  real16 * r_data2 = new real16[7] {-1.0e0, 3.0e0, 2.0e0, 5.0e0, 4.0e0, 6.0e0, 7.0e0 };
+  int * colPtr = new int[6] {0, 2, 4, 7, 7, 7};
+  int * colPtr2 = new int[6] {0, 1, 3, 7, 7, 7};
+  int * rowIdx = new int[7] {0, 1, 0, 2, 1, 2, 3 };
+  int * rowIdx2 = new int[7] {0, 1, 1, 2, 1, 2, 3 };
+  int rows = 5;
+  int cols = 4;
+  OGRealSparseMatrix * matrix = new OGRealSparseMatrix(colPtr, rowIdx, r_data1, rows, cols);
+  OGRealSparseMatrix * same = new OGRealSparseMatrix(colPtr, rowIdx, r_data1, rows, cols);
+  OGRealSparseMatrix * badrows = new OGRealSparseMatrix(colPtr, rowIdx, r_data1, 1, cols);
+  OGRealSparseMatrix * badcols = new OGRealSparseMatrix(colPtr, rowIdx, r_data1, rows, 1);
+  OGRealSparseMatrix * baddata = new OGRealSparseMatrix(colPtr, rowIdx, r_data2, rows, 1);
+  OGRealSparseMatrix * badcolptr = new OGRealSparseMatrix(colPtr2, rowIdx, r_data1, rows, cols);
+  OGRealSparseMatrix * badrowidx = new OGRealSparseMatrix(colPtr, rowIdx2, r_data1, rows, cols);
+  OGRealScalar * badtype = new OGRealScalar(1.0e0);
+
+  ASSERT_TRUE(matrix->equals(same));
+  ASSERT_TRUE(*matrix==*same);
+  ASSERT_FALSE(matrix->equals(badrows));
+  ASSERT_TRUE(*matrix!=*badrows);
+  ASSERT_FALSE(matrix->equals(badcols));
+  ASSERT_TRUE(*matrix!=*badcols);
+  ASSERT_FALSE(matrix->equals(baddata));
+  ASSERT_TRUE(*matrix!=*baddata);
+  ASSERT_FALSE(matrix->equals(badcolptr));
+  ASSERT_TRUE(*matrix!=*badcolptr);
+  ASSERT_FALSE(matrix->equals(badrowidx));
+  ASSERT_TRUE(*matrix!=*badrowidx);
+  ASSERT_FALSE(matrix->equals(badtype));
+  ASSERT_TRUE(*matrix!=*badtype);
+
+  ASSERT_TRUE(matrix->fuzzyequals(same));
+  ASSERT_TRUE(*matrix==~*same);
+  ASSERT_FALSE(matrix->fuzzyequals(badrows));
+  ASSERT_TRUE(*matrix!=~*badrows);
+  ASSERT_FALSE(matrix->fuzzyequals(badcols));
+  ASSERT_TRUE(*matrix!=~*badcols);
+  ASSERT_FALSE(matrix->fuzzyequals(baddata));
+  ASSERT_TRUE(*matrix!=~*baddata);
+  ASSERT_FALSE(matrix->fuzzyequals(badcolptr));
+  ASSERT_TRUE(*matrix!=~*badcolptr);
+  ASSERT_FALSE(matrix->fuzzyequals(badrowidx));
+  ASSERT_TRUE(*matrix!=~*badrowidx);
+  ASSERT_FALSE(matrix->fuzzyequals(badtype));
+  ASSERT_TRUE(*matrix!=~*badtype);
+
+  delete matrix;
+  delete same;
+  delete badrows;
+  delete badcols;
+  delete badcolptr;
+  delete badrowidx;
+  delete baddata;
+  delete badtype;
+  delete [] r_data1;
+  delete [] r_data2;
+  delete [] colPtr;
+  delete [] rowIdx;
+  delete [] colPtr2;
+  delete [] rowIdx2;
+}
+
+TEST(EqualsTest, OGComplexSparseMatrix) {
+  complex16 * c_data1 = new complex16[7] {{1.0e0,10.0e0}, {3.0e0,30.0e0}, {2.0e0,20.0e0}, {5.0e0,50.0e0}, {4.0e0,40.0e0}, {6.0e0,60.0e0}, {7.0e0,70.0e0} };
+  complex16 * c_data2 = new complex16[7] {{-1.0e0,10.0e0}, {3.0e0,30.0e0}, {2.0e0,20.0e0}, {5.0e0,50.0e0}, {4.0e0,40.0e0}, {6.0e0,60.0e0}, {7.0e0,70.0e0} };
+  int * colPtr = new int[6] {0, 2, 4, 7, 7, 7};
+  int * colPtr2 = new int[6] {0, 1, 3, 7, 7, 7};
+  int * rowIdx = new int[7] {0, 1, 0, 2, 1, 2, 3 };
+  int * rowIdx2 = new int[7] {0, 1, 1, 2, 1, 2, 3 };
+  int rows = 5;
+  int cols = 4;
+  OGComplexSparseMatrix * matrix = new OGComplexSparseMatrix(colPtr, rowIdx, c_data1, rows, cols);
+  OGComplexSparseMatrix * same = new OGComplexSparseMatrix(colPtr, rowIdx, c_data1, rows, cols);
+  OGComplexSparseMatrix * badrows = new OGComplexSparseMatrix(colPtr, rowIdx, c_data1, 1, cols);
+  OGComplexSparseMatrix * badcols = new OGComplexSparseMatrix(colPtr, rowIdx, c_data1, rows, 1);
+  OGComplexSparseMatrix * baddata = new OGComplexSparseMatrix(colPtr, rowIdx, c_data2, rows, 1);
+  OGComplexSparseMatrix * badcolptr = new OGComplexSparseMatrix(colPtr2, rowIdx, c_data1, rows, cols);
+  OGComplexSparseMatrix * badrowidx = new OGComplexSparseMatrix(colPtr, rowIdx2, c_data1, rows, cols);
+  OGRealScalar * badtype = new OGRealScalar(1.0e0);
+
+  ASSERT_TRUE(matrix->equals(same));
+  ASSERT_TRUE(*matrix==*same);
+  ASSERT_FALSE(matrix->equals(badrows));
+  ASSERT_TRUE(*matrix!=*badrows);
+  ASSERT_FALSE(matrix->equals(badcols));
+  ASSERT_TRUE(*matrix!=*badcols);
+  ASSERT_FALSE(matrix->equals(baddata));
+  ASSERT_TRUE(*matrix!=*baddata);
+  ASSERT_FALSE(matrix->equals(badcolptr));
+  ASSERT_TRUE(*matrix!=*badcolptr);
+  ASSERT_FALSE(matrix->equals(badrowidx));
+  ASSERT_TRUE(*matrix!=*badrowidx);
+  ASSERT_FALSE(matrix->equals(badtype));
+  ASSERT_TRUE(*matrix!=*badtype);
+
+  ASSERT_TRUE(matrix->fuzzyequals(same));
+  ASSERT_TRUE(*matrix==~*same);
+  ASSERT_FALSE(matrix->fuzzyequals(badrows));
+  ASSERT_TRUE(*matrix!=~*badrows);
+  ASSERT_FALSE(matrix->fuzzyequals(badcols));
+  ASSERT_TRUE(*matrix!=~*badcols);
+  ASSERT_FALSE(matrix->fuzzyequals(baddata));
+  ASSERT_TRUE(*matrix!=~*baddata);
+  ASSERT_FALSE(matrix->fuzzyequals(badcolptr));
+  ASSERT_TRUE(*matrix!=~*badcolptr);
+  ASSERT_FALSE(matrix->fuzzyequals(badrowidx));
+  ASSERT_TRUE(*matrix!=~*badrowidx);
+  ASSERT_FALSE(matrix->fuzzyequals(badtype));
+  ASSERT_TRUE(*matrix!=~*badtype);
+
+  delete matrix;
+  delete same;
+  delete badrows;
+  delete badcols;
+  delete badcolptr;
+  delete badrowidx;
+  delete baddata;
+  delete badtype;
+  delete [] c_data1;
+  delete [] c_data2;
+  delete [] colPtr;
+  delete [] rowIdx;
+  delete [] colPtr2;
+  delete [] rowIdx2;
+}
+
+TEST(EqualsTest, OGRealDiagonalMatrix) {
+  real16 * r_data1 = new real16[4] {1.0e0,2.0e0,3.0e0,4.0e0};
+  real16 * r_data2 = new real16[4] {-1.0e0,2.0e0,3.0e0,4.0e0};
+  complex16 * c_data1 = new complex16[4] {{1.0e0,10.0e0},{2.0e0,20.0e0},{3.0e0,30.0e0},{4.0e0,40.0e0}};
+  OGRealDiagonalMatrix * matrix = new OGRealDiagonalMatrix(r_data1,4,4);
+  OGRealDiagonalMatrix * same = new OGRealDiagonalMatrix(r_data1,4,4);
+  OGRealDiagonalMatrix * badrows = new OGRealDiagonalMatrix(r_data1,12,4);
+  OGRealDiagonalMatrix * badcols = new OGRealDiagonalMatrix(r_data1,4,12);
+  OGRealDiagonalMatrix * baddata = new OGRealDiagonalMatrix(r_data2,4,4);
+  OGComplexMatrix * badtype = new OGComplexMatrix(c_data1,2,2);
+
+  ASSERT_TRUE(matrix->equals(same));
+  ASSERT_TRUE(*matrix==*same);
+  ASSERT_FALSE(matrix->equals(badrows));
+  ASSERT_TRUE(*matrix!=*badrows);
+  ASSERT_FALSE(matrix->equals(badcols));
+  ASSERT_TRUE(*matrix!=*badcols);
+  ASSERT_FALSE(matrix->equals(baddata));
+  ASSERT_TRUE(*matrix!=*baddata);
+  ASSERT_FALSE(matrix->equals(badtype));
+  ASSERT_TRUE(*matrix!=*badtype);
+
+  ASSERT_TRUE(matrix->fuzzyequals(same));
+  ASSERT_TRUE(*matrix==~*same);
+  ASSERT_FALSE(matrix->fuzzyequals(badrows));
+  ASSERT_TRUE(*matrix!=~*badrows);
+  ASSERT_FALSE(matrix->fuzzyequals(badcols));
+  ASSERT_TRUE(*matrix!=~*badcols);
+  ASSERT_FALSE(matrix->fuzzyequals(baddata));
+  ASSERT_TRUE(*matrix!=~*baddata);
+  ASSERT_FALSE(matrix->fuzzyequals(badtype));
+  ASSERT_TRUE(*matrix!=~*badtype);
+
+  delete[] r_data1;
+  delete[] r_data2;
+  delete[] c_data1;
+  delete matrix;
+  delete same;
+  delete badrows;
+  delete badcols;
+  delete baddata;
+  delete badtype;
+
+}
+
+
+TEST(EqualsTest, OGComplexDiagonalMatrix) {
+  complex16 * c_data1 = new complex16[4] {{1.0e0,10.0e0},{2.0e0,20.0e0},{3.0e0,30.0e0},{4.0e0,40.0e0}};
+  complex16 * c_data2 = new complex16[4] {{-1.0e0,10.0e0},{2.0e0,20.0e0},{3.0e0,30.0e0},{4.0e0,40.0e0}};
+  real16 * r_data1 = new real16[4] {1.0e0,2.0e0,3.0e0,4.0e0};
+  OGComplexDiagonalMatrix * matrix = new OGComplexDiagonalMatrix(c_data1,4,4);
+  OGComplexDiagonalMatrix * same = new OGComplexDiagonalMatrix(c_data1,4,4);
+  OGComplexDiagonalMatrix * badrows = new OGComplexDiagonalMatrix(c_data1,12,4);
+  OGComplexDiagonalMatrix * badcols = new OGComplexDiagonalMatrix(c_data1,4,12);
+  OGComplexDiagonalMatrix * baddata = new OGComplexDiagonalMatrix(c_data2,4,4);
+  OGRealMatrix * badtype = new OGRealMatrix(r_data1,2,2);
+
+  ASSERT_TRUE(matrix->equals(same));
+  ASSERT_TRUE(*matrix==*same);
+  ASSERT_FALSE(matrix->equals(badrows));
+  ASSERT_TRUE(*matrix!=*badrows);
+  ASSERT_FALSE(matrix->equals(badcols));
+  ASSERT_TRUE(*matrix!=*badcols);
+  ASSERT_FALSE(matrix->equals(baddata));
+  ASSERT_TRUE(*matrix!=*baddata);
+  ASSERT_FALSE(matrix->equals(badtype));
+  ASSERT_TRUE(*matrix!=*badtype);
+
+  ASSERT_TRUE(matrix->fuzzyequals(same));
+  ASSERT_TRUE(*matrix==~*same);
+  ASSERT_FALSE(matrix->fuzzyequals(badrows));
+  ASSERT_TRUE(*matrix!=~*badrows);
+  ASSERT_FALSE(matrix->fuzzyequals(badcols));
+  ASSERT_TRUE(*matrix!=~*badcols);
+  ASSERT_FALSE(matrix->fuzzyequals(baddata));
+  ASSERT_TRUE(*matrix!=~*baddata);
+  ASSERT_FALSE(matrix->fuzzyequals(badtype));
+  ASSERT_TRUE(*matrix!=~*badtype);
+
+  delete[] c_data1;
+  delete[] c_data2;
+  delete[] r_data1;
+  delete matrix;
+  delete same;
+  delete badrows;
+  delete badcols;
+  delete baddata;
+  delete badtype;
+
+}

--- a/src/librdag/test/check_numerictypes.cc
+++ b/src/librdag/test/check_numerictypes.cc
@@ -1,0 +1,73 @@
+/**
+ * Copyright (C) 2013 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+#include "gtest/gtest.h"
+#include "warningmacros.h"
+#include "equals.hh"
+#include "terminal.hh"
+#include "register.hh"
+
+using namespace std;
+using namespace librdag;
+
+TEST(NumericTypesTest, getNaN) {
+  ASSERT_TRUE(std::isnan(getNaN()));
+}
+
+TEST(NumericTypesTest, getComplexNaN) {
+  ASSERT_TRUE(std::isnan(std::real(getComplexNaN())));
+  ASSERT_TRUE(std::isnan(std::imag(getComplexNaN())));
+}
+
+TEST(NumericTypesTest, getPosInf) {
+  ASSERT_TRUE(std::isinf(getPosInf()));
+  ASSERT_EQ(signbit(getPosInf()),0);
+}
+
+TEST(NumericTypesTest, getNegInf) {
+  ASSERT_TRUE(std::isinf(getNegInf()));
+  ASSERT_NE(signbit(getNegInf()),0);
+}
+
+TEST(NumericTypesTest, getPosPosComplexInf) {
+  real16 r = std::real(getPosPosComplexInf());
+  real16 i = std::imag(getPosPosComplexInf());
+
+  ASSERT_TRUE(std::isinf(r));
+  ASSERT_EQ(signbit(r),0);
+  ASSERT_TRUE(std::isinf(i));
+  ASSERT_EQ(signbit(i),0);
+}
+
+TEST(NumericTypesTest, getPosNegComplexInf) {
+  real16 r = std::real(getPosNegComplexInf());
+  real16 i = std::imag(getPosNegComplexInf());
+
+  ASSERT_TRUE(std::isinf(r));
+  ASSERT_EQ(signbit(r),0);
+  ASSERT_TRUE(std::isinf(i));
+  ASSERT_NE(signbit(i),0);
+}
+
+TEST(NumericTypesTest, getNegPosComplexInf) {
+  real16 r = std::real(getNegPosComplexInf());
+  real16 i = std::imag(getNegPosComplexInf());
+
+  ASSERT_TRUE(std::isinf(r));
+  ASSERT_NE(signbit(r),0);
+  ASSERT_TRUE(std::isinf(i));
+  ASSERT_EQ(signbit(i),0);
+}
+
+TEST(NumericTypesTest, getNegNegComplexInf) {
+  real16 r = std::real(getNegNegComplexInf());
+  real16 i = std::imag(getNegNegComplexInf());
+
+  ASSERT_TRUE(std::isinf(r));
+  ASSERT_NE(signbit(r),0);
+  ASSERT_TRUE(std::isinf(i));
+  ASSERT_NE(signbit(i),0);
+}


### PR DESCRIPTION
This started out as being converters and then realised the testing was impossibly tedious without `.equals()` and subsequent `.fuzzyequals()` methods. So this branch covers that with view of writing converters next.

This code:
- Adds numeric types for various combinations of `(+/-)inf` and `NaN` as constants.
- Bit wise equals for all terminals
- Fuzzy equals for all terminals
- Fuzzy comparison methods for arrays and singles of types `real16` and `complex16`
- Operators `==` and `!=` for doing bitwise equals across terminals
- Operator sequence `==~` and `!=~` for doing fuzzy equals across terminals. This is done via an overloaded `~` operator on terminals to return a "fuzzy equals container type" for comparison operators `==` and `!=` to then use the fuzzy equals variations while comparing.

BB Pass: [http://devmaths-lx-1:8011/builders/nyqwk2-testing/builds/393](http://devmaths-lx-1:8011/builders/nyqwk2-testing/builds/393)

New code covered to 100%. Librdag is at 82.9 %. No change to jshim or java.
