### PR TITLE
[MAT-281] Regenerate code if the generator is touched.

### DIFF
--- a/src/librdag/CMakeLists.txt
+++ b/src/librdag/CMakeLists.txt
@@ -17,12 +17,16 @@ set(RUNNERS_HH ${BIN_INCLUDE_DIR}/runners.hh)
 set(RUNNERS_CC ${CMAKE_BINARY_DIR}/src/librdag/runners.cc)
 set(RUNNERS_GENERATOR ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/generator.py)
 
+set(GENERATOR_FILES ${CMAKE_CURRENT_SOURCE_DIR}/generator.py
+                    ${CMAKE_CURRENT_SOURCE_DIR}/templates.py)
+
 add_custom_command(OUTPUT ${RUNNERS_HH}
                    COMMAND ${RUNNERS_GENERATOR} -o ${RUNNERS_HH} --runners-hh
+                   DEPENDS ${GENERATOR_FILES}
                    COMMENT "Generating runners.hh")
 
 add_custom_command(OUTPUT ${RUNNERS_CC}
-                   DEPENDS ${RUNNERS_HH}
+                   DEPENDS ${RUNNERS_HH} ${GENERATOR_FILES}
                    COMMAND ${RUNNERS_GENERATOR} -o ${RUNNERS_CC} --runners-cc
                    COMMENT "Generating runners.cc")
 


### PR DESCRIPTION
This should fix 281 and the odd behaviour that results in modifying the generator and not running "make clean" before rebuilding.

Buildbot: http://devmaths-lx-1:8011/builders/nyqwk2-testing/builds/422
