### PR TITLE
Mat-263 Add converters

### DIFF
--- a/include/convertto.hh
+++ b/include/convertto.hh
@@ -34,7 +34,6 @@ class ConvertTo
     ConvertTo();
     OGRealMatrixRegister * convertToOGRealMatrix(OGRealScalar const * thing) const;
     OGRealMatrixRegister * convertToOGRealMatrix(OGRealDiagonalMatrix const * thing) const;
-    OGRealMatrixRegister * convertToOGRealMatrix(OGLogicalMatrix const * thing) const;
     OGRealMatrixRegister * convertToOGRealMatrix(OGRealSparseMatrix const * thing) const;
 
     OGComplexMatrixRegister * convertToOGComplexMatrix(OGRealScalar const * thing) const;

--- a/include/convertto.hh
+++ b/include/convertto.hh
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2013 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+#ifndef _CONVERTTO_HH
+#define _CONVERTTO_HH
+#include "terminal.hh"
+#include "register.hh"
+
+// defines permissable type conversions
+
+//                                            _TO_
+// _FROM_        RealScal CmplxScal RDiag  CDiag   Logical  Idx  RSparse CSparse   RDense  CDense
+//RealScalar    |  Yes   |   Yes   | Yes |  Yes   |  No   | No  |  Yes  |   Yes   | Yes  |  Yes  |
+//ComplexScalar |   No   |   Yes   | No  |  Yes   |  No   | No  |  No   |   Yes   | No   |  Yes  |
+//RealDiag      |   No   |   No    | Yes |  Yes   |  No   | No  |  Yes  |   Yes   | Yes  |  Yes  |
+//CplxDiag      |   No   |   No    | No  |  Yes   |  No   | No  |  No   |   Yes   | No   |  Yes  |
+//Logical       |   No   |   No    | No  |  No    |  Yes  | No  |  Yes  |   Yes   | Yes  |  Yes  |
+//Idx           |   No   |   No    | No  |  No    |  No   | Yes |  Yes  |   Yes   | Yes  |  Yes  |
+//RealSparse    |   No   |   No    | No  |  No    |  No   | No  |  Yes  |   Yes   | Yes  |  Yes  |
+//CplxSparse    |   No   |   No    | No  |  No    |  No   | No  |  No   |   Yes   | No   |  Yes  |
+//RealDense     |   No   |   No    | No  |  No    |  No   | No  |  No   |   No    | Yes  |  Yes  |
+//CplxDense     |   No   |   No    | No  |  No    |  No   | No  |  No   |   No    | No   |  Yes  |
+
+
+namespace librdag {
+
+// conversion class, it need not be a class
+class ConvertTo
+{
+  public:
+    ConvertTo();
+    OGRealMatrixRegister * convertToOGRealMatrix(OGRealScalar const * thing) const;
+    OGRealMatrixRegister * convertToOGRealMatrix(OGRealDiagonalMatrix const * thing) const;
+    OGRealMatrixRegister * convertToOGRealMatrix(OGLogicalMatrix const * thing) const;
+    OGRealMatrixRegister * convertToOGRealMatrix(OGRealSparseMatrix const * thing) const;
+
+    OGComplexMatrixRegister * convertToOGComplexMatrix(OGRealScalar const * thing) const;
+    OGComplexMatrixRegister * convertToOGComplexMatrix(OGComplexScalar const * thing) const;
+    OGComplexMatrixRegister * convertToOGComplexMatrix(OGRealDiagonalMatrix const * thing) const;
+    OGComplexMatrixRegister * convertToOGComplexMatrix(OGComplexDiagonalMatrix const * thing) const;
+    OGComplexMatrixRegister * convertToOGComplexMatrix(OGRealSparseMatrix const * thing) const;
+    OGComplexMatrixRegister * convertToOGComplexMatrix(OGComplexSparseMatrix const * thing) const;
+    OGComplexMatrixRegister * convertToOGComplexMatrix(OGRealMatrix const * thing) const;
+};
+
+}
+
+#endif //_CONVERTTO_HH

--- a/src/librdag/CMakeLists.txt
+++ b/src/librdag/CMakeLists.txt
@@ -10,7 +10,7 @@ SET(CMAKE_FC_FLAGS  "${CMAKE_FC_FLAGS} ${GCC_COVERAGE_COMPILE_FLAGS} -cpp" )
 SET(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -Wl,--no-undefined")
 SET(CMAKE_CC_FLAGS  "${CMAKE_CC_FLAGS} -Wl,--no-undefined -frepo")
  
-add_library(rdag SHARED entrypt.cc expression.cc execution.cc terminal.cc containers.cc numeric.cc register.cc dispatch.cc equals.cc numerictypes.cc)
+add_library(rdag SHARED entrypt.cc expression.cc execution.cc terminal.cc containers.cc numeric.cc register.cc dispatch.cc equals.cc numerictypes.cc convertto.cc)
 
 set_target_properties(rdag PROPERTIES SOVERSION ${longdog_VERSION_MAJOR} VERSION ${longdog_VERSION})
 install(TARGETS rdag DESTINATION lib)

--- a/src/librdag/convertto.cc
+++ b/src/librdag/convertto.cc
@@ -45,12 +45,6 @@ ConvertTo::convertToOGRealMatrix(OGRealDiagonalMatrix const * thing) const
 }
 
 OGRealMatrixRegister *
-ConvertTo::convertToOGRealMatrix(OGLogicalMatrix const SUPPRESS_UNUSED * thing) const
-{
-  throw rdag_error("Context for convert logical to real matrix unknown and therefore not implemented.");
-}
-
-OGRealMatrixRegister *
 ConvertTo::convertToOGRealMatrix(OGRealSparseMatrix const * thing) const
 {
 

--- a/src/librdag/convertto.cc
+++ b/src/librdag/convertto.cc
@@ -1,0 +1,192 @@
+
+/**
+ * Copyright (C) 2013 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+#include "convertto.hh"
+#include "terminal.hh"
+#include "warningmacros.h"
+#include "exceptions.hh"
+
+using namespace std;
+namespace librdag {
+
+
+ConvertTo::ConvertTo()
+{}
+
+// things that convert to OGRealMatrix
+OGRealMatrixRegister *
+ConvertTo::convertToOGRealMatrix(OGRealScalar const * thing) const
+{
+  OGRealMatrixRegister * ret = new OGRealMatrixRegister(1,1);
+  ret->incRef();
+  ret->getData()[0]=thing->getValue();
+  return ret;
+}
+
+OGRealMatrixRegister *
+ConvertTo::convertToOGRealMatrix(OGRealDiagonalMatrix const * thing) const
+{
+  int rows = thing->getRows();
+  int cols = thing->getCols();
+  int wlen = thing->getDatalen();
+  OGRealMatrixRegister * ret = new OGRealMatrixRegister(rows,cols);
+  ret->incRef();
+  real16 * diagdata = thing->getData();
+  real16 * data = ret->getData();
+  for(int i=0;i<wlen;i++)
+  {
+    data[i+i*rows]=diagdata[i];
+  }
+  return ret;
+}
+
+OGRealMatrixRegister *
+ConvertTo::convertToOGRealMatrix(OGLogicalMatrix const SUPPRESS_UNUSED * thing) const
+{
+  throw rdag_error("Context for convert logical to real matrix unknown and therefore not implemented.");
+}
+
+OGRealMatrixRegister *
+ConvertTo::convertToOGRealMatrix(OGRealSparseMatrix const * thing) const
+{
+
+  int rows = thing->getRows();
+  int cols = thing->getCols();
+  int * colPtr = thing->getColPtr();
+  int * rowIdx = thing->getRowIdx();
+  real16 * sparsedata = thing->getData();
+
+  OGRealMatrixRegister * ret = new OGRealMatrixRegister(rows,cols);
+  ret->incRef();
+  real16 * data = ret->getData();
+  for (int ir = 0; ir < cols; ir++)
+  {
+    for (int i = colPtr[ir]; i < colPtr[ir + 1]; i++)
+    {
+      data[rowIdx[i] + ir * rows] = sparsedata[i];
+    }
+  }
+  return ret;
+}
+
+
+// things that convert to OGComplexMatrix
+
+OGComplexMatrixRegister *
+ConvertTo::convertToOGComplexMatrix(OGRealScalar const * thing) const
+{
+  OGComplexMatrixRegister * ret = new OGComplexMatrixRegister(1,1);
+  ret->incRef();
+  ret->getData()[0]=thing->getValue();
+  return ret;
+}
+
+OGComplexMatrixRegister *
+ConvertTo::convertToOGComplexMatrix(OGComplexScalar const * thing) const
+{
+  OGComplexMatrixRegister * ret = new OGComplexMatrixRegister(1,1);
+  ret->incRef();
+  ret->getData()[0]=thing->getValue();
+  return ret;
+}
+
+OGComplexMatrixRegister *
+ConvertTo::convertToOGComplexMatrix(OGRealDiagonalMatrix const * thing) const
+{
+  int rows = thing->getRows();
+  int cols = thing->getCols();
+  int wlen = thing->getDatalen();
+  OGComplexMatrixRegister * ret = new OGComplexMatrixRegister(rows,cols);
+  ret->incRef();
+  real16 * diagdata = thing->getData();
+  complex16 * data = ret->getData();
+  for(int i=0;i<wlen;i++)
+  {
+    data[i+i*rows]=diagdata[i];
+  }
+  return ret;
+}
+
+OGComplexMatrixRegister *
+ConvertTo::convertToOGComplexMatrix(OGComplexDiagonalMatrix const * thing) const
+{
+  int rows = thing->getRows();
+  int cols = thing->getCols();
+  int wlen = thing->getDatalen();
+  OGComplexMatrixRegister * ret = new OGComplexMatrixRegister(rows,cols);
+  ret->incRef();
+  complex16 * diagdata = thing->getData();
+  complex16 * data = ret->getData();
+  for(int i=0;i<wlen;i++)
+  {
+    data[i+i*rows]=diagdata[i];
+  }
+  return ret;
+}
+
+OGComplexMatrixRegister *
+ConvertTo::convertToOGComplexMatrix(OGRealSparseMatrix const * thing) const
+{
+  int rows = thing->getRows();
+  int cols = thing->getCols();
+  int * colPtr = thing->getColPtr();
+  int * rowIdx = thing->getRowIdx();
+  real16 * sparsedata = thing->getData();
+
+  OGComplexMatrixRegister * ret = new OGComplexMatrixRegister(rows,cols);
+  ret->incRef();
+  complex16 * data = ret->getData();
+  for (int ir = 0; ir < cols; ir++)
+  {
+    for (int i = colPtr[ir]; i < colPtr[ir + 1]; i++)
+    {
+      data[rowIdx[i] + ir * rows] = sparsedata[i];
+    }
+  }
+  return ret;
+}
+
+OGComplexMatrixRegister *
+ConvertTo::convertToOGComplexMatrix(OGComplexSparseMatrix const * thing) const
+{
+  int rows = thing->getRows();
+  int cols = thing->getCols();
+  int * colPtr = thing->getColPtr();
+  int * rowIdx = thing->getRowIdx();
+  complex16 * sparsedata = thing->getData();
+
+  OGComplexMatrixRegister * ret = new OGComplexMatrixRegister(rows,cols);
+  ret->incRef();
+  complex16 * data = ret->getData();
+  for (int ir = 0; ir < cols; ir++)
+  {
+    for (int i = colPtr[ir]; i < colPtr[ir + 1]; i++)
+    {
+      data[rowIdx[i] + ir * rows] = sparsedata[i];
+    }
+  }
+  return ret;
+}
+
+OGComplexMatrixRegister *
+ConvertTo::convertToOGComplexMatrix(OGRealMatrix const * thing) const
+{
+  int rows = thing->getRows();
+  int cols = thing->getCols();
+  int wlen = thing->getDatalen();
+  OGComplexMatrixRegister * ret = new OGComplexMatrixRegister(rows,cols);
+  ret->incRef();
+  real16 * densedata = thing->getData();
+  complex16 * data = ret->getData();
+  for(int i=0;i<wlen;i++)
+  {
+    data[i]=densedata[i];
+  }
+  return ret;
+}
+
+} // end namespace

--- a/src/librdag/register.cc
+++ b/src/librdag/register.cc
@@ -103,7 +103,7 @@ OGRealMatrixRegister::OGRealMatrixRegister(int rows, int cols)
 
 void OGRealMatrixRegister::alloc()
 {
-  real16* data = new real16[getDatalen()];
+  real16* data = new real16[getDatalen()]();
   setData(data);
 
 }
@@ -128,7 +128,7 @@ OGComplexMatrixRegister::OGComplexMatrixRegister(int rows, int cols)
                         :OGComplexMatrix(rows, cols), Register() {}
 void OGComplexMatrixRegister::alloc()
 {
-  complex16* data = new complex16[getDatalen()];
+  complex16* data = new complex16[getDatalen()]();
   setData(data);
 
 }
@@ -154,7 +154,7 @@ OGRealDiagonalMatrixRegister::OGRealDiagonalMatrixRegister(int rows, int cols)
 
 void OGRealDiagonalMatrixRegister::alloc()
 {
-  real16* data = new real16[getDatalen()];
+  real16* data = new real16[getDatalen()]();
   setData(data);
 
 }
@@ -179,7 +179,7 @@ OGComplexDiagonalMatrixRegister::OGComplexDiagonalMatrixRegister(int rows, int c
                                 :OGComplexDiagonalMatrix(rows, cols), Register() {}
 void OGComplexDiagonalMatrixRegister::alloc()
 {
-  complex16* data = new complex16[getDatalen()];
+  complex16* data = new complex16[getDatalen()]();
   setData(data);
 
 }

--- a/src/librdag/terminal.cc
+++ b/src/librdag/terminal.cc
@@ -514,18 +514,18 @@ OGRealMatrix::getType() const
 void
 OGComplexMatrix::debug_print() const
 {
-  size_t ptr=0;
   printf("\n");
-  for(int i = 0 ; i < this->getRows(); i++)
+  int lim = (this->getCols()-1);
+  int rows = this->getRows();
+  for(int i = 0 ; i < rows; i++)
   {
-    for(int j = 0 ; j < this->getCols()-1; j++)
+    for(int j = 0 ; j < lim; j++)
     {
-      printf("%6.4f + %6.4fi, ",this->getData()[ptr].real(),this->getData()[ptr].imag());
-      ptr++;
+      printf("%6.4f + %6.4fi, ",this->getData()[j*rows+i].real(),this->getData()[j*rows+i].imag());
     }
-    printf("%6.4f + %6.4fi\n",this->getData()[ptr].real(),this->getData()[ptr].imag());
-    ptr++;
+      printf("%6.4f + %6.4fi, ",this->getData()[lim*rows+i].real(),this->getData()[lim*rows+i].imag());
   }
+
 }
 
 complex16**

--- a/src/librdag/terminal.cc
+++ b/src/librdag/terminal.cc
@@ -469,15 +469,16 @@ template class OGMatrix<complex16>;
 void
 OGRealMatrix::debug_print() const
 {
-  size_t ptr=0;
   printf("\n");
-  for(int i = 0 ; i < this->getRows(); i++)
+  int lim = (this->getCols()-1);
+  int rows = this->getRows();
+  for(int i = 0 ; i < rows; i++)
   {
-    for(int j = 0 ; j < this->getCols()-1; j++)
+    for(int j = 0 ; j < lim; j++)
     {
-      printf("%6.4f, ",this->getData()[ptr++]);
+      printf("%6.4f, ",this->getData()[j*rows+i]);
     }
-    printf("%6.4f\n",this->getData()[ptr++]);
+    printf("%6.4f\n",this->getData()[lim*rows+i]);
   }
 }
 

--- a/src/librdag/test/CMakeLists.txt
+++ b/src/librdag/test/CMakeLists.txt
@@ -9,7 +9,7 @@ SET(CMAKE_FC_FLAGS  "${CMAKE_FC_FLAGS} ${GCC_COVERAGE_COMPILE_FLAGS} -cpp" )
 
 link_directories(${longdog_BINARY_DIR}/src/librdag})
 
-set(TESTS check_expressions check_containers check_execution check_rtti check_terminals check_register check_entrypt check_dispatch check_equals check_numerictypes)
+set(TESTS check_expressions check_containers check_execution check_rtti check_terminals check_register check_entrypt check_dispatch check_equals check_numerictypes check_convertto)
 
 # Compile and link each test and add to the list of tests
 foreach(TEST ${TESTS})

--- a/src/librdag/test/check_convertto.cc
+++ b/src/librdag/test/check_convertto.cc
@@ -1,0 +1,233 @@
+/**
+ * Copyright (C) 2013 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+#include "terminal.hh"
+#include "exceptions.hh"
+#include "gtest/gtest.h"
+#include "warningmacros.h"
+#include "convertto.hh"
+#include "dispatch.hh"
+#include <iostream>
+using namespace std;
+using namespace librdag;
+
+TEST(ConvertToTest, OGRealScalarConvertToOGRealMatrix) {
+
+  real16 value = 13.e0;
+  OGRealScalar * scalar = new OGRealScalar(value);
+  real16 * data = new real16[1];
+  data[0]=value;
+  OGRealMatrix * expected = new OGRealMatrix(data,1,1);
+  ConvertTo * c = new ConvertTo();
+  OGRealMatrixRegister * answer = c->convertToOGRealMatrix(scalar);
+  ASSERT_TRUE(*expected==~*answer);
+  answer->decRef();
+
+  delete c;
+  delete scalar;
+  delete expected;
+  delete [] data;
+  delete answer;
+
+}
+
+
+TEST(ConvertToTest, OGRealDiagonalMatrixConvertToOGRealMatrix) {
+
+  real16 * input_values = new real16[4] {1,2,3,4};
+  real16 * expected_values = new real16[24]{1,0,0,0,0,2,0,0,0,0,3,0,0,0,0,4,0,0,0,0,0,0,0,0};
+  OGRealDiagonalMatrix * input = new OGRealDiagonalMatrix(input_values,4,6);
+  OGRealMatrix * expected = new OGRealMatrix(expected_values,4,6);
+  ConvertTo * c = new ConvertTo();
+  OGRealMatrixRegister * answer = c->convertToOGRealMatrix(input);
+  ASSERT_TRUE(*expected==~*answer);
+  answer->decRef();
+
+  delete c;
+  delete [] input_values;
+  delete [] expected_values;
+  delete input;
+  delete expected;
+  delete answer;
+
+}
+
+TEST(ConvertToTest, OGRealSparseMatrixConvertToOGRealMatrix) {
+
+  real16 * input_values = new real16[7] {1,4,2,8,11,6,12};
+  int * input_colPtr = new int[4] {0,2,5,7};
+  int * input_rowIdx = new int[7] {0,1,0,2,3,1,3};
+  real16 * expected_values = new real16[12]{1,4,0,0,2,0,8,11,0,6,0,12};
+  OGRealSparseMatrix * input = new OGRealSparseMatrix(input_colPtr, input_rowIdx, input_values,4,3);
+  OGRealMatrix * expected = new OGRealMatrix(expected_values,4,3);
+  ConvertTo * c = new ConvertTo();
+  OGRealMatrixRegister * answer = c->convertToOGRealMatrix(input);
+  ASSERT_TRUE(*expected==~*answer);
+  answer->decRef();
+
+  delete c;
+  delete [] input_values;
+  delete [] input_colPtr;
+  delete [] input_rowIdx;
+  delete [] expected_values;
+  delete input;
+  delete expected;
+  delete answer;
+
+}
+
+
+TEST(ConvertToTest, OGRealScalarConvertToOGComplexMatrix) {
+
+  real16 value = {13.e0};
+  OGRealScalar * scalar = new OGRealScalar(value);
+  complex16 * data = new complex16[1];
+  data[0]=value;
+  OGComplexMatrix * expected = new OGComplexMatrix(data,1,1);
+  ConvertTo * c = new ConvertTo();
+  OGComplexMatrixRegister * answer = c->convertToOGComplexMatrix(scalar);
+  ASSERT_TRUE(*expected==~*answer);
+  answer->decRef();
+
+  delete c;
+  delete scalar;
+  delete expected;
+  delete [] data;
+  delete answer;
+
+}
+
+TEST(ConvertToTest, OGComplexScalarConvertToOGComplexMatrix) {
+
+  complex16 value = {13.e0, 37.e0};
+  OGComplexScalar * scalar = new OGComplexScalar(value);
+  complex16 * data = new complex16[1];
+  data[0]=value;
+  OGComplexMatrix * expected = new OGComplexMatrix(data,1,1);
+  ConvertTo * c = new ConvertTo();
+  OGComplexMatrixRegister * answer = c->convertToOGComplexMatrix(scalar);
+  ASSERT_TRUE(*expected==~*answer);
+  answer->decRef();
+
+  delete c;
+  delete scalar;
+  delete expected;
+  delete [] data;
+  delete answer;
+
+}
+
+
+TEST(ConvertToTest, OGRealDiagonalMatrixConvertToOGComplexMatrix) {
+
+  real16 * input_values = new real16[4] {1,2,3,4};
+  complex16 * expected_values = new complex16[24]{{1,0},{0,0},{0,0},{0,0},{0,0},{2,0},{0,0},{0,0},{0,0},{0,0},{3,0},{0,0},{0,0},{0,0},{0,0},{4,0},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0}};
+  OGRealDiagonalMatrix * input = new OGRealDiagonalMatrix(input_values,4,6);
+  OGComplexMatrix * expected = new OGComplexMatrix(expected_values,4,6);
+  ConvertTo * c = new ConvertTo();
+  OGComplexMatrixRegister * answer = c->convertToOGComplexMatrix(input);
+  ASSERT_TRUE(*expected==~*answer);
+  answer->decRef();
+
+  delete c;
+  delete [] input_values;
+  delete [] expected_values;
+  delete input;
+  delete expected;
+  delete answer;
+
+}
+
+
+TEST(ConvertToTest, OGComplexDiagonalMatrixConvertToOGComplexMatrix) {
+
+  complex16 * input_values = new complex16[4] {{1,10},{2,20},{3,30},{4,40}};
+  complex16 * expected_values = new complex16[24]{{1,10},{0,0},{0,0},{0,0},{0,0},{2,20},{0,0},{0,0},{0,0},{0,0},{3,30},{0,0},{0,0},{0,0},{0,0},{4,40},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0},{0,0}};
+  OGComplexDiagonalMatrix * input = new OGComplexDiagonalMatrix(input_values,4,6);
+  OGComplexMatrix * expected = new OGComplexMatrix(expected_values,4,6);
+  ConvertTo * c = new ConvertTo();
+  OGComplexMatrixRegister * answer = c->convertToOGComplexMatrix(input);
+  ASSERT_TRUE(*expected==~*answer);
+  answer->decRef();
+
+  delete c;
+  delete [] input_values;
+  delete [] expected_values;
+  delete input;
+  delete expected;
+  delete answer;
+
+}
+
+TEST(ConvertToTest, OGRealSparseMatrixConvertToOGComplexMatrix) {
+
+  real16 * input_values = new real16[7] {1,4,2,8,11,6,12};
+  int * input_colPtr = new int[4] {0,2,5,7};
+  int * input_rowIdx = new int[7] {0,1,0,2,3,1,3};
+  complex16 * expected_values = new complex16[12]{{1,0},{4,0},{0,0},{0,0},{2,0},{0,0},{8,0},{11,0},{0,0},{6,0},{0,0},{12,0}};
+  OGRealSparseMatrix * input = new OGRealSparseMatrix(input_colPtr, input_rowIdx, input_values,4,3);
+  OGComplexMatrix * expected = new OGComplexMatrix(expected_values,4,3);
+  ConvertTo * c = new ConvertTo();
+  OGComplexMatrixRegister * answer = c->convertToOGComplexMatrix(input);
+  ASSERT_TRUE(*expected==~*answer);
+  answer->decRef();
+
+  delete c;
+  delete [] input_values;
+  delete [] input_colPtr;
+  delete [] input_rowIdx;
+  delete [] expected_values;
+  delete input;
+  delete expected;
+  delete answer;
+
+}
+
+
+TEST(ConvertToTest, OGComplexSparseMatrixConvertToOGComplexMatrix) {
+
+  complex16 * input_values = new complex16[8] {{1,0},{4,0},{0,70},{2,0},{8,0},{11,0},{6,0},{12,0}};
+  int * input_colPtr = new int[4] {0,3,6,8};
+  int * input_rowIdx = new int[8] {0,1,2,0,2,3,1,3};
+  complex16 * expected_values = new complex16[12]{{1,0},{4,0},{0,70},{0,0},{2,0},{0,0},{8,0},{11,0},{0,0},{6,0},{0,0},{12,0}};
+  OGComplexSparseMatrix * input = new OGComplexSparseMatrix(input_colPtr, input_rowIdx, input_values,4,3);
+  OGComplexMatrix * expected = new OGComplexMatrix(expected_values,4,3);
+  ConvertTo * c = new ConvertTo();
+  OGComplexMatrixRegister * answer = c->convertToOGComplexMatrix(input);
+  ASSERT_TRUE(*expected==~*answer);
+  answer->decRef();
+
+  delete c;
+  delete [] input_values;
+  delete [] input_colPtr;
+  delete [] input_rowIdx;
+  delete [] expected_values;
+  delete input;
+  delete expected;
+  delete answer;
+
+}
+
+
+TEST(ConvertToTest, OGRealMatrixConvertToOGComplexMatrix) {
+
+  real16 * input_values = new real16[12] {1,4,7,10,2,5,8,11,3,6,9,12};
+  complex16 * expected_values = new complex16[12]{{1,0},{4,0},{7,0},{10,0},{2,0},{5,0},{8,0},{11,0},{3,0},{6,0},{9,0},{12,0}};
+  OGRealMatrix * input = new OGRealMatrix(input_values,4,3);
+  OGComplexMatrix * expected = new OGComplexMatrix(expected_values,4,3);
+  ConvertTo * c = new ConvertTo();
+  OGComplexMatrixRegister * answer = c->convertToOGComplexMatrix(input);
+  ASSERT_TRUE(*expected==~*answer);
+  answer->decRef();
+
+  delete c;
+  delete [] input_values;
+  delete [] expected_values;
+  delete input;
+  delete expected;
+  delete answer;
+
+}


### PR DESCRIPTION
This PR adds converters from all possible types to their possible dense matrix counterparts.
- Adds ConvertTo class
- Adds test coverage for converter class
- Makes registers memset to 0 all their allocated data space, this prevents forgetting to init to 0.
- Fixes a couple of minor bugs in the debug_print() implementations for dense matrices (data access pattern incorrect)

BB Pass: [http://devmaths-lx-1:8011/builders/nyqwk2-testing/builds/406](http://devmaths-lx-1:8011/builders/nyqwk2-testing/builds/406)
Coverage: New code covered to 100%. Librdag is at 84.5% (was 82.9 %), jshim and java, no change.
