### PR TITLE
Mat 276

### DIFF
--- a/include/convertto.hh
+++ b/include/convertto.hh
@@ -32,16 +32,20 @@ class ConvertTo
   public:
     ConvertTo();
     OGOwningRealMatrix * convertToOGRealMatrix(OGRealScalar const * thing) const;
+    OGOwningRealMatrix * convertToOGRealMatrix(OGIntegerScalar const * thing) const;
     OGOwningRealMatrix * convertToOGRealMatrix(OGRealDiagonalMatrix const * thing) const;
+    OGOwningRealMatrix * convertToOGRealMatrix(OGLogicalMatrix const * thing) const;
     OGOwningRealMatrix * convertToOGRealMatrix(OGRealSparseMatrix const * thing) const;
 
     OGOwningComplexMatrix * convertToOGComplexMatrix(OGRealScalar const * thing) const;
+    OGOwningComplexMatrix * convertToOGComplexMatrix(OGIntegerScalar const * thing) const;
     OGOwningComplexMatrix * convertToOGComplexMatrix(OGComplexScalar const * thing) const;
     OGOwningComplexMatrix * convertToOGComplexMatrix(OGRealDiagonalMatrix const * thing) const;
     OGOwningComplexMatrix * convertToOGComplexMatrix(OGComplexDiagonalMatrix const * thing) const;
     OGOwningComplexMatrix * convertToOGComplexMatrix(OGRealSparseMatrix const * thing) const;
     OGOwningComplexMatrix * convertToOGComplexMatrix(OGComplexSparseMatrix const * thing) const;
     OGOwningComplexMatrix * convertToOGComplexMatrix(OGRealMatrix const * thing) const;
+    OGOwningComplexMatrix * convertToOGComplexMatrix(OGLogicalMatrix const * thing) const;
 };
 
 }

--- a/include/dispatch.hh
+++ b/include/dispatch.hh
@@ -14,6 +14,7 @@
 #include "jvmmanager.hh"
 #include "exceptions.hh"
 #include "debug.h"
+#include "convertto.hh"
 
 
 namespace librdag {
@@ -50,110 +51,133 @@ public:
   virtual void dispatch(COPY const * thing) const;
   virtual void dispatch(SVD const * thing) const;
   virtual void dispatch(SELECTRESULT const * thing) const;
-  
+
 private:
   PlusRunner * _PlusRunner;
   NegateRunner* _NegateRunner;
-  
+};
+
+class DispatchOp
+{
+  public:
+    DispatchOp();
+    virtual ~DispatchOp();
+    const ConvertTo * getConvertTo() const;
+  private:
+    const ConvertTo * _convert;
 };
 
 /**
  * For dispatching operations of the form "T foo(Register * register1, OGTerminal * arg)"
  */
-template<typename T> class  DispatchUnaryOp
+template<typename T> class  DispatchUnaryOp: public DispatchOp
 {
+static_assert(is_pointer<T>::value, "Type T must be a pointer");
+
 public:
   virtual ~DispatchUnaryOp(){};
-
+  using DispatchOp::getConvertTo;
   // will run the operation
   T eval(RegContainer SUPPRESS_UNUSED * reg, OGTerminal const * arg) const
   {
     ExprType_t argID = arg->getType();
+    T ret = nullptr;
     switch(argID)
     {
       case REAL_SPARSE_MATRIX_ENUM:
         DEBUG_PRINT("running with run(reg, arg->asOGRealSparseMatrix());\n");
-        run(reg, arg->asOGRealSparseMatrix());
+        ret = run(reg, arg->asOGRealSparseMatrix());
         break;
       case REAL_SCALAR_ENUM:
         DEBUG_PRINT("running with run(reg, arg->asOGRealScalar());\n");
-        run(reg, arg->asOGRealScalar());
+        ret = run(reg, arg->asOGRealScalar());
         break;
       case REAL_DIAGONAL_MATRIX_ENUM:
         DEBUG_PRINT("running with run(reg, arg->asOGRealDiagonalMatrix());\n");
-        run(reg, arg->asOGRealDiagonalMatrix());
+        ret = run(reg, arg->asOGRealDiagonalMatrix());
         break;
       case INTEGER_SCALAR_ENUM:
         DEBUG_PRINT("running with run(reg, arg->asOGIntegerScalar());\n");
-        run(reg, arg->asOGIntegerScalar());
+        ret = run(reg, arg->asOGIntegerScalar());
         break;
       case COMPLEX_MATRIX_ENUM:
         DEBUG_PRINT("running with run(reg, arg->asOGComplexMatrix());\n");
-        run(reg, arg->asOGComplexMatrix());
+        ret = run(reg, arg->asOGComplexMatrix());
         break;
       case COMPLEX_DIAGONAL_MATRIX_ENUM:
         DEBUG_PRINT("running with run(reg, arg->asOGComplexDiagonalMatrix());\n");
-        run(reg, arg->asOGComplexDiagonalMatrix());
+        ret = run(reg, arg->asOGComplexDiagonalMatrix());
         break;
       case COMPLEX_SCALAR_ENUM:
         DEBUG_PRINT("running with run(reg, arg->asOGComplexScalar());\n");
-        run(reg, arg->asOGComplexScalar());
+        ret = run(reg, arg->asOGComplexScalar());
         break;
       case LOGICAL_MATRIX_ENUM:
         DEBUG_PRINT("running with run(reg, arg->asOGLogicalMatrix());\n");
-        run(reg, arg->asOGLogicalMatrix());
+        ret = run(reg, arg->asOGLogicalMatrix());
         break;
       case REAL_MATRIX_ENUM:
         DEBUG_PRINT("running with run(reg, arg->asOGRealMatrix());\n");
-        run(reg, arg->asOGRealMatrix());
+        ret = run(reg, arg->asOGRealMatrix());
         break;
       case COMPLEX_SPARSE_MATRIX_ENUM:
         DEBUG_PRINT("running with run(reg, arg->asOGComplexSparseMatrix());\n");
-        run(reg, arg->asOGComplexSparseMatrix());
+        ret = run(reg, arg->asOGComplexSparseMatrix());
         break;
       default:
           throw rdag_error("Unknown type in dispatch on arg");
     }
+    return ret;
   }
 
   virtual T run(RegContainer SUPPRESS_UNUSED * reg, OGRealScalar const SUPPRESS_UNUSED * arg) const
   {
-    // impl convert and run for type OGRealScalar
+    OGOwningRealMatrix * conv = this->getConvertTo()->convertToOGRealMatrix(arg);
+    T ret = run(reg, conv);
+    delete conv;
+    return ret;
   };
 
   virtual T run(RegContainer SUPPRESS_UNUSED * reg, OGComplexScalar const SUPPRESS_UNUSED * arg) const
   {
-    // impl convert and run for type OGComplexScalar
+//     return run(reg, this->getConvertTo()->convertToOGComplexMatrix(arg));
+    return nullptr;
   };
 
   virtual T run(RegContainer SUPPRESS_UNUSED * reg, OGIntegerScalar const SUPPRESS_UNUSED * arg) const
   {
-    // impl convert and run for type OGIntegerScalar
+//     return run(reg, this->getConvertTo()->convertToOGRealMatrix(arg));
+    return nullptr;
   };
 
   virtual T run(RegContainer SUPPRESS_UNUSED * reg, OGLogicalMatrix const SUPPRESS_UNUSED * arg) const
   {
-    // impl convert and run for type OGLogicalMatrix
+//     return run(reg, this->getConvertTo()->convertToOGRealMatrix(arg));
+    return nullptr;
   };
 
   virtual T run(RegContainer SUPPRESS_UNUSED * reg, OGRealDiagonalMatrix const SUPPRESS_UNUSED * arg) const
   {
-    // impl convert and run for type OGRealDiagonalMatrix
+//     return run(reg, this->getConvertTo()->convertToOGRealMatrix(arg));
+    return nullptr;
   };
 
   virtual T run(RegContainer SUPPRESS_UNUSED * reg, OGComplexDiagonalMatrix const SUPPRESS_UNUSED * arg) const
   {
-    // impl convert and run for type OGComplexDiagonalMatrix
+//     return run(reg, this->getConvertTo()->convertToOGComplexMatrix(arg));
+    return nullptr;
   };
 
   virtual T run(RegContainer SUPPRESS_UNUSED * reg, OGRealSparseMatrix const SUPPRESS_UNUSED * arg) const
   {
-    // impl convert and run for type OGRealSparseMatrix
+//     return run(reg, this->getConvertTo()->convertToOGRealMatrix(arg));
+    return nullptr;
   };
 
   virtual T run(RegContainer SUPPRESS_UNUSED * reg, OGComplexSparseMatrix const SUPPRESS_UNUSED * arg) const
   {
-    // impl convert and run for type OGComplexSparseMatrix
+//     return run(reg, this->getConvertTo()->convertToOGComplexMatrix(arg));
+    return nullptr;
   };
 
   // Backstop methods for generic implementation
@@ -165,987 +189,1565 @@ public:
 /**
  * For dispatching operations of the form "T foo(Register * register1, OGTerminal * arg0, OGTerminal * arg1)"
  */
-template<typename T> class  DispatchBinaryOp
+template<typename T> class  DispatchBinaryOp: public DispatchOp
 {
+static_assert(is_pointer<T>::value, "Type T must be a pointer");
 public:
 virtual ~DispatchBinaryOp(){};
- 
+using DispatchOp::getConvertTo;
+
 // will run the operation
 T eval(RegContainer SUPPRESS_UNUSED * reg0, OGTerminal const *arg0, OGTerminal const *arg1) const
 {
   ExprType_t arg0ID = arg0->getType();
   ExprType_t arg1ID = arg1->getType();
+  T ret = nullptr;
   // massive switch table
   switch(arg0ID)
   {
-    case REAL_SPARSE_MATRIX_ENUM:
-        switch(arg1ID)
-        {
-          case REAL_SPARSE_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGRealSparseMatrix());\n");
-              run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGRealSparseMatrix());
-              break;
-          case REAL_SCALAR_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGRealScalar());\n");
-              run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGRealScalar());
-              break;
-          case REAL_DIAGONAL_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGRealDiagonalMatrix());\n");
-              run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGRealDiagonalMatrix());
-              break;
-          case INTEGER_SCALAR_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGIntegerScalar());\n");
-              run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGIntegerScalar());
-              break;
-          case COMPLEX_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGComplexMatrix());\n");
-              run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGComplexMatrix());
-              break;
-          case COMPLEX_DIAGONAL_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGComplexDiagonalMatrix());\n");
-              run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGComplexDiagonalMatrix());
-              break;
-          case COMPLEX_SCALAR_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGComplexScalar());\n");
-              run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGComplexScalar());
-              break;
-          case LOGICAL_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGLogicalMatrix());\n");
-              run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGLogicalMatrix());
-              break;
-          case REAL_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGRealMatrix());\n");
-              run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGRealMatrix());
-              break;
-          case COMPLEX_SPARSE_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGComplexSparseMatrix());\n");
-              run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGComplexSparseMatrix());
-              break;
-          default:
-              throw rdag_error("Unknown type in dispatch on arg1");
-        }
-        break; // end case: arg0ID == REAL_SPARSE_MATRIX_ENUM
     case REAL_SCALAR_ENUM:
         switch(arg1ID)
         {
-          case REAL_SPARSE_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGRealScalar(), arg1->asOGRealSparseMatrix());\n");
-              run(reg0, arg0->asOGRealScalar(), arg1->asOGRealSparseMatrix());
-              break;
           case REAL_SCALAR_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGRealScalar(), arg1->asOGRealScalar());\n");
-              run(reg0, arg0->asOGRealScalar(), arg1->asOGRealScalar());
-              break;
-          case REAL_DIAGONAL_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGRealScalar(), arg1->asOGRealDiagonalMatrix());\n");
-              run(reg0, arg0->asOGRealScalar(), arg1->asOGRealDiagonalMatrix());
-              break;
-          case INTEGER_SCALAR_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGRealScalar(), arg1->asOGIntegerScalar());\n");
-              run(reg0, arg0->asOGRealScalar(), arg1->asOGIntegerScalar());
-              break;
-          case COMPLEX_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGRealScalar(), arg1->asOGComplexMatrix());\n");
-              run(reg0, arg0->asOGRealScalar(), arg1->asOGComplexMatrix());
-              break;
-          case COMPLEX_DIAGONAL_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGRealScalar(), arg1->asOGComplexDiagonalMatrix());\n");
-              run(reg0, arg0->asOGRealScalar(), arg1->asOGComplexDiagonalMatrix());
+              cout << "running with run(reg0, arg0->asOGRealScalar(), arg1->asOGRealScalar());" << std::endl;
+              ret = run(reg0, arg0->asOGRealScalar(), arg1->asOGRealScalar());
               break;
           case COMPLEX_SCALAR_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGRealScalar(), arg1->asOGComplexScalar());\n");
-              run(reg0, arg0->asOGRealScalar(), arg1->asOGComplexScalar());
+              cout << "running with run(reg0, arg0->asOGRealScalar(), arg1->asOGComplexScalar());" << std::endl;
+              ret = run(reg0, arg0->asOGRealScalar(), arg1->asOGComplexScalar());
               break;
-          case LOGICAL_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGRealScalar(), arg1->asOGLogicalMatrix());\n");
-              run(reg0, arg0->asOGRealScalar(), arg1->asOGLogicalMatrix());
+          case INTEGER_SCALAR_ENUM:
+              cout << "running with run(reg0, arg0->asOGRealScalar(), arg1->asOGIntegerScalar());" << std::endl;
+              ret = run(reg0, arg0->asOGRealScalar(), arg1->asOGIntegerScalar());
               break;
           case REAL_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGRealScalar(), arg1->asOGRealMatrix());\n");
-              run(reg0, arg0->asOGRealScalar(), arg1->asOGRealMatrix());
+              cout << "running with run(reg0, arg0->asOGRealScalar(), arg1->asOGRealMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGRealScalar(), arg1->asOGRealMatrix());
+              break;
+          case LOGICAL_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGRealScalar(), arg1->asOGLogicalMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGRealScalar(), arg1->asOGLogicalMatrix());
+              break;
+          case COMPLEX_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGRealScalar(), arg1->asOGComplexMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGRealScalar(), arg1->asOGComplexMatrix());
+              break;
+          case REAL_SPARSE_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGRealScalar(), arg1->asOGRealSparseMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGRealScalar(), arg1->asOGRealSparseMatrix());
               break;
           case COMPLEX_SPARSE_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGRealScalar(), arg1->asOGComplexSparseMatrix());\n");
-              run(reg0, arg0->asOGRealScalar(), arg1->asOGComplexSparseMatrix());
+              cout << "running with run(reg0, arg0->asOGRealScalar(), arg1->asOGComplexSparseMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGRealScalar(), arg1->asOGComplexSparseMatrix());
+              break;
+          case REAL_DIAGONAL_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGRealScalar(), arg1->asOGRealDiagonalMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGRealScalar(), arg1->asOGRealDiagonalMatrix());
+              break;
+          case COMPLEX_DIAGONAL_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGRealScalar(), arg1->asOGComplexDiagonalMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGRealScalar(), arg1->asOGComplexDiagonalMatrix());
               break;
           default:
               throw rdag_error("Unknown type in dispatch on arg1");
         }
         break; // end case: arg0ID == REAL_SCALAR_ENUM
-    case REAL_DIAGONAL_MATRIX_ENUM:
-        switch(arg1ID)
-        {
-          case REAL_SPARSE_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGRealSparseMatrix());\n");
-              run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGRealSparseMatrix());
-              break;
-          case REAL_SCALAR_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGRealScalar());\n");
-              run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGRealScalar());
-              break;
-          case REAL_DIAGONAL_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGRealDiagonalMatrix());\n");
-              run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGRealDiagonalMatrix());
-              break;
-          case INTEGER_SCALAR_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGIntegerScalar());\n");
-              run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGIntegerScalar());
-              break;
-          case COMPLEX_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGComplexMatrix());\n");
-              run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGComplexMatrix());
-              break;
-          case COMPLEX_DIAGONAL_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGComplexDiagonalMatrix());\n");
-              run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGComplexDiagonalMatrix());
-              break;
-          case COMPLEX_SCALAR_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGComplexScalar());\n");
-              run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGComplexScalar());
-              break;
-          case LOGICAL_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGLogicalMatrix());\n");
-              run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGLogicalMatrix());
-              break;
-          case REAL_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGRealMatrix());\n");
-              run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGRealMatrix());
-              break;
-          case COMPLEX_SPARSE_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGComplexSparseMatrix());\n");
-              run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGComplexSparseMatrix());
-              break;
-          default:
-              throw rdag_error("Unknown type in dispatch on arg1");
-        }
-        break; // end case: arg0ID == REAL_DIAGONAL_MATRIX_ENUM
-    case INTEGER_SCALAR_ENUM:
-        switch(arg1ID)
-        {
-          case REAL_SPARSE_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGIntegerScalar(), arg1->asOGRealSparseMatrix());\n");
-              run(reg0, arg0->asOGIntegerScalar(), arg1->asOGRealSparseMatrix());
-              break;
-          case REAL_SCALAR_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGIntegerScalar(), arg1->asOGRealScalar());\n");
-              run(reg0, arg0->asOGIntegerScalar(), arg1->asOGRealScalar());
-              break;
-          case REAL_DIAGONAL_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGIntegerScalar(), arg1->asOGRealDiagonalMatrix());\n");
-              run(reg0, arg0->asOGIntegerScalar(), arg1->asOGRealDiagonalMatrix());
-              break;
-          case INTEGER_SCALAR_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGIntegerScalar(), arg1->asOGIntegerScalar());\n");
-              run(reg0, arg0->asOGIntegerScalar(), arg1->asOGIntegerScalar());
-              break;
-          case COMPLEX_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGIntegerScalar(), arg1->asOGComplexMatrix());\n");
-              run(reg0, arg0->asOGIntegerScalar(), arg1->asOGComplexMatrix());
-              break;
-          case COMPLEX_DIAGONAL_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGIntegerScalar(), arg1->asOGComplexDiagonalMatrix());\n");
-              run(reg0, arg0->asOGIntegerScalar(), arg1->asOGComplexDiagonalMatrix());
-              break;
-          case COMPLEX_SCALAR_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGIntegerScalar(), arg1->asOGComplexScalar());\n");
-              run(reg0, arg0->asOGIntegerScalar(), arg1->asOGComplexScalar());
-              break;
-          case LOGICAL_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGIntegerScalar(), arg1->asOGLogicalMatrix());\n");
-              run(reg0, arg0->asOGIntegerScalar(), arg1->asOGLogicalMatrix());
-              break;
-          case REAL_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGIntegerScalar(), arg1->asOGRealMatrix());\n");
-              run(reg0, arg0->asOGIntegerScalar(), arg1->asOGRealMatrix());
-              break;
-          case COMPLEX_SPARSE_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGIntegerScalar(), arg1->asOGComplexSparseMatrix());\n");
-              run(reg0, arg0->asOGIntegerScalar(), arg1->asOGComplexSparseMatrix());
-              break;
-          default:
-              throw rdag_error("Unknown type in dispatch on arg1");
-        }
-        break; // end case: arg0ID == INTEGER_SCALAR_ENUM
-    case COMPLEX_MATRIX_ENUM:
-        switch(arg1ID)
-        {
-          case REAL_SPARSE_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexMatrix(), arg1->asOGRealSparseMatrix());\n");
-              run(reg0, arg0->asOGComplexMatrix(), arg1->asOGRealSparseMatrix());
-              break;
-          case REAL_SCALAR_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexMatrix(), arg1->asOGRealScalar());\n");
-              run(reg0, arg0->asOGComplexMatrix(), arg1->asOGRealScalar());
-              break;
-          case REAL_DIAGONAL_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexMatrix(), arg1->asOGRealDiagonalMatrix());\n");
-              run(reg0, arg0->asOGComplexMatrix(), arg1->asOGRealDiagonalMatrix());
-              break;
-          case INTEGER_SCALAR_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexMatrix(), arg1->asOGIntegerScalar());\n");
-              run(reg0, arg0->asOGComplexMatrix(), arg1->asOGIntegerScalar());
-              break;
-          case COMPLEX_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexMatrix(), arg1->asOGComplexMatrix());\n");
-              run(reg0, arg0->asOGComplexMatrix(), arg1->asOGComplexMatrix());
-              break;
-          case COMPLEX_DIAGONAL_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexMatrix(), arg1->asOGComplexDiagonalMatrix());\n");
-              run(reg0, arg0->asOGComplexMatrix(), arg1->asOGComplexDiagonalMatrix());
-              break;
-          case COMPLEX_SCALAR_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexMatrix(), arg1->asOGComplexScalar());\n");
-              run(reg0, arg0->asOGComplexMatrix(), arg1->asOGComplexScalar());
-              break;
-          case LOGICAL_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexMatrix(), arg1->asOGLogicalMatrix());\n");
-              run(reg0, arg0->asOGComplexMatrix(), arg1->asOGLogicalMatrix());
-              break;
-          case REAL_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexMatrix(), arg1->asOGRealMatrix());\n");
-              run(reg0, arg0->asOGComplexMatrix(), arg1->asOGRealMatrix());
-              break;
-          case COMPLEX_SPARSE_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexMatrix(), arg1->asOGComplexSparseMatrix());\n");
-              run(reg0, arg0->asOGComplexMatrix(), arg1->asOGComplexSparseMatrix());
-              break;
-          default:
-              throw rdag_error("Unknown type in dispatch on arg1");
-        }
-        break; // end case: arg0ID == COMPLEX_MATRIX_ENUM
-    case COMPLEX_DIAGONAL_MATRIX_ENUM:
-        switch(arg1ID)
-        {
-          case REAL_SPARSE_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGRealSparseMatrix());\n");
-              run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGRealSparseMatrix());
-              break;
-          case REAL_SCALAR_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGRealScalar());\n");
-              run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGRealScalar());
-              break;
-          case REAL_DIAGONAL_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGRealDiagonalMatrix());\n");
-              run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGRealDiagonalMatrix());
-              break;
-          case INTEGER_SCALAR_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGIntegerScalar());\n");
-              run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGIntegerScalar());
-              break;
-          case COMPLEX_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGComplexMatrix());\n");
-              run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGComplexMatrix());
-              break;
-          case COMPLEX_DIAGONAL_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGComplexDiagonalMatrix());\n");
-              run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGComplexDiagonalMatrix());
-              break;
-          case COMPLEX_SCALAR_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGComplexScalar());\n");
-              run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGComplexScalar());
-              break;
-          case LOGICAL_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGLogicalMatrix());\n");
-              run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGLogicalMatrix());
-              break;
-          case REAL_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGRealMatrix());\n");
-              run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGRealMatrix());
-              break;
-          case COMPLEX_SPARSE_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGComplexSparseMatrix());\n");
-              run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGComplexSparseMatrix());
-              break;
-          default:
-              throw rdag_error("Unknown type in dispatch on arg1");
-        }
-        break; // end case: arg0ID == COMPLEX_DIAGONAL_MATRIX_ENUM
     case COMPLEX_SCALAR_ENUM:
         switch(arg1ID)
         {
-          case REAL_SPARSE_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexScalar(), arg1->asOGRealSparseMatrix());\n");
-              run(reg0, arg0->asOGComplexScalar(), arg1->asOGRealSparseMatrix());
-              break;
           case REAL_SCALAR_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexScalar(), arg1->asOGRealScalar());\n");
-              run(reg0, arg0->asOGComplexScalar(), arg1->asOGRealScalar());
-              break;
-          case REAL_DIAGONAL_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexScalar(), arg1->asOGRealDiagonalMatrix());\n");
-              run(reg0, arg0->asOGComplexScalar(), arg1->asOGRealDiagonalMatrix());
-              break;
-          case INTEGER_SCALAR_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexScalar(), arg1->asOGIntegerScalar());\n");
-              run(reg0, arg0->asOGComplexScalar(), arg1->asOGIntegerScalar());
-              break;
-          case COMPLEX_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexScalar(), arg1->asOGComplexMatrix());\n");
-              run(reg0, arg0->asOGComplexScalar(), arg1->asOGComplexMatrix());
-              break;
-          case COMPLEX_DIAGONAL_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexScalar(), arg1->asOGComplexDiagonalMatrix());\n");
-              run(reg0, arg0->asOGComplexScalar(), arg1->asOGComplexDiagonalMatrix());
+              cout << "running with run(reg0, arg0->asOGComplexScalar(), arg1->asOGRealScalar());" << std::endl;
+              ret = run(reg0, arg0->asOGComplexScalar(), arg1->asOGRealScalar());
               break;
           case COMPLEX_SCALAR_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexScalar(), arg1->asOGComplexScalar());\n");
-              run(reg0, arg0->asOGComplexScalar(), arg1->asOGComplexScalar());
+              cout << "running with run(reg0, arg0->asOGComplexScalar(), arg1->asOGComplexScalar());" << std::endl;
+              ret = run(reg0, arg0->asOGComplexScalar(), arg1->asOGComplexScalar());
               break;
-          case LOGICAL_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexScalar(), arg1->asOGLogicalMatrix());\n");
-              run(reg0, arg0->asOGComplexScalar(), arg1->asOGLogicalMatrix());
+          case INTEGER_SCALAR_ENUM:
+              cout << "running with run(reg0, arg0->asOGComplexScalar(), arg1->asOGIntegerScalar());" << std::endl;
+              ret = run(reg0, arg0->asOGComplexScalar(), arg1->asOGIntegerScalar());
               break;
           case REAL_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexScalar(), arg1->asOGRealMatrix());\n");
-              run(reg0, arg0->asOGComplexScalar(), arg1->asOGRealMatrix());
+              cout << "running with run(reg0, arg0->asOGComplexScalar(), arg1->asOGRealMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGComplexScalar(), arg1->asOGRealMatrix());
+              break;
+          case LOGICAL_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGComplexScalar(), arg1->asOGLogicalMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGComplexScalar(), arg1->asOGLogicalMatrix());
+              break;
+          case COMPLEX_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGComplexScalar(), arg1->asOGComplexMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGComplexScalar(), arg1->asOGComplexMatrix());
+              break;
+          case REAL_SPARSE_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGComplexScalar(), arg1->asOGRealSparseMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGComplexScalar(), arg1->asOGRealSparseMatrix());
               break;
           case COMPLEX_SPARSE_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexScalar(), arg1->asOGComplexSparseMatrix());\n");
-              run(reg0, arg0->asOGComplexScalar(), arg1->asOGComplexSparseMatrix());
+              cout << "running with run(reg0, arg0->asOGComplexScalar(), arg1->asOGComplexSparseMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGComplexScalar(), arg1->asOGComplexSparseMatrix());
+              break;
+          case REAL_DIAGONAL_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGComplexScalar(), arg1->asOGRealDiagonalMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGComplexScalar(), arg1->asOGRealDiagonalMatrix());
+              break;
+          case COMPLEX_DIAGONAL_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGComplexScalar(), arg1->asOGComplexDiagonalMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGComplexScalar(), arg1->asOGComplexDiagonalMatrix());
               break;
           default:
               throw rdag_error("Unknown type in dispatch on arg1");
         }
         break; // end case: arg0ID == COMPLEX_SCALAR_ENUM
-    case LOGICAL_MATRIX_ENUM:
+    case INTEGER_SCALAR_ENUM:
         switch(arg1ID)
         {
-          case REAL_SPARSE_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGRealSparseMatrix());\n");
-              run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGRealSparseMatrix());
-              break;
           case REAL_SCALAR_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGRealScalar());\n");
-              run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGRealScalar());
-              break;
-          case REAL_DIAGONAL_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGRealDiagonalMatrix());\n");
-              run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGRealDiagonalMatrix());
-              break;
-          case INTEGER_SCALAR_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGIntegerScalar());\n");
-              run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGIntegerScalar());
-              break;
-          case COMPLEX_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGComplexMatrix());\n");
-              run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGComplexMatrix());
-              break;
-          case COMPLEX_DIAGONAL_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGComplexDiagonalMatrix());\n");
-              run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGComplexDiagonalMatrix());
+              cout << "running with run(reg0, arg0->asOGIntegerScalar(), arg1->asOGRealScalar());" << std::endl;
+              ret = run(reg0, arg0->asOGIntegerScalar(), arg1->asOGRealScalar());
               break;
           case COMPLEX_SCALAR_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGComplexScalar());\n");
-              run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGComplexScalar());
+              cout << "running with run(reg0, arg0->asOGIntegerScalar(), arg1->asOGComplexScalar());" << std::endl;
+              ret = run(reg0, arg0->asOGIntegerScalar(), arg1->asOGComplexScalar());
               break;
-          case LOGICAL_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGLogicalMatrix());\n");
-              run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGLogicalMatrix());
+          case INTEGER_SCALAR_ENUM:
+              cout << "running with run(reg0, arg0->asOGIntegerScalar(), arg1->asOGIntegerScalar());" << std::endl;
+              ret = run(reg0, arg0->asOGIntegerScalar(), arg1->asOGIntegerScalar());
               break;
           case REAL_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGRealMatrix());\n");
-              run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGRealMatrix());
+              cout << "running with run(reg0, arg0->asOGIntegerScalar(), arg1->asOGRealMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGIntegerScalar(), arg1->asOGRealMatrix());
+              break;
+          case LOGICAL_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGIntegerScalar(), arg1->asOGLogicalMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGIntegerScalar(), arg1->asOGLogicalMatrix());
+              break;
+          case COMPLEX_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGIntegerScalar(), arg1->asOGComplexMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGIntegerScalar(), arg1->asOGComplexMatrix());
+              break;
+          case REAL_SPARSE_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGIntegerScalar(), arg1->asOGRealSparseMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGIntegerScalar(), arg1->asOGRealSparseMatrix());
               break;
           case COMPLEX_SPARSE_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGComplexSparseMatrix());\n");
-              run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGComplexSparseMatrix());
+              cout << "running with run(reg0, arg0->asOGIntegerScalar(), arg1->asOGComplexSparseMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGIntegerScalar(), arg1->asOGComplexSparseMatrix());
+              break;
+          case REAL_DIAGONAL_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGIntegerScalar(), arg1->asOGRealDiagonalMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGIntegerScalar(), arg1->asOGRealDiagonalMatrix());
+              break;
+          case COMPLEX_DIAGONAL_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGIntegerScalar(), arg1->asOGComplexDiagonalMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGIntegerScalar(), arg1->asOGComplexDiagonalMatrix());
               break;
           default:
               throw rdag_error("Unknown type in dispatch on arg1");
         }
-        break; // end case: arg0ID == LOGICAL_MATRIX_ENUM
+        break; // end case: arg0ID == INTEGER_SCALAR_ENUM
     case REAL_MATRIX_ENUM:
         switch(arg1ID)
         {
-          case REAL_SPARSE_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGRealMatrix(), arg1->asOGRealSparseMatrix());\n");
-              run(reg0, arg0->asOGRealMatrix(), arg1->asOGRealSparseMatrix());
-              break;
           case REAL_SCALAR_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGRealMatrix(), arg1->asOGRealScalar());\n");
-              run(reg0, arg0->asOGRealMatrix(), arg1->asOGRealScalar());
-              break;
-          case REAL_DIAGONAL_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGRealMatrix(), arg1->asOGRealDiagonalMatrix());\n");
-              run(reg0, arg0->asOGRealMatrix(), arg1->asOGRealDiagonalMatrix());
-              break;
-          case INTEGER_SCALAR_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGRealMatrix(), arg1->asOGIntegerScalar());\n");
-              run(reg0, arg0->asOGRealMatrix(), arg1->asOGIntegerScalar());
-              break;
-          case COMPLEX_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGRealMatrix(), arg1->asOGComplexMatrix());\n");
-              run(reg0, arg0->asOGRealMatrix(), arg1->asOGComplexMatrix());
-              break;
-          case COMPLEX_DIAGONAL_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGRealMatrix(), arg1->asOGComplexDiagonalMatrix());\n");
-              run(reg0, arg0->asOGRealMatrix(), arg1->asOGComplexDiagonalMatrix());
+              cout << "running with run(reg0, arg0->asOGRealMatrix(), arg1->asOGRealScalar());" << std::endl;
+              ret = run(reg0, arg0->asOGRealMatrix(), arg1->asOGRealScalar());
               break;
           case COMPLEX_SCALAR_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGRealMatrix(), arg1->asOGComplexScalar());\n");
-              run(reg0, arg0->asOGRealMatrix(), arg1->asOGComplexScalar());
+              cout << "running with run(reg0, arg0->asOGRealMatrix(), arg1->asOGComplexScalar());" << std::endl;
+              ret = run(reg0, arg0->asOGRealMatrix(), arg1->asOGComplexScalar());
               break;
-          case LOGICAL_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGRealMatrix(), arg1->asOGLogicalMatrix());\n");
-              run(reg0, arg0->asOGRealMatrix(), arg1->asOGLogicalMatrix());
+          case INTEGER_SCALAR_ENUM:
+              cout << "running with run(reg0, arg0->asOGRealMatrix(), arg1->asOGIntegerScalar());" << std::endl;
+              ret = run(reg0, arg0->asOGRealMatrix(), arg1->asOGIntegerScalar());
               break;
           case REAL_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGRealMatrix(), arg1->asOGRealMatrix());\n");
-              run(reg0, arg0->asOGRealMatrix(), arg1->asOGRealMatrix());
+              cout << "running with run(reg0, arg0->asOGRealMatrix(), arg1->asOGRealMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGRealMatrix(), arg1->asOGRealMatrix());
+              break;
+          case LOGICAL_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGRealMatrix(), arg1->asOGLogicalMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGRealMatrix(), arg1->asOGLogicalMatrix());
+              break;
+          case COMPLEX_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGRealMatrix(), arg1->asOGComplexMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGRealMatrix(), arg1->asOGComplexMatrix());
+              break;
+          case REAL_SPARSE_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGRealMatrix(), arg1->asOGRealSparseMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGRealMatrix(), arg1->asOGRealSparseMatrix());
               break;
           case COMPLEX_SPARSE_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGRealMatrix(), arg1->asOGComplexSparseMatrix());\n");
-              run(reg0, arg0->asOGRealMatrix(), arg1->asOGComplexSparseMatrix());
+              cout << "running with run(reg0, arg0->asOGRealMatrix(), arg1->asOGComplexSparseMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGRealMatrix(), arg1->asOGComplexSparseMatrix());
+              break;
+          case REAL_DIAGONAL_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGRealMatrix(), arg1->asOGRealDiagonalMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGRealMatrix(), arg1->asOGRealDiagonalMatrix());
+              break;
+          case COMPLEX_DIAGONAL_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGRealMatrix(), arg1->asOGComplexDiagonalMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGRealMatrix(), arg1->asOGComplexDiagonalMatrix());
               break;
           default:
               throw rdag_error("Unknown type in dispatch on arg1");
         }
         break; // end case: arg0ID == REAL_MATRIX_ENUM
+    case LOGICAL_MATRIX_ENUM:
+        switch(arg1ID)
+        {
+          case REAL_SCALAR_ENUM:
+              cout << "running with run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGRealScalar());" << std::endl;
+              ret = run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGRealScalar());
+              break;
+          case COMPLEX_SCALAR_ENUM:
+              cout << "running with run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGComplexScalar());" << std::endl;
+              ret = run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGComplexScalar());
+              break;
+          case INTEGER_SCALAR_ENUM:
+              cout << "running with run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGIntegerScalar());" << std::endl;
+              ret = run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGIntegerScalar());
+              break;
+          case REAL_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGRealMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGRealMatrix());
+              break;
+          case LOGICAL_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGLogicalMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGLogicalMatrix());
+              break;
+          case COMPLEX_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGComplexMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGComplexMatrix());
+              break;
+          case REAL_SPARSE_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGRealSparseMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGRealSparseMatrix());
+              break;
+          case COMPLEX_SPARSE_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGComplexSparseMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGComplexSparseMatrix());
+              break;
+          case REAL_DIAGONAL_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGRealDiagonalMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGRealDiagonalMatrix());
+              break;
+          case COMPLEX_DIAGONAL_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGComplexDiagonalMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGLogicalMatrix(), arg1->asOGComplexDiagonalMatrix());
+              break;
+          default:
+              throw rdag_error("Unknown type in dispatch on arg1");
+        }
+        break; // end case: arg0ID == LOGICAL_MATRIX_ENUM
+    case COMPLEX_MATRIX_ENUM:
+        switch(arg1ID)
+        {
+          case REAL_SCALAR_ENUM:
+              cout << "running with run(reg0, arg0->asOGComplexMatrix(), arg1->asOGRealScalar());" << std::endl;
+              ret = run(reg0, arg0->asOGComplexMatrix(), arg1->asOGRealScalar());
+              break;
+          case COMPLEX_SCALAR_ENUM:
+              cout << "running with run(reg0, arg0->asOGComplexMatrix(), arg1->asOGComplexScalar());" << std::endl;
+              ret = run(reg0, arg0->asOGComplexMatrix(), arg1->asOGComplexScalar());
+              break;
+          case INTEGER_SCALAR_ENUM:
+              cout << "running with run(reg0, arg0->asOGComplexMatrix(), arg1->asOGIntegerScalar());" << std::endl;
+              ret = run(reg0, arg0->asOGComplexMatrix(), arg1->asOGIntegerScalar());
+              break;
+          case REAL_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGComplexMatrix(), arg1->asOGRealMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGComplexMatrix(), arg1->asOGRealMatrix());
+              break;
+          case LOGICAL_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGComplexMatrix(), arg1->asOGLogicalMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGComplexMatrix(), arg1->asOGLogicalMatrix());
+              break;
+          case COMPLEX_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGComplexMatrix(), arg1->asOGComplexMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGComplexMatrix(), arg1->asOGComplexMatrix());
+              break;
+          case REAL_SPARSE_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGComplexMatrix(), arg1->asOGRealSparseMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGComplexMatrix(), arg1->asOGRealSparseMatrix());
+              break;
+          case COMPLEX_SPARSE_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGComplexMatrix(), arg1->asOGComplexSparseMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGComplexMatrix(), arg1->asOGComplexSparseMatrix());
+              break;
+          case REAL_DIAGONAL_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGComplexMatrix(), arg1->asOGRealDiagonalMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGComplexMatrix(), arg1->asOGRealDiagonalMatrix());
+              break;
+          case COMPLEX_DIAGONAL_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGComplexMatrix(), arg1->asOGComplexDiagonalMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGComplexMatrix(), arg1->asOGComplexDiagonalMatrix());
+              break;
+          default:
+              throw rdag_error("Unknown type in dispatch on arg1");
+        }
+        break; // end case: arg0ID == COMPLEX_MATRIX_ENUM
+    case REAL_SPARSE_MATRIX_ENUM:
+        switch(arg1ID)
+        {
+          case REAL_SCALAR_ENUM:
+              cout << "running with run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGRealScalar());" << std::endl;
+              ret = run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGRealScalar());
+              break;
+          case COMPLEX_SCALAR_ENUM:
+              cout << "running with run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGComplexScalar());" << std::endl;
+              ret = run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGComplexScalar());
+              break;
+          case INTEGER_SCALAR_ENUM:
+              cout << "running with run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGIntegerScalar());" << std::endl;
+              ret = run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGIntegerScalar());
+              break;
+          case REAL_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGRealMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGRealMatrix());
+              break;
+          case LOGICAL_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGLogicalMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGLogicalMatrix());
+              break;
+          case COMPLEX_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGComplexMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGComplexMatrix());
+              break;
+          case REAL_SPARSE_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGRealSparseMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGRealSparseMatrix());
+              break;
+          case COMPLEX_SPARSE_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGComplexSparseMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGComplexSparseMatrix());
+              break;
+          case REAL_DIAGONAL_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGRealDiagonalMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGRealDiagonalMatrix());
+              break;
+          case COMPLEX_DIAGONAL_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGComplexDiagonalMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGRealSparseMatrix(), arg1->asOGComplexDiagonalMatrix());
+              break;
+          default:
+              throw rdag_error("Unknown type in dispatch on arg1");
+        }
+        break; // end case: arg0ID == REAL_SPARSE_MATRIX_ENUM
     case COMPLEX_SPARSE_MATRIX_ENUM:
         switch(arg1ID)
         {
-          case REAL_SPARSE_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGRealSparseMatrix());\n");
-              run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGRealSparseMatrix());
-              break;
           case REAL_SCALAR_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGRealScalar());\n");
-              run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGRealScalar());
-              break;
-          case REAL_DIAGONAL_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGRealDiagonalMatrix());\n");
-              run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGRealDiagonalMatrix());
-              break;
-          case INTEGER_SCALAR_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGIntegerScalar());\n");
-              run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGIntegerScalar());
-              break;
-          case COMPLEX_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGComplexMatrix());\n");
-              run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGComplexMatrix());
-              break;
-          case COMPLEX_DIAGONAL_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGComplexDiagonalMatrix());\n");
-              run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGComplexDiagonalMatrix());
+              cout << "running with run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGRealScalar());" << std::endl;
+              ret = run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGRealScalar());
               break;
           case COMPLEX_SCALAR_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGComplexScalar());\n");
-              run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGComplexScalar());
+              cout << "running with run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGComplexScalar());" << std::endl;
+              ret = run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGComplexScalar());
               break;
-          case LOGICAL_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGLogicalMatrix());\n");
-              run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGLogicalMatrix());
+          case INTEGER_SCALAR_ENUM:
+              cout << "running with run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGIntegerScalar());" << std::endl;
+              ret = run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGIntegerScalar());
               break;
           case REAL_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGRealMatrix());\n");
-              run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGRealMatrix());
+              cout << "running with run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGRealMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGRealMatrix());
+              break;
+          case LOGICAL_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGLogicalMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGLogicalMatrix());
+              break;
+          case COMPLEX_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGComplexMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGComplexMatrix());
+              break;
+          case REAL_SPARSE_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGRealSparseMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGRealSparseMatrix());
               break;
           case COMPLEX_SPARSE_MATRIX_ENUM:
-              DEBUG_PRINT("running with run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGComplexSparseMatrix());\n");
-              run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGComplexSparseMatrix());
+              cout << "running with run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGComplexSparseMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGComplexSparseMatrix());
+              break;
+          case REAL_DIAGONAL_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGRealDiagonalMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGRealDiagonalMatrix());
+              break;
+          case COMPLEX_DIAGONAL_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGComplexDiagonalMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGComplexSparseMatrix(), arg1->asOGComplexDiagonalMatrix());
               break;
           default:
               throw rdag_error("Unknown type in dispatch on arg1");
         }
         break; // end case: arg0ID == COMPLEX_SPARSE_MATRIX_ENUM
+    case REAL_DIAGONAL_MATRIX_ENUM:
+        switch(arg1ID)
+        {
+          case REAL_SCALAR_ENUM:
+              cout << "running with run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGRealScalar());" << std::endl;
+              ret = run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGRealScalar());
+              break;
+          case COMPLEX_SCALAR_ENUM:
+              cout << "running with run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGComplexScalar());" << std::endl;
+              ret = run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGComplexScalar());
+              break;
+          case INTEGER_SCALAR_ENUM:
+              cout << "running with run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGIntegerScalar());" << std::endl;
+              ret = run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGIntegerScalar());
+              break;
+          case REAL_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGRealMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGRealMatrix());
+              break;
+          case LOGICAL_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGLogicalMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGLogicalMatrix());
+              break;
+          case COMPLEX_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGComplexMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGComplexMatrix());
+              break;
+          case REAL_SPARSE_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGRealSparseMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGRealSparseMatrix());
+              break;
+          case COMPLEX_SPARSE_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGComplexSparseMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGComplexSparseMatrix());
+              break;
+          case REAL_DIAGONAL_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGRealDiagonalMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGRealDiagonalMatrix());
+              break;
+          case COMPLEX_DIAGONAL_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGComplexDiagonalMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGRealDiagonalMatrix(), arg1->asOGComplexDiagonalMatrix());
+              break;
+          default:
+              throw rdag_error("Unknown type in dispatch on arg1");
+        }
+        break; // end case: arg0ID == REAL_DIAGONAL_MATRIX_ENUM
+    case COMPLEX_DIAGONAL_MATRIX_ENUM:
+        switch(arg1ID)
+        {
+          case REAL_SCALAR_ENUM:
+              cout << "running with run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGRealScalar());" << std::endl;
+              ret = run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGRealScalar());
+              break;
+          case COMPLEX_SCALAR_ENUM:
+              cout << "running with run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGComplexScalar());" << std::endl;
+              ret = run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGComplexScalar());
+              break;
+          case INTEGER_SCALAR_ENUM:
+              cout << "running with run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGIntegerScalar());" << std::endl;
+              ret = run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGIntegerScalar());
+              break;
+          case REAL_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGRealMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGRealMatrix());
+              break;
+          case LOGICAL_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGLogicalMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGLogicalMatrix());
+              break;
+          case COMPLEX_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGComplexMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGComplexMatrix());
+              break;
+          case REAL_SPARSE_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGRealSparseMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGRealSparseMatrix());
+              break;
+          case COMPLEX_SPARSE_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGComplexSparseMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGComplexSparseMatrix());
+              break;
+          case REAL_DIAGONAL_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGRealDiagonalMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGRealDiagonalMatrix());
+              break;
+          case COMPLEX_DIAGONAL_MATRIX_ENUM:
+              cout << "running with run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGComplexDiagonalMatrix());" << std::endl;
+              ret = run(reg0, arg0->asOGComplexDiagonalMatrix(), arg1->asOGComplexDiagonalMatrix());
+              break;
+          default:
+              throw rdag_error("Unknown type in dispatch on arg1");
+        }
+        break; // end case: arg0ID == COMPLEX_DIAGONAL_MATRIX_ENUM
     default:
         throw rdag_error("Unknown type in dispatch on arg0");
   }
-
-  
+  return ret;
 };
 
 // specific methods
-//  MAT="OGRealScalar OGComplexScalar OGIntegerScalar OGRealMatrix OGLogicalMatrix OGComplexMatrix OGRealDiagonalMatrix OGComplexDiagonalMatrix OGRealSparseMatrix OGComplexSparseMatrix"; for i in $MAT; do for j in $MAT; do printf "virtual T run(RegContainer SUPPRESS_UNUSED * reg0, ${i} const SUPPRESS_UNUSED * arg0, ${j} const SUPPRESS_UNUSED * arg1) const \n{\n  // impl convert and run for types ${i} and ${j} \n};\n\n";done;done
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealScalar const SUPPRESS_UNUSED * arg0, OGRealScalar const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGRealScalar and OGRealScalar 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealScalar const SUPPRESS_UNUSED * arg0, OGComplexScalar const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGRealScalar and OGComplexScalar 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealScalar const SUPPRESS_UNUSED * arg0, OGIntegerScalar const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGRealScalar and OGIntegerScalar 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealScalar const SUPPRESS_UNUSED * arg0, OGRealMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGRealScalar and OGRealMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealScalar const SUPPRESS_UNUSED * arg0, OGLogicalMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGRealScalar and OGLogicalMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealScalar const SUPPRESS_UNUSED * arg0, OGComplexMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGRealScalar and OGComplexMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealScalar const SUPPRESS_UNUSED * arg0, OGRealDiagonalMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGRealScalar and OGRealDiagonalMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealScalar const SUPPRESS_UNUSED * arg0, OGComplexDiagonalMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGRealScalar and OGComplexDiagonalMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealScalar const SUPPRESS_UNUSED * arg0, OGRealSparseMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGRealScalar and OGRealSparseMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealScalar const SUPPRESS_UNUSED * arg0, OGComplexSparseMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGRealScalar and OGComplexSparseMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexScalar const SUPPRESS_UNUSED * arg0, OGRealScalar const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGComplexScalar and OGRealScalar 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexScalar const SUPPRESS_UNUSED * arg0, OGComplexScalar const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGComplexScalar and OGComplexScalar 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexScalar const SUPPRESS_UNUSED * arg0, OGIntegerScalar const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGComplexScalar and OGIntegerScalar 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexScalar const SUPPRESS_UNUSED * arg0, OGRealMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGComplexScalar and OGRealMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexScalar const SUPPRESS_UNUSED * arg0, OGLogicalMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGComplexScalar and OGLogicalMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexScalar const SUPPRESS_UNUSED * arg0, OGComplexMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGComplexScalar and OGComplexMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexScalar const SUPPRESS_UNUSED * arg0, OGRealDiagonalMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGComplexScalar and OGRealDiagonalMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexScalar const SUPPRESS_UNUSED * arg0, OGComplexDiagonalMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGComplexScalar and OGComplexDiagonalMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexScalar const SUPPRESS_UNUSED * arg0, OGRealSparseMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGComplexScalar and OGRealSparseMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexScalar const SUPPRESS_UNUSED * arg0, OGComplexSparseMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGComplexScalar and OGComplexSparseMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGIntegerScalar const SUPPRESS_UNUSED * arg0, OGRealScalar const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGIntegerScalar and OGRealScalar 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGIntegerScalar const SUPPRESS_UNUSED * arg0, OGComplexScalar const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGIntegerScalar and OGComplexScalar 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGIntegerScalar const SUPPRESS_UNUSED * arg0, OGIntegerScalar const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGIntegerScalar and OGIntegerScalar 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGIntegerScalar const SUPPRESS_UNUSED * arg0, OGRealMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGIntegerScalar and OGRealMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGIntegerScalar const SUPPRESS_UNUSED * arg0, OGLogicalMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGIntegerScalar and OGLogicalMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGIntegerScalar const SUPPRESS_UNUSED * arg0, OGComplexMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGIntegerScalar and OGComplexMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGIntegerScalar const SUPPRESS_UNUSED * arg0, OGRealDiagonalMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGIntegerScalar and OGRealDiagonalMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGIntegerScalar const SUPPRESS_UNUSED * arg0, OGComplexDiagonalMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGIntegerScalar and OGComplexDiagonalMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGIntegerScalar const SUPPRESS_UNUSED * arg0, OGRealSparseMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGIntegerScalar and OGRealSparseMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGIntegerScalar const SUPPRESS_UNUSED * arg0, OGComplexSparseMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGIntegerScalar and OGComplexSparseMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealMatrix const SUPPRESS_UNUSED * arg0, OGRealScalar const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGRealMatrix and OGRealScalar 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealMatrix const SUPPRESS_UNUSED * arg0, OGComplexScalar const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGRealMatrix and OGComplexScalar 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealMatrix const SUPPRESS_UNUSED * arg0, OGIntegerScalar const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGRealMatrix and OGIntegerScalar 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealMatrix const SUPPRESS_UNUSED * arg0, OGLogicalMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGRealMatrix and OGLogicalMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealMatrix const SUPPRESS_UNUSED * arg0, OGComplexMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGRealMatrix and OGComplexMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealMatrix const SUPPRESS_UNUSED * arg0, OGRealDiagonalMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGRealMatrix and OGRealDiagonalMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealMatrix const SUPPRESS_UNUSED * arg0, OGComplexDiagonalMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGRealMatrix and OGComplexDiagonalMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealMatrix const SUPPRESS_UNUSED * arg0, OGRealSparseMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGRealMatrix and OGRealSparseMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealMatrix const SUPPRESS_UNUSED * arg0, OGComplexSparseMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGRealMatrix and OGComplexSparseMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGLogicalMatrix const SUPPRESS_UNUSED * arg0, OGRealScalar const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGLogicalMatrix and OGRealScalar 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGLogicalMatrix const SUPPRESS_UNUSED * arg0, OGComplexScalar const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGLogicalMatrix and OGComplexScalar 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGLogicalMatrix const SUPPRESS_UNUSED * arg0, OGIntegerScalar const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGLogicalMatrix and OGIntegerScalar 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGLogicalMatrix const SUPPRESS_UNUSED * arg0, OGRealMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGLogicalMatrix and OGRealMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGLogicalMatrix const SUPPRESS_UNUSED * arg0, OGLogicalMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGLogicalMatrix and OGLogicalMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGLogicalMatrix const SUPPRESS_UNUSED * arg0, OGComplexMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGLogicalMatrix and OGComplexMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGLogicalMatrix const SUPPRESS_UNUSED * arg0, OGRealDiagonalMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGLogicalMatrix and OGRealDiagonalMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGLogicalMatrix const SUPPRESS_UNUSED * arg0, OGComplexDiagonalMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGLogicalMatrix and OGComplexDiagonalMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGLogicalMatrix const SUPPRESS_UNUSED * arg0, OGRealSparseMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGLogicalMatrix and OGRealSparseMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGLogicalMatrix const SUPPRESS_UNUSED * arg0, OGComplexSparseMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGLogicalMatrix and OGComplexSparseMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexMatrix const SUPPRESS_UNUSED * arg0, OGRealScalar const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGComplexMatrix and OGRealScalar 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexMatrix const SUPPRESS_UNUSED * arg0, OGComplexScalar const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGComplexMatrix and OGComplexScalar 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexMatrix const SUPPRESS_UNUSED * arg0, OGIntegerScalar const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGComplexMatrix and OGIntegerScalar 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexMatrix const SUPPRESS_UNUSED * arg0, OGRealMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGComplexMatrix and OGRealMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexMatrix const SUPPRESS_UNUSED * arg0, OGLogicalMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGComplexMatrix and OGLogicalMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexMatrix const SUPPRESS_UNUSED * arg0, OGRealDiagonalMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGComplexMatrix and OGRealDiagonalMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexMatrix const SUPPRESS_UNUSED * arg0, OGComplexDiagonalMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGComplexMatrix and OGComplexDiagonalMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexMatrix const SUPPRESS_UNUSED * arg0, OGRealSparseMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGComplexMatrix and OGRealSparseMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexMatrix const SUPPRESS_UNUSED * arg0, OGComplexSparseMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGComplexMatrix and OGComplexSparseMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealDiagonalMatrix const SUPPRESS_UNUSED * arg0, OGRealScalar const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGRealDiagonalMatrix and OGRealScalar 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealDiagonalMatrix const SUPPRESS_UNUSED * arg0, OGComplexScalar const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGRealDiagonalMatrix and OGComplexScalar 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealDiagonalMatrix const SUPPRESS_UNUSED * arg0, OGIntegerScalar const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGRealDiagonalMatrix and OGIntegerScalar 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealDiagonalMatrix const SUPPRESS_UNUSED * arg0, OGRealMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGRealDiagonalMatrix and OGRealMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealDiagonalMatrix const SUPPRESS_UNUSED * arg0, OGLogicalMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGRealDiagonalMatrix and OGLogicalMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealDiagonalMatrix const SUPPRESS_UNUSED * arg0, OGComplexMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGRealDiagonalMatrix and OGComplexMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealDiagonalMatrix const SUPPRESS_UNUSED * arg0, OGRealDiagonalMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGRealDiagonalMatrix and OGRealDiagonalMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealDiagonalMatrix const SUPPRESS_UNUSED * arg0, OGComplexDiagonalMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGRealDiagonalMatrix and OGComplexDiagonalMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealDiagonalMatrix const SUPPRESS_UNUSED * arg0, OGRealSparseMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGRealDiagonalMatrix and OGRealSparseMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealDiagonalMatrix const SUPPRESS_UNUSED * arg0, OGComplexSparseMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGRealDiagonalMatrix and OGComplexSparseMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexDiagonalMatrix const SUPPRESS_UNUSED * arg0, OGRealScalar const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGComplexDiagonalMatrix and OGRealScalar 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexDiagonalMatrix const SUPPRESS_UNUSED * arg0, OGComplexScalar const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGComplexDiagonalMatrix and OGComplexScalar 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexDiagonalMatrix const SUPPRESS_UNUSED * arg0, OGIntegerScalar const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGComplexDiagonalMatrix and OGIntegerScalar 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexDiagonalMatrix const SUPPRESS_UNUSED * arg0, OGRealMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGComplexDiagonalMatrix and OGRealMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexDiagonalMatrix const SUPPRESS_UNUSED * arg0, OGLogicalMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGComplexDiagonalMatrix and OGLogicalMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexDiagonalMatrix const SUPPRESS_UNUSED * arg0, OGComplexMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGComplexDiagonalMatrix and OGComplexMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexDiagonalMatrix const SUPPRESS_UNUSED * arg0, OGRealDiagonalMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGComplexDiagonalMatrix and OGRealDiagonalMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexDiagonalMatrix const SUPPRESS_UNUSED * arg0, OGComplexDiagonalMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGComplexDiagonalMatrix and OGComplexDiagonalMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexDiagonalMatrix const SUPPRESS_UNUSED * arg0, OGRealSparseMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGComplexDiagonalMatrix and OGRealSparseMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexDiagonalMatrix const SUPPRESS_UNUSED * arg0, OGComplexSparseMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGComplexDiagonalMatrix and OGComplexSparseMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealSparseMatrix const SUPPRESS_UNUSED * arg0, OGRealScalar const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGRealSparseMatrix and OGRealScalar 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealSparseMatrix const SUPPRESS_UNUSED * arg0, OGComplexScalar const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGRealSparseMatrix and OGComplexScalar 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealSparseMatrix const SUPPRESS_UNUSED * arg0, OGIntegerScalar const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGRealSparseMatrix and OGIntegerScalar 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealSparseMatrix const SUPPRESS_UNUSED * arg0, OGRealMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGRealSparseMatrix and OGRealMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealSparseMatrix const SUPPRESS_UNUSED * arg0, OGLogicalMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGRealSparseMatrix and OGLogicalMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealSparseMatrix const SUPPRESS_UNUSED * arg0, OGComplexMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGRealSparseMatrix and OGComplexMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealSparseMatrix const SUPPRESS_UNUSED * arg0, OGRealDiagonalMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGRealSparseMatrix and OGRealDiagonalMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealSparseMatrix const SUPPRESS_UNUSED * arg0, OGComplexDiagonalMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGRealSparseMatrix and OGComplexDiagonalMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealSparseMatrix const SUPPRESS_UNUSED * arg0, OGRealSparseMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGRealSparseMatrix and OGRealSparseMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealSparseMatrix const SUPPRESS_UNUSED * arg0, OGComplexSparseMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGRealSparseMatrix and OGComplexSparseMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexSparseMatrix const SUPPRESS_UNUSED * arg0, OGRealScalar const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGComplexSparseMatrix and OGRealScalar 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexSparseMatrix const SUPPRESS_UNUSED * arg0, OGComplexScalar const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGComplexSparseMatrix and OGComplexScalar 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexSparseMatrix const SUPPRESS_UNUSED * arg0, OGIntegerScalar const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGComplexSparseMatrix and OGIntegerScalar 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexSparseMatrix const SUPPRESS_UNUSED * arg0, OGRealMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGComplexSparseMatrix and OGRealMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexSparseMatrix const SUPPRESS_UNUSED * arg0, OGLogicalMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGComplexSparseMatrix and OGLogicalMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexSparseMatrix const SUPPRESS_UNUSED * arg0, OGComplexMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGComplexSparseMatrix and OGComplexMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexSparseMatrix const SUPPRESS_UNUSED * arg0, OGRealDiagonalMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGComplexSparseMatrix and OGRealDiagonalMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexSparseMatrix const SUPPRESS_UNUSED * arg0, OGComplexDiagonalMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGComplexSparseMatrix and OGComplexDiagonalMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexSparseMatrix const SUPPRESS_UNUSED * arg0, OGRealSparseMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGComplexSparseMatrix and OGRealSparseMatrix 
-};
-
-virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexSparseMatrix const SUPPRESS_UNUSED * arg0, OGComplexSparseMatrix const SUPPRESS_UNUSED * arg1) const 
-{
-  // impl convert and run for types OGComplexSparseMatrix and OGComplexSparseMatrix 
-};
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealScalar const SUPPRESS_UNUSED * arg0, OGRealScalar const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGRealScalar and OGRealScalar
+         OGRealMatrix * conv0 = this->getConvertTo()->convertToOGRealMatrix(arg0);
+         OGRealMatrix * conv1 = this->getConvertTo()->convertToOGRealMatrix(arg1);
+         T ret = run(reg0,conv0,conv1);
+
+         delete conv0;
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealScalar const SUPPRESS_UNUSED * arg0, OGComplexScalar const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGRealScalar and OGComplexScalar
+         OGComplexMatrix * conv0 = this->getConvertTo()->convertToOGComplexMatrix(arg0);
+         OGComplexMatrix * conv1 = this->getConvertTo()->convertToOGComplexMatrix(arg1);
+         T ret = run(reg0,conv0,conv1);
+         delete conv0;
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealScalar const SUPPRESS_UNUSED * arg0, OGIntegerScalar const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGRealScalar and OGIntegerScalar
+   return nullptr;
+
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealScalar const SUPPRESS_UNUSED * arg0, OGRealMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGRealScalar and OGRealMatrix
+         OGRealMatrix * conv0 = this->getConvertTo()->convertToOGRealMatrix(arg0);
+         T ret = run(reg0,conv0,arg1);
+         delete conv0;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealScalar const SUPPRESS_UNUSED * arg0, OGLogicalMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGRealScalar and OGLogicalMatrix
+   return nullptr;
+
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealScalar const SUPPRESS_UNUSED * arg0, OGComplexMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGRealScalar and OGComplexMatrix
+         OGComplexMatrix * conv0 = this->getConvertTo()->convertToOGComplexMatrix(arg0);
+         T ret = run(reg0,conv0,arg1);
+         delete conv0;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealScalar const SUPPRESS_UNUSED * arg0, OGRealSparseMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGRealScalar and OGRealSparseMatrix
+         OGRealMatrix * conv0 = this->getConvertTo()->convertToOGRealMatrix(arg0);
+         OGRealMatrix * conv1 = this->getConvertTo()->convertToOGRealMatrix(arg1);
+         T ret = run(reg0,conv0,conv1);
+
+         delete conv0;
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealScalar const SUPPRESS_UNUSED * arg0, OGComplexSparseMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGRealScalar and OGComplexSparseMatrix
+         OGComplexMatrix * conv0 = this->getConvertTo()->convertToOGComplexMatrix(arg0);
+         OGComplexMatrix * conv1 = this->getConvertTo()->convertToOGComplexMatrix(arg1);
+         T ret = run(reg0,conv0,conv1);
+         delete conv0;
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealScalar const SUPPRESS_UNUSED * arg0, OGRealDiagonalMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGRealScalar and OGRealDiagonalMatrix
+         OGRealMatrix * conv0 = this->getConvertTo()->convertToOGRealMatrix(arg0);
+         OGRealMatrix * conv1 = this->getConvertTo()->convertToOGRealMatrix(arg1);
+         T ret = run(reg0,conv0,conv1);
+
+         delete conv0;
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealScalar const SUPPRESS_UNUSED * arg0, OGComplexDiagonalMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGRealScalar and OGComplexDiagonalMatrix
+         OGComplexMatrix * conv0 = this->getConvertTo()->convertToOGComplexMatrix(arg0);
+         OGComplexMatrix * conv1 = this->getConvertTo()->convertToOGComplexMatrix(arg1);
+         T ret = run(reg0,conv0,conv1);
+         delete conv0;
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexScalar const SUPPRESS_UNUSED * arg0, OGRealScalar const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGComplexScalar and OGRealScalar
+         OGComplexMatrix * conv0 = this->getConvertTo()->convertToOGComplexMatrix(arg0);
+         OGComplexMatrix * conv1 = this->getConvertTo()->convertToOGComplexMatrix(arg1);
+         T ret = run(reg0,conv0,conv1);
+         delete conv0;
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexScalar const SUPPRESS_UNUSED * arg0, OGComplexScalar const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGComplexScalar and OGComplexScalar
+         OGComplexMatrix * conv0 = this->getConvertTo()->convertToOGComplexMatrix(arg0);
+         OGComplexMatrix * conv1 = this->getConvertTo()->convertToOGComplexMatrix(arg1);
+         T ret = run(reg0,conv0,conv1);
+         delete conv0;
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexScalar const SUPPRESS_UNUSED * arg0, OGIntegerScalar const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGComplexScalar and OGIntegerScalar
+   return nullptr;
+
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexScalar const SUPPRESS_UNUSED * arg0, OGRealMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGComplexScalar and OGRealMatrix
+         OGComplexMatrix * conv0 = this->getConvertTo()->convertToOGComplexMatrix(arg0);
+         OGComplexMatrix * conv1 = this->getConvertTo()->convertToOGComplexMatrix(arg1);
+         T ret = run(reg0,conv0,conv1);
+         delete conv0;
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexScalar const SUPPRESS_UNUSED * arg0, OGLogicalMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGComplexScalar and OGLogicalMatrix
+   return nullptr;
+
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexScalar const SUPPRESS_UNUSED * arg0, OGComplexMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGComplexScalar and OGComplexMatrix
+         OGComplexMatrix * conv0 = this->getConvertTo()->convertToOGComplexMatrix(arg0);
+         T ret = run(reg0,conv0,arg1);
+         delete conv0;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexScalar const SUPPRESS_UNUSED * arg0, OGRealSparseMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGComplexScalar and OGRealSparseMatrix
+         OGComplexMatrix * conv0 = this->getConvertTo()->convertToOGComplexMatrix(arg0);
+         OGComplexMatrix * conv1 = this->getConvertTo()->convertToOGComplexMatrix(arg1);
+         T ret = run(reg0,conv0,conv1);
+         delete conv0;
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexScalar const SUPPRESS_UNUSED * arg0, OGComplexSparseMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGComplexScalar and OGComplexSparseMatrix
+         OGComplexMatrix * conv0 = this->getConvertTo()->convertToOGComplexMatrix(arg0);
+         OGComplexMatrix * conv1 = this->getConvertTo()->convertToOGComplexMatrix(arg1);
+         T ret = run(reg0,conv0,conv1);
+         delete conv0;
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexScalar const SUPPRESS_UNUSED * arg0, OGRealDiagonalMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGComplexScalar and OGRealDiagonalMatrix
+         OGComplexMatrix * conv0 = this->getConvertTo()->convertToOGComplexMatrix(arg0);
+         OGComplexMatrix * conv1 = this->getConvertTo()->convertToOGComplexMatrix(arg1);
+         T ret = run(reg0,conv0,conv1);
+         delete conv0;
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexScalar const SUPPRESS_UNUSED * arg0, OGComplexDiagonalMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGComplexScalar and OGComplexDiagonalMatrix
+         OGComplexMatrix * conv0 = this->getConvertTo()->convertToOGComplexMatrix(arg0);
+         OGComplexMatrix * conv1 = this->getConvertTo()->convertToOGComplexMatrix(arg1);
+         T ret = run(reg0,conv0,conv1);
+         delete conv0;
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGIntegerScalar const SUPPRESS_UNUSED * arg0, OGRealScalar const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGIntegerScalar and OGRealScalar
+   return nullptr;
+
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGIntegerScalar const SUPPRESS_UNUSED * arg0, OGComplexScalar const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGIntegerScalar and OGComplexScalar
+   return nullptr;
+
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGIntegerScalar const SUPPRESS_UNUSED * arg0, OGIntegerScalar const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGIntegerScalar and OGIntegerScalar
+   return nullptr;
+
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGIntegerScalar const SUPPRESS_UNUSED * arg0, OGRealMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGIntegerScalar and OGRealMatrix
+   return nullptr;
+
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGIntegerScalar const SUPPRESS_UNUSED * arg0, OGLogicalMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGIntegerScalar and OGLogicalMatrix
+   return nullptr;
+
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGIntegerScalar const SUPPRESS_UNUSED * arg0, OGComplexMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGIntegerScalar and OGComplexMatrix
+   return nullptr;
+
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGIntegerScalar const SUPPRESS_UNUSED * arg0, OGRealSparseMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGIntegerScalar and OGRealSparseMatrix
+   return nullptr;
+
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGIntegerScalar const SUPPRESS_UNUSED * arg0, OGComplexSparseMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGIntegerScalar and OGComplexSparseMatrix
+   return nullptr;
+
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGIntegerScalar const SUPPRESS_UNUSED * arg0, OGRealDiagonalMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGIntegerScalar and OGRealDiagonalMatrix
+   return nullptr;
+
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGIntegerScalar const SUPPRESS_UNUSED * arg0, OGComplexDiagonalMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGIntegerScalar and OGComplexDiagonalMatrix
+   return nullptr;
+
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealMatrix const SUPPRESS_UNUSED * arg0, OGRealScalar const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGRealMatrix and OGRealScalar
+         OGRealMatrix * conv1 = this->getConvertTo()->convertToOGRealMatrix(arg1);
+         T ret = run(reg0,arg0,conv1);
+
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealMatrix const SUPPRESS_UNUSED * arg0, OGComplexScalar const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGRealMatrix and OGComplexScalar
+         OGComplexMatrix * conv0 = this->getConvertTo()->convertToOGComplexMatrix(arg0);
+         OGComplexMatrix * conv1 = this->getConvertTo()->convertToOGComplexMatrix(arg1);
+         T ret = run(reg0,conv0,conv1);
+         delete conv0;
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealMatrix const SUPPRESS_UNUSED * arg0, OGIntegerScalar const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGRealMatrix and OGIntegerScalar
+   return nullptr;
+
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealMatrix const SUPPRESS_UNUSED * arg0, OGLogicalMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGRealMatrix and OGLogicalMatrix
+   return nullptr;
+
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealMatrix const SUPPRESS_UNUSED * arg0, OGComplexMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGRealMatrix and OGComplexMatrix
+         OGComplexMatrix * conv0 = this->getConvertTo()->convertToOGComplexMatrix(arg0);
+         T ret = run(reg0,conv0,arg1);
+         delete conv0;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealMatrix const SUPPRESS_UNUSED * arg0, OGRealSparseMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGRealMatrix and OGRealSparseMatrix
+         OGRealMatrix * conv1 = this->getConvertTo()->convertToOGRealMatrix(arg1);
+         T ret = run(reg0,arg0,conv1);
+
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealMatrix const SUPPRESS_UNUSED * arg0, OGComplexSparseMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGRealMatrix and OGComplexSparseMatrix
+         OGComplexMatrix * conv0 = this->getConvertTo()->convertToOGComplexMatrix(arg0);
+         OGComplexMatrix * conv1 = this->getConvertTo()->convertToOGComplexMatrix(arg1);
+         T ret = run(reg0,conv0,conv1);
+         delete conv0;
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealMatrix const SUPPRESS_UNUSED * arg0, OGRealDiagonalMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGRealMatrix and OGRealDiagonalMatrix
+         OGRealMatrix * conv1 = this->getConvertTo()->convertToOGRealMatrix(arg1);
+         T ret = run(reg0,arg0,conv1);
+
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealMatrix const SUPPRESS_UNUSED * arg0, OGComplexDiagonalMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGRealMatrix and OGComplexDiagonalMatrix
+         OGComplexMatrix * conv0 = this->getConvertTo()->convertToOGComplexMatrix(arg0);
+         OGComplexMatrix * conv1 = this->getConvertTo()->convertToOGComplexMatrix(arg1);
+         T ret = run(reg0,conv0,conv1);
+         delete conv0;
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGLogicalMatrix const SUPPRESS_UNUSED * arg0, OGRealScalar const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGLogicalMatrix and OGRealScalar
+   return nullptr;
+
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGLogicalMatrix const SUPPRESS_UNUSED * arg0, OGComplexScalar const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGLogicalMatrix and OGComplexScalar
+   return nullptr;
+
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGLogicalMatrix const SUPPRESS_UNUSED * arg0, OGIntegerScalar const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGLogicalMatrix and OGIntegerScalar
+   return nullptr;
+
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGLogicalMatrix const SUPPRESS_UNUSED * arg0, OGRealMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGLogicalMatrix and OGRealMatrix
+   return nullptr;
+
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGLogicalMatrix const SUPPRESS_UNUSED * arg0, OGLogicalMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGLogicalMatrix and OGLogicalMatrix
+   return nullptr;
+
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGLogicalMatrix const SUPPRESS_UNUSED * arg0, OGComplexMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGLogicalMatrix and OGComplexMatrix
+   return nullptr;
+
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGLogicalMatrix const SUPPRESS_UNUSED * arg0, OGRealSparseMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGLogicalMatrix and OGRealSparseMatrix
+   return nullptr;
+
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGLogicalMatrix const SUPPRESS_UNUSED * arg0, OGComplexSparseMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGLogicalMatrix and OGComplexSparseMatrix
+   return nullptr;
+
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGLogicalMatrix const SUPPRESS_UNUSED * arg0, OGRealDiagonalMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGLogicalMatrix and OGRealDiagonalMatrix
+   return nullptr;
+
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGLogicalMatrix const SUPPRESS_UNUSED * arg0, OGComplexDiagonalMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGLogicalMatrix and OGComplexDiagonalMatrix
+   return nullptr;
+
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexMatrix const SUPPRESS_UNUSED * arg0, OGRealScalar const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGComplexMatrix and OGRealScalar
+         OGComplexMatrix * conv1 = this->getConvertTo()->convertToOGComplexMatrix(arg1);
+         T ret = run(reg0,arg0,conv1);
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexMatrix const SUPPRESS_UNUSED * arg0, OGComplexScalar const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGComplexMatrix and OGComplexScalar
+         OGComplexMatrix * conv1 = this->getConvertTo()->convertToOGComplexMatrix(arg1);
+         T ret = run(reg0,arg0,conv1);
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexMatrix const SUPPRESS_UNUSED * arg0, OGIntegerScalar const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGComplexMatrix and OGIntegerScalar
+   return nullptr;
+
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexMatrix const SUPPRESS_UNUSED * arg0, OGRealMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGComplexMatrix and OGRealMatrix
+         OGComplexMatrix * conv1 = this->getConvertTo()->convertToOGComplexMatrix(arg1);
+         T ret = run(reg0,arg0,conv1);
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexMatrix const SUPPRESS_UNUSED * arg0, OGLogicalMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGComplexMatrix and OGLogicalMatrix
+   return nullptr;
+
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexMatrix const SUPPRESS_UNUSED * arg0, OGRealSparseMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGComplexMatrix and OGRealSparseMatrix
+         OGComplexMatrix * conv1 = this->getConvertTo()->convertToOGComplexMatrix(arg1);
+         T ret = run(reg0,arg0,conv1);
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexMatrix const SUPPRESS_UNUSED * arg0, OGComplexSparseMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGComplexMatrix and OGComplexSparseMatrix
+         OGComplexMatrix * conv1 = this->getConvertTo()->convertToOGComplexMatrix(arg1);
+         T ret = run(reg0,arg0,conv1);
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexMatrix const SUPPRESS_UNUSED * arg0, OGRealDiagonalMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGComplexMatrix and OGRealDiagonalMatrix
+         OGComplexMatrix * conv1 = this->getConvertTo()->convertToOGComplexMatrix(arg1);
+         T ret = run(reg0,arg0,conv1);
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexMatrix const SUPPRESS_UNUSED * arg0, OGComplexDiagonalMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGComplexMatrix and OGComplexDiagonalMatrix
+         OGComplexMatrix * conv1 = this->getConvertTo()->convertToOGComplexMatrix(arg1);
+         T ret = run(reg0,arg0,conv1);
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealSparseMatrix const SUPPRESS_UNUSED * arg0, OGRealScalar const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGRealSparseMatrix and OGRealScalar
+         OGRealMatrix * conv0 = this->getConvertTo()->convertToOGRealMatrix(arg0);
+         OGRealMatrix * conv1 = this->getConvertTo()->convertToOGRealMatrix(arg1);
+         T ret = run(reg0,conv0,conv1);
+
+         delete conv0;
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealSparseMatrix const SUPPRESS_UNUSED * arg0, OGComplexScalar const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGRealSparseMatrix and OGComplexScalar
+         OGComplexMatrix * conv0 = this->getConvertTo()->convertToOGComplexMatrix(arg0);
+         OGComplexMatrix * conv1 = this->getConvertTo()->convertToOGComplexMatrix(arg1);
+         T ret = run(reg0,conv0,conv1);
+         delete conv0;
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealSparseMatrix const SUPPRESS_UNUSED * arg0, OGIntegerScalar const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGRealSparseMatrix and OGIntegerScalar
+   return nullptr;
+
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealSparseMatrix const SUPPRESS_UNUSED * arg0, OGRealMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGRealSparseMatrix and OGRealMatrix
+         OGRealMatrix * conv0 = this->getConvertTo()->convertToOGRealMatrix(arg0);
+         T ret = run(reg0,conv0,arg1);
+         delete conv0;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealSparseMatrix const SUPPRESS_UNUSED * arg0, OGLogicalMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGRealSparseMatrix and OGLogicalMatrix
+   return nullptr;
+
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealSparseMatrix const SUPPRESS_UNUSED * arg0, OGComplexMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGRealSparseMatrix and OGComplexMatrix
+         OGComplexMatrix * conv0 = this->getConvertTo()->convertToOGComplexMatrix(arg0);
+         T ret = run(reg0,conv0,arg1);
+         delete conv0;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealSparseMatrix const SUPPRESS_UNUSED * arg0, OGRealSparseMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGRealSparseMatrix and OGRealSparseMatrix
+         OGRealMatrix * conv0 = this->getConvertTo()->convertToOGRealMatrix(arg0);
+         OGRealMatrix * conv1 = this->getConvertTo()->convertToOGRealMatrix(arg1);
+         T ret = run(reg0,conv0,conv1);
+
+         delete conv0;
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealSparseMatrix const SUPPRESS_UNUSED * arg0, OGComplexSparseMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGRealSparseMatrix and OGComplexSparseMatrix
+         OGComplexMatrix * conv0 = this->getConvertTo()->convertToOGComplexMatrix(arg0);
+         OGComplexMatrix * conv1 = this->getConvertTo()->convertToOGComplexMatrix(arg1);
+         T ret = run(reg0,conv0,conv1);
+         delete conv0;
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealSparseMatrix const SUPPRESS_UNUSED * arg0, OGRealDiagonalMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGRealSparseMatrix and OGRealDiagonalMatrix
+         OGRealMatrix * conv0 = this->getConvertTo()->convertToOGRealMatrix(arg0);
+         OGRealMatrix * conv1 = this->getConvertTo()->convertToOGRealMatrix(arg1);
+         T ret = run(reg0,conv0,conv1);
+
+         delete conv0;
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealSparseMatrix const SUPPRESS_UNUSED * arg0, OGComplexDiagonalMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGRealSparseMatrix and OGComplexDiagonalMatrix
+         OGComplexMatrix * conv0 = this->getConvertTo()->convertToOGComplexMatrix(arg0);
+         OGComplexMatrix * conv1 = this->getConvertTo()->convertToOGComplexMatrix(arg1);
+         T ret = run(reg0,conv0,conv1);
+         delete conv0;
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexSparseMatrix const SUPPRESS_UNUSED * arg0, OGRealScalar const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGComplexSparseMatrix and OGRealScalar
+         OGComplexMatrix * conv0 = this->getConvertTo()->convertToOGComplexMatrix(arg0);
+         OGComplexMatrix * conv1 = this->getConvertTo()->convertToOGComplexMatrix(arg1);
+         T ret = run(reg0,conv0,conv1);
+         delete conv0;
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexSparseMatrix const SUPPRESS_UNUSED * arg0, OGComplexScalar const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGComplexSparseMatrix and OGComplexScalar
+         OGComplexMatrix * conv0 = this->getConvertTo()->convertToOGComplexMatrix(arg0);
+         OGComplexMatrix * conv1 = this->getConvertTo()->convertToOGComplexMatrix(arg1);
+         T ret = run(reg0,conv0,conv1);
+         delete conv0;
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexSparseMatrix const SUPPRESS_UNUSED * arg0, OGIntegerScalar const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGComplexSparseMatrix and OGIntegerScalar
+   return nullptr;
+
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexSparseMatrix const SUPPRESS_UNUSED * arg0, OGRealMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGComplexSparseMatrix and OGRealMatrix
+         OGComplexMatrix * conv0 = this->getConvertTo()->convertToOGComplexMatrix(arg0);
+         OGComplexMatrix * conv1 = this->getConvertTo()->convertToOGComplexMatrix(arg1);
+         T ret = run(reg0,conv0,conv1);
+         delete conv0;
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexSparseMatrix const SUPPRESS_UNUSED * arg0, OGLogicalMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGComplexSparseMatrix and OGLogicalMatrix
+   return nullptr;
+
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexSparseMatrix const SUPPRESS_UNUSED * arg0, OGComplexMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGComplexSparseMatrix and OGComplexMatrix
+         OGComplexMatrix * conv0 = this->getConvertTo()->convertToOGComplexMatrix(arg0);
+         T ret = run(reg0,conv0,arg1);
+         delete conv0;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexSparseMatrix const SUPPRESS_UNUSED * arg0, OGRealSparseMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGComplexSparseMatrix and OGRealSparseMatrix
+         OGComplexMatrix * conv0 = this->getConvertTo()->convertToOGComplexMatrix(arg0);
+         OGComplexMatrix * conv1 = this->getConvertTo()->convertToOGComplexMatrix(arg1);
+         T ret = run(reg0,conv0,conv1);
+         delete conv0;
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexSparseMatrix const SUPPRESS_UNUSED * arg0, OGComplexSparseMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGComplexSparseMatrix and OGComplexSparseMatrix
+         OGComplexMatrix * conv0 = this->getConvertTo()->convertToOGComplexMatrix(arg0);
+         OGComplexMatrix * conv1 = this->getConvertTo()->convertToOGComplexMatrix(arg1);
+         T ret = run(reg0,conv0,conv1);
+         delete conv0;
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexSparseMatrix const SUPPRESS_UNUSED * arg0, OGRealDiagonalMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGComplexSparseMatrix and OGRealDiagonalMatrix
+         OGComplexMatrix * conv0 = this->getConvertTo()->convertToOGComplexMatrix(arg0);
+         OGComplexMatrix * conv1 = this->getConvertTo()->convertToOGComplexMatrix(arg1);
+         T ret = run(reg0,conv0,conv1);
+         delete conv0;
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexSparseMatrix const SUPPRESS_UNUSED * arg0, OGComplexDiagonalMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGComplexSparseMatrix and OGComplexDiagonalMatrix
+         OGComplexMatrix * conv0 = this->getConvertTo()->convertToOGComplexMatrix(arg0);
+         OGComplexMatrix * conv1 = this->getConvertTo()->convertToOGComplexMatrix(arg1);
+         T ret = run(reg0,conv0,conv1);
+         delete conv0;
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealDiagonalMatrix const SUPPRESS_UNUSED * arg0, OGRealScalar const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGRealDiagonalMatrix and OGRealScalar
+         OGRealMatrix * conv0 = this->getConvertTo()->convertToOGRealMatrix(arg0);
+         OGRealMatrix * conv1 = this->getConvertTo()->convertToOGRealMatrix(arg1);
+         T ret = run(reg0,conv0,conv1);
+
+         delete conv0;
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealDiagonalMatrix const SUPPRESS_UNUSED * arg0, OGComplexScalar const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGRealDiagonalMatrix and OGComplexScalar
+         OGComplexMatrix * conv0 = this->getConvertTo()->convertToOGComplexMatrix(arg0);
+         OGComplexMatrix * conv1 = this->getConvertTo()->convertToOGComplexMatrix(arg1);
+         T ret = run(reg0,conv0,conv1);
+         delete conv0;
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealDiagonalMatrix const SUPPRESS_UNUSED * arg0, OGIntegerScalar const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGRealDiagonalMatrix and OGIntegerScalar
+   return nullptr;
+
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealDiagonalMatrix const SUPPRESS_UNUSED * arg0, OGRealMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGRealDiagonalMatrix and OGRealMatrix
+         OGRealMatrix * conv0 = this->getConvertTo()->convertToOGRealMatrix(arg0);
+         T ret = run(reg0,conv0,arg1);
+         delete conv0;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealDiagonalMatrix const SUPPRESS_UNUSED * arg0, OGLogicalMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGRealDiagonalMatrix and OGLogicalMatrix
+   return nullptr;
+
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealDiagonalMatrix const SUPPRESS_UNUSED * arg0, OGComplexMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGRealDiagonalMatrix and OGComplexMatrix
+         OGComplexMatrix * conv0 = this->getConvertTo()->convertToOGComplexMatrix(arg0);
+         T ret = run(reg0,conv0,arg1);
+         delete conv0;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealDiagonalMatrix const SUPPRESS_UNUSED * arg0, OGRealSparseMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGRealDiagonalMatrix and OGRealSparseMatrix
+         OGRealMatrix * conv0 = this->getConvertTo()->convertToOGRealMatrix(arg0);
+         OGRealMatrix * conv1 = this->getConvertTo()->convertToOGRealMatrix(arg1);
+         T ret = run(reg0,conv0,conv1);
+
+         delete conv0;
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealDiagonalMatrix const SUPPRESS_UNUSED * arg0, OGComplexSparseMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGRealDiagonalMatrix and OGComplexSparseMatrix
+         OGComplexMatrix * conv0 = this->getConvertTo()->convertToOGComplexMatrix(arg0);
+         OGComplexMatrix * conv1 = this->getConvertTo()->convertToOGComplexMatrix(arg1);
+         T ret = run(reg0,conv0,conv1);
+         delete conv0;
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealDiagonalMatrix const SUPPRESS_UNUSED * arg0, OGRealDiagonalMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGRealDiagonalMatrix and OGRealDiagonalMatrix
+         OGRealMatrix * conv0 = this->getConvertTo()->convertToOGRealMatrix(arg0);
+         OGRealMatrix * conv1 = this->getConvertTo()->convertToOGRealMatrix(arg1);
+         T ret = run(reg0,conv0,conv1);
+
+         delete conv0;
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealDiagonalMatrix const SUPPRESS_UNUSED * arg0, OGComplexDiagonalMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGRealDiagonalMatrix and OGComplexDiagonalMatrix
+         OGComplexMatrix * conv0 = this->getConvertTo()->convertToOGComplexMatrix(arg0);
+         OGComplexMatrix * conv1 = this->getConvertTo()->convertToOGComplexMatrix(arg1);
+         T ret = run(reg0,conv0,conv1);
+         delete conv0;
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexDiagonalMatrix const SUPPRESS_UNUSED * arg0, OGRealScalar const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGComplexDiagonalMatrix and OGRealScalar
+         OGComplexMatrix * conv0 = this->getConvertTo()->convertToOGComplexMatrix(arg0);
+         OGComplexMatrix * conv1 = this->getConvertTo()->convertToOGComplexMatrix(arg1);
+         T ret = run(reg0,conv0,conv1);
+         delete conv0;
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexDiagonalMatrix const SUPPRESS_UNUSED * arg0, OGComplexScalar const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGComplexDiagonalMatrix and OGComplexScalar
+         OGComplexMatrix * conv0 = this->getConvertTo()->convertToOGComplexMatrix(arg0);
+         OGComplexMatrix * conv1 = this->getConvertTo()->convertToOGComplexMatrix(arg1);
+         T ret = run(reg0,conv0,conv1);
+         delete conv0;
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexDiagonalMatrix const SUPPRESS_UNUSED * arg0, OGIntegerScalar const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGComplexDiagonalMatrix and OGIntegerScalar
+   return nullptr;
+
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexDiagonalMatrix const SUPPRESS_UNUSED * arg0, OGRealMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGComplexDiagonalMatrix and OGRealMatrix
+         OGComplexMatrix * conv0 = this->getConvertTo()->convertToOGComplexMatrix(arg0);
+         OGComplexMatrix * conv1 = this->getConvertTo()->convertToOGComplexMatrix(arg1);
+         T ret = run(reg0,conv0,conv1);
+         delete conv0;
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexDiagonalMatrix const SUPPRESS_UNUSED * arg0, OGLogicalMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGComplexDiagonalMatrix and OGLogicalMatrix
+   return nullptr;
+
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexDiagonalMatrix const SUPPRESS_UNUSED * arg0, OGComplexMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGComplexDiagonalMatrix and OGComplexMatrix
+         OGComplexMatrix * conv0 = this->getConvertTo()->convertToOGComplexMatrix(arg0);
+         T ret = run(reg0,conv0,arg1);
+         delete conv0;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexDiagonalMatrix const SUPPRESS_UNUSED * arg0, OGRealSparseMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGComplexDiagonalMatrix and OGRealSparseMatrix
+         OGComplexMatrix * conv0 = this->getConvertTo()->convertToOGComplexMatrix(arg0);
+         OGComplexMatrix * conv1 = this->getConvertTo()->convertToOGComplexMatrix(arg1);
+         T ret = run(reg0,conv0,conv1);
+         delete conv0;
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexDiagonalMatrix const SUPPRESS_UNUSED * arg0, OGComplexSparseMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGComplexDiagonalMatrix and OGComplexSparseMatrix
+         OGComplexMatrix * conv0 = this->getConvertTo()->convertToOGComplexMatrix(arg0);
+         OGComplexMatrix * conv1 = this->getConvertTo()->convertToOGComplexMatrix(arg1);
+         T ret = run(reg0,conv0,conv1);
+         delete conv0;
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexDiagonalMatrix const SUPPRESS_UNUSED * arg0, OGRealDiagonalMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGComplexDiagonalMatrix and OGRealDiagonalMatrix
+         OGComplexMatrix * conv0 = this->getConvertTo()->convertToOGComplexMatrix(arg0);
+         OGComplexMatrix * conv1 = this->getConvertTo()->convertToOGComplexMatrix(arg1);
+         T ret = run(reg0,conv0,conv1);
+         delete conv0;
+         delete conv1;
+
+         return ret;
+   };
+
+
+   virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGComplexDiagonalMatrix const SUPPRESS_UNUSED * arg0, OGComplexDiagonalMatrix const SUPPRESS_UNUSED * arg1) const
+   {
+      // impl convert and run for types OGComplexDiagonalMatrix and OGComplexDiagonalMatrix
+         OGComplexMatrix * conv0 = this->getConvertTo()->convertToOGComplexMatrix(arg0);
+         OGComplexMatrix * conv1 = this->getConvertTo()->convertToOGComplexMatrix(arg1);
+         T ret = run(reg0,conv0,conv1);
+         delete conv0;
+         delete conv1;
+
+         return ret;
+   };
+
 
 
 // Required backstop impls
@@ -1156,10 +1758,10 @@ virtual T run(RegContainer SUPPRESS_UNUSED * reg0, OGRealMatrix const * arg0, OG
 };
 
 // typedef the void dispatch of a binary operation
-typedef DispatchBinaryOp<void> DispatchVoidBinaryOp;
+typedef DispatchBinaryOp<void *> DispatchVoidBinaryOp;
 
 // typedef the void dispatch of a unary operation
-typedef DispatchUnaryOp<void> DispatchVoidUnaryOp;
+typedef DispatchUnaryOp<void *> DispatchVoidUnaryOp;
 
 } // namespace librdag
 

--- a/include/dispatch.hh
+++ b/include/dispatch.hh
@@ -132,7 +132,7 @@ public:
 
   virtual T run(RegContainer SUPPRESS_UNUSED * reg, OGRealScalar const SUPPRESS_UNUSED * arg) const
   {
-    OGOwningRealMatrix * conv = this->getConvertTo()->convertToOGRealMatrix(arg);
+    OGRealMatrix * conv = this->getConvertTo()->convertToOGRealMatrix(arg);
     T ret = run(reg, conv);
     delete conv;
     return ret;
@@ -140,44 +140,52 @@ public:
 
   virtual T run(RegContainer SUPPRESS_UNUSED * reg, OGComplexScalar const SUPPRESS_UNUSED * arg) const
   {
-//     return run(reg, this->getConvertTo()->convertToOGComplexMatrix(arg));
-    return nullptr;
+    OGComplexMatrix * conv = this->getConvertTo()->convertToOGComplexMatrix(arg);
+    T ret = run(reg, conv);
+    delete conv;
+    return ret;
   };
 
   virtual T run(RegContainer SUPPRESS_UNUSED * reg, OGIntegerScalar const SUPPRESS_UNUSED * arg) const
   {
-//     return run(reg, this->getConvertTo()->convertToOGRealMatrix(arg));
     return nullptr;
   };
 
   virtual T run(RegContainer SUPPRESS_UNUSED * reg, OGLogicalMatrix const SUPPRESS_UNUSED * arg) const
   {
-//     return run(reg, this->getConvertTo()->convertToOGRealMatrix(arg));
     return nullptr;
   };
 
   virtual T run(RegContainer SUPPRESS_UNUSED * reg, OGRealDiagonalMatrix const SUPPRESS_UNUSED * arg) const
   {
-//     return run(reg, this->getConvertTo()->convertToOGRealMatrix(arg));
-    return nullptr;
+    OGRealMatrix * conv = this->getConvertTo()->convertToOGRealMatrix(arg);
+    T ret = run(reg, conv);
+    delete conv;
+    return ret;
   };
 
   virtual T run(RegContainer SUPPRESS_UNUSED * reg, OGComplexDiagonalMatrix const SUPPRESS_UNUSED * arg) const
   {
-//     return run(reg, this->getConvertTo()->convertToOGComplexMatrix(arg));
-    return nullptr;
+    OGComplexMatrix * conv = this->getConvertTo()->convertToOGComplexMatrix(arg);
+    T ret = run(reg, conv);
+    delete conv;
+    return ret;
   };
 
   virtual T run(RegContainer SUPPRESS_UNUSED * reg, OGRealSparseMatrix const SUPPRESS_UNUSED * arg) const
   {
-//     return run(reg, this->getConvertTo()->convertToOGRealMatrix(arg));
-    return nullptr;
+    OGRealMatrix * conv = this->getConvertTo()->convertToOGRealMatrix(arg);
+    T ret = run(reg, conv);
+    delete conv;
+    return ret;
   };
 
   virtual T run(RegContainer SUPPRESS_UNUSED * reg, OGComplexSparseMatrix const SUPPRESS_UNUSED * arg) const
   {
-//     return run(reg, this->getConvertTo()->convertToOGComplexMatrix(arg));
-    return nullptr;
+    OGComplexMatrix * conv = this->getConvertTo()->convertToOGComplexMatrix(arg);
+    T ret = run(reg, conv);
+    delete conv;
+    return ret;
   };
 
   // Backstop methods for generic implementation

--- a/include/iss.hh
+++ b/include/iss.hh
@@ -11,10 +11,10 @@
 
 namespace librdag {
 
-DLLEXPORT_C bool isScalar(const OGTerminal *);
-DLLEXPORT_C bool isMatrix(const OGTerminal *);
-DLLEXPORT_C bool isReal(const OGTerminal *);
-DLLEXPORT_C bool isComplex(const OGTerminal *);
+bool isScalar(const OGTerminal *);
+bool isMatrix(const OGTerminal *);
+bool isReal(const OGTerminal *);
+bool isComplex(const OGTerminal *);
 
 }
 #endif

--- a/include/iss.hh
+++ b/include/iss.hh
@@ -1,0 +1,20 @@
+/**
+ * Copyright (C) 2013 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+#ifndef _ISS_HH
+#define _ISS_HH
+#include "terminal.hh"
+#include "modifiermacros.h"
+
+namespace librdag {
+
+DLLEXPORT_C bool isScalar(const OGTerminal *);
+DLLEXPORT_C bool isMatrix(const OGTerminal *);
+DLLEXPORT_C bool isReal(const OGTerminal *);
+DLLEXPORT_C bool isComplex(const OGTerminal *);
+
+}
+#endif

--- a/include/numeric.hh
+++ b/include/numeric.hh
@@ -24,6 +24,9 @@ class OGRealDiagonalMatrix;
 class OGComplexDiagonalMatrix;
 class OGRealSparseMatrix;
 class OGComplexSparseMatrix;
+class OGOwningRealMatrix;
+class OGOwningComplexMatrix;
+class ConvertTo;
 class Visitor;
 class OGExpr;
 class COPY;
@@ -31,6 +34,7 @@ class PLUS;
 class NEGATE;
 class SVD;
 class SELECTRESULT;
+
 
 /*
  * Base class for absolutely everything!

--- a/include/terminal.hh
+++ b/include/terminal.hh
@@ -189,7 +189,8 @@ class OGOwningComplexMatrix: public OGComplexMatrix
 
 class OGLogicalMatrix: public OGRealMatrix
 {
-
+  public:
+    using OGRealMatrix::OGRealMatrix; // TODO: range limit inputs
 };
 
 /**

--- a/include/terminal.hh
+++ b/include/terminal.hh
@@ -10,6 +10,7 @@
 #include "numeric.hh"
 #include "numerictypes.hh"
 #include "warningmacros.h"
+#include "convertto.hh"
 
 namespace librdag {
 
@@ -28,30 +29,80 @@ class FuzzyCompareOGTerminalContainer
 
 }
 
-
 /*
  * Base class for terminal nodes in the AST
  */
 class OGTerminal: public OGNumeric
 {
   public:
+    /**
+     * Gets the number of rows
+     */
+    virtual int getRows() const = 0;
+    /**
+     * Gets the number of columns
+     */
+    virtual int getCols() const = 0;
+    /**
+     * Gets the data length
+     */
+    virtual int getDatalen() const = 0;
+    /**
+     * Copies the underlying data to a new real16 array
+     */
     virtual real16* toReal16Array() const;
+    /**
+     * Copies the underlying data to a new complex16 array
+     */
     virtual complex16* toComplex16Array() const;
+    /**
+     * Converts the data to a real16 array of arrays representation
+     */
     virtual real16 ** toReal16ArrayOfArrays() const;
+    /**
+     * Converts the data to a complex16 array of arrays representation
+     */
     virtual complex16 ** toComplex16ArrayOfArrays() const;
+    /**
+     * Returns a real dense matrix representation of this terminal
+     */
+    virtual OGOwningRealMatrix * asFullOGRealMatrix() const = 0;
+    /**
+     * Returns a complex dense matrix representation of this terminal
+     */
+    virtual OGOwningComplexMatrix * asFullOGComplexMatrix() const = 0;
+    /**
+     *  Returns this
+     */
     virtual const OGTerminal* asOGTerminal() const override;
+    /**
+     * Equals method. Computed bit wise on relavent data fields.
+     */
     virtual bool equals(const OGTerminal *)const = 0;
+    /**
+     * Fuzzy Equals method. Computed with a fuzzy tolerance (to deal with floating point fuzz) on relavent data fields.
+     */
     virtual bool fuzzyequals(const OGTerminal *)const = 0;
+    /**
+     * Checks if two data containers are mathematically equal, regardless of thier underlying data representation.
+     */
+    virtual bool mathsequals(const OGTerminal *)const;
     virtual bool operator==(const OGTerminal&) const;
     virtual bool operator!=(const OGTerminal&) const;
+    virtual bool operator%(const OGTerminal&) const;
     virtual detail::FuzzyCompareOGTerminalContainer& operator~(void) const;
     virtual bool operator==(const detail::FuzzyCompareOGTerminalContainer&) const;
     virtual bool operator!=(const detail::FuzzyCompareOGTerminalContainer&) const;
     OGTerminal();
     virtual ~OGTerminal();
+    /**
+     * Gets the converter
+     */
+    const ConvertTo * getConvertTo() const;
   private:
     detail::FuzzyCompareOGTerminalContainer& getFuzzyContainer() const;
     detail::FuzzyCompareOGTerminalContainer * _fuzzyref = nullptr;
+    const ConvertTo * _converter = nullptr;
 };
 
 
@@ -64,6 +115,9 @@ class OGScalar: public OGTerminal
 {
   public:
     OGScalar(T data);
+    virtual int getRows() const override;
+    virtual int getCols() const override;
+    virtual int getDatalen() const override;
     virtual void accept(Visitor &v) const override;
     T getValue() const;
     T ** toArrayOfArrays() const;
@@ -86,6 +140,8 @@ class OGRealScalar: public OGScalar<real16>
     virtual const OGRealScalar* asOGRealScalar() const override;
     virtual void debug_print() const override;
     virtual ExprType_t getType() const override;
+    virtual OGOwningRealMatrix * asFullOGRealMatrix() const override;
+    virtual OGOwningComplexMatrix * asFullOGComplexMatrix() const override;
 };
 
 
@@ -98,6 +154,8 @@ class OGComplexScalar: public OGScalar<complex16>
     virtual const OGComplexScalar* asOGComplexScalar() const override;
     virtual void debug_print() const override;
     virtual ExprType_t getType() const override;
+    virtual OGOwningRealMatrix * asFullOGRealMatrix() const override;
+    virtual OGOwningComplexMatrix * asFullOGComplexMatrix() const override;
 };
 
 class OGIntegerScalar: public OGScalar<int>
@@ -108,6 +166,8 @@ class OGIntegerScalar: public OGScalar<int>
     virtual const OGIntegerScalar* asOGIntegerScalar() const override;
     virtual void debug_print() const override;
     virtual ExprType_t getType() const override;
+    virtual OGOwningRealMatrix * asFullOGRealMatrix() const override;
+    virtual OGOwningComplexMatrix * asFullOGComplexMatrix() const override;
 };
 
 
@@ -116,9 +176,9 @@ template <typename T> class OGArray: public OGTerminal
   public:
     T * getData() const; // Returns a pointer to the underlying data
     T * toArray() const; // Returns a pointer to a copy of the underlying data
-    int getRows() const;
-    int getCols() const;
-    int getDatalen() const;
+    virtual int getRows() const override;
+    virtual int getCols() const override;
+    virtual int getDatalen() const override;
     virtual bool equals(const OGTerminal *)const override;
     virtual bool fuzzyequals(const OGTerminal * ) const override;
   protected:
@@ -158,6 +218,8 @@ class OGRealMatrix: public OGMatrix<real16>
     virtual OGNumeric* copy() const override;
     virtual const OGRealMatrix* asOGRealMatrix() const override;
     virtual ExprType_t getType() const override;
+    virtual OGOwningRealMatrix * asFullOGRealMatrix() const override;
+    virtual OGOwningComplexMatrix * asFullOGComplexMatrix() const override;
 };
 
 class OGOwningRealMatrix: public OGRealMatrix
@@ -177,6 +239,8 @@ class OGComplexMatrix: public OGMatrix<complex16>
     virtual OGNumeric* copy() const override;
     virtual const OGComplexMatrix* asOGComplexMatrix() const override;
     virtual ExprType_t getType() const override;
+    virtual OGOwningRealMatrix * asFullOGRealMatrix() const override;
+    virtual OGOwningComplexMatrix * asFullOGComplexMatrix() const override;
 };
 
 class OGOwningComplexMatrix: public OGComplexMatrix
@@ -191,6 +255,7 @@ class OGLogicalMatrix: public OGRealMatrix
 {
   public:
     using OGRealMatrix::OGRealMatrix; // TODO: range limit inputs
+    virtual const OGLogicalMatrix * asOGLogicalMatrix() const override;
 };
 
 /**
@@ -217,7 +282,9 @@ class OGRealDiagonalMatrix: public OGDiagonalMatrix<real16>
     virtual real16** toReal16ArrayOfArrays() const override;
     virtual OGNumeric* copy() const override;
     virtual const OGRealDiagonalMatrix* asOGRealDiagonalMatrix() const override;
-    virtual ExprType_t getType() const override;    
+    virtual ExprType_t getType() const override;
+    virtual OGOwningRealMatrix * asFullOGRealMatrix() const override;
+    virtual OGOwningComplexMatrix * asFullOGComplexMatrix() const override;
 };
 
 class OGOwningRealDiagonalMatrix: public OGRealDiagonalMatrix
@@ -236,7 +303,9 @@ class OGComplexDiagonalMatrix: public OGDiagonalMatrix<complex16>
     virtual complex16** toComplex16ArrayOfArrays() const override;
     virtual OGNumeric* copy() const override;
     virtual const OGComplexDiagonalMatrix* asOGComplexDiagonalMatrix() const override;
-    virtual ExprType_t getType() const override;    
+    virtual ExprType_t getType() const override;
+    virtual OGOwningRealMatrix * asFullOGRealMatrix() const override;
+    virtual OGOwningComplexMatrix * asFullOGComplexMatrix() const override;
 };
 
 class OGOwningComplexDiagonalMatrix: public OGComplexDiagonalMatrix
@@ -281,6 +350,8 @@ class OGRealSparseMatrix: public OGSparseMatrix<real16>
     virtual OGNumeric* copy() const override;
     virtual const OGRealSparseMatrix* asOGRealSparseMatrix() const override;
     virtual ExprType_t getType() const override;
+    virtual OGOwningRealMatrix * asFullOGRealMatrix() const override;
+    virtual OGOwningComplexMatrix * asFullOGComplexMatrix() const override;
 };
 
 class OGOwningRealSparseMatrix: public OGRealSparseMatrix
@@ -300,6 +371,8 @@ class OGComplexSparseMatrix: public OGSparseMatrix<complex16>
     virtual OGNumeric* copy() const override;
     virtual const OGComplexSparseMatrix* asOGComplexSparseMatrix() const override;
     virtual ExprType_t getType() const override;
+    virtual OGOwningRealMatrix * asFullOGRealMatrix() const override;
+    virtual OGOwningComplexMatrix * asFullOGComplexMatrix() const override;
 };
 
 class OGOwningComplexSparseMatrix: public OGComplexSparseMatrix

--- a/src/java/src/main/java/com/opengamma/longdog/datacontainers/scalar/OGComplexScalar.java
+++ b/src/java/src/main/java/com/opengamma/longdog/datacontainers/scalar/OGComplexScalar.java
@@ -93,4 +93,9 @@ public class OGComplexScalar extends OGScalar {
     return _data;
   }
 
+  @Override
+  public String toString() {
+    String str = "\nOGComplexScalar: value = " + String.format("%24.18f " + (_data[1] >= 0 ? "+" : "-") + "%24.18fi, ", _data[0], Math.abs(_data[1]));
+    return str;
+  }
 }

--- a/src/java/src/main/java/com/opengamma/longdog/datacontainers/scalar/OGRealScalar.java
+++ b/src/java/src/main/java/com/opengamma/longdog/datacontainers/scalar/OGRealScalar.java
@@ -40,4 +40,10 @@ public class OGRealScalar extends OGScalar {
     return _data;
   }
 
+  @Override
+  public String toString() {
+    String str = "\nOGRealScalar: value = " + String.format("%24.18f\n", _data[0]);
+    return str;
+  }
+
 }

--- a/src/jshim/jshim.cc
+++ b/src/jshim/jshim.cc
@@ -73,18 +73,20 @@ JNIEXPORT jobject JNICALL Java_com_opengamma_longdog_materialisers_Materialisers
   checkEx(env);
   DEBUG_PRINT("Calling entrypt function\n");
   const librdag::OGTerminal* answer = entrypt(chain);
-  delete chain;
+
 
   DispatchToComplex16ArrayOfArrays *visitor = new DispatchToComplex16ArrayOfArrays();
   answer->accept(*visitor);
 
   jobjectArray realPart = extractRealPartOfCcomplex16ArrOfArr2JDoubleArrOfArr(env, visitor->getData(), visitor->getRows(), visitor->getCols());
   jobjectArray complexPart = extractImagPartOfCcomplex16ArrOfArr2JDoubleArrOfArr(env, visitor->getData(), visitor->getRows(), visitor->getCols());
-  delete visitor;
 
   jobject returnVal = env->NewObject(JVMManager::getComplexArrayContainerClazz(),
                                      JVMManager::getComplexArrayContainerClazz_ctor_DAoA_DAoA(),
                                      realPart, complexPart);
+
+  delete chain;
+  delete visitor;
 
   DEBUG_PRINT("Returning\n");
   return returnVal;
@@ -114,11 +116,12 @@ Java_com_opengamma_longdog_materialisers_Materialisers_materialiseToOGTerminal(J
   checkEx(env);
   DEBUG_PRINT("Calling entrypt function\n");
   const librdag::OGTerminal* answer = entrypt(chain);
-  delete chain;
 
   DispatchToOGTerminal *visitor = new DispatchToOGTerminal(env);
   answer->accept(*visitor);
   jobject result = visitor->getObject();
+
+  delete chain;
   delete visitor;
 
   DEBUG_PRINT("Returning\n");

--- a/src/librdag/CMakeLists.txt
+++ b/src/librdag/CMakeLists.txt
@@ -31,7 +31,7 @@ add_custom_command(OUTPUT ${RUNNERS_CC}
                    COMMAND ${RUNNERS_GENERATOR} -o ${RUNNERS_CC} --runners-cc
                    COMMENT "Generating runners.cc")
 
-set(RDAG_SOURCES entrypt.cc expression.cc execution.cc terminal.cc containers.cc numeric.cc dispatch.cc equals.cc numerictypes.cc convertto.cc ${RUNNERS_CC})
+set(RDAG_SOURCES entrypt.cc expression.cc execution.cc terminal.cc containers.cc numeric.cc dispatch.cc equals.cc numerictypes.cc convertto.cc iss.cc ${RUNNERS_CC})
 
 add_library(rdag SHARED ${RDAG_SOURCES})
 

--- a/src/librdag/convertto.cc
+++ b/src/librdag/convertto.cc
@@ -9,6 +9,7 @@
 #include "terminal.hh"
 #include "warningmacros.h"
 #include "exceptions.hh"
+#include <cstring>
 
 using namespace std;
 namespace librdag {
@@ -20,6 +21,14 @@ ConvertTo::ConvertTo()
 // things that convert to OGRealMatrix
 OGOwningRealMatrix *
 ConvertTo::convertToOGRealMatrix(OGRealScalar const * thing) const
+{
+  OGOwningRealMatrix * ret = new OGOwningRealMatrix(1,1);
+  ret->getData()[0]=thing->getValue();
+  return ret;
+}
+
+OGOwningRealMatrix *
+ConvertTo::convertToOGRealMatrix(OGIntegerScalar const * thing) const
 {
   OGOwningRealMatrix * ret = new OGOwningRealMatrix(1,1);
   ret->getData()[0]=thing->getValue();
@@ -41,6 +50,20 @@ ConvertTo::convertToOGRealMatrix(OGRealDiagonalMatrix const * thing) const
   }
   return ret;
 }
+
+OGOwningRealMatrix *
+ConvertTo::convertToOGRealMatrix(OGLogicalMatrix const * thing) const
+{
+  int rows = thing->getRows();
+  int cols = thing->getCols();
+  int wlen = thing->getDatalen();
+  OGOwningRealMatrix * ret = new OGOwningRealMatrix(rows,cols);
+  real16 * thedata = thing->getData();
+  real16 * data = ret->getData();
+  memcpy(data,thedata,sizeof(real16)*wlen);
+  return ret;
+}
+
 
 OGOwningRealMatrix *
 ConvertTo::convertToOGRealMatrix(OGRealSparseMatrix const * thing) const
@@ -69,6 +92,14 @@ ConvertTo::convertToOGRealMatrix(OGRealSparseMatrix const * thing) const
 
 OGOwningComplexMatrix *
 ConvertTo::convertToOGComplexMatrix(OGRealScalar const * thing) const
+{
+  OGOwningComplexMatrix * ret = new OGOwningComplexMatrix(1,1);
+  ret->getData()[0]=thing->getValue();
+  return ret;
+}
+
+OGOwningComplexMatrix *
+ConvertTo::convertToOGComplexMatrix(OGIntegerScalar const * thing) const
 {
   OGOwningComplexMatrix * ret = new OGOwningComplexMatrix(1,1);
   ret->getData()[0]=thing->getValue();
@@ -157,6 +188,22 @@ ConvertTo::convertToOGComplexMatrix(OGComplexSparseMatrix const * thing) const
 
 OGOwningComplexMatrix *
 ConvertTo::convertToOGComplexMatrix(OGRealMatrix const * thing) const
+{
+  int rows = thing->getRows();
+  int cols = thing->getCols();
+  int wlen = thing->getDatalen();
+  OGOwningComplexMatrix * ret = new OGOwningComplexMatrix(rows,cols);
+  real16 * densedata = thing->getData();
+  complex16 * data = ret->getData();
+  for(int i=0;i<wlen;i++)
+  {
+    data[i]=densedata[i];
+  }
+  return ret;
+}
+
+OGOwningComplexMatrix *
+ConvertTo::convertToOGComplexMatrix(OGLogicalMatrix const * thing) const
 {
   int rows = thing->getRows();
   int cols = thing->getCols();

--- a/src/librdag/dispatch.cc
+++ b/src/librdag/dispatch.cc
@@ -15,16 +15,35 @@
 
 namespace librdag {
 
-template class DispatchUnaryOp<void>;
-template class DispatchBinaryOp<void>;
+
+DispatchOp::DispatchOp()
+{
+ _convert = new ConvertTo();
+}
+
+const ConvertTo *
+DispatchOp::getConvertTo() const
+{
+  return _convert;
+}
+
+
+DispatchOp::~DispatchOp()
+{
+ delete _convert;
+}
+
+
+template class DispatchUnaryOp<void *>;
+template class DispatchBinaryOp<void *>;
 
 Dispatcher::Dispatcher()
 {
     _PlusRunner = new PlusRunner();
     _NegateRunner = new NegateRunner();
 }
-  
-  
+
+
 Dispatcher::~Dispatcher(){
   delete _PlusRunner;
   delete _NegateRunner;

--- a/src/librdag/iss.cc
+++ b/src/librdag/iss.cc
@@ -8,7 +8,7 @@
 
 namespace librdag {
 
-DLLEXPORT_C bool isScalar(const OGTerminal * terminal)
+bool isScalar(const OGTerminal * terminal)
 {
   if(terminal->asOGRealScalar()!=nullptr)
   {
@@ -25,12 +25,12 @@ DLLEXPORT_C bool isScalar(const OGTerminal * terminal)
   return false;
 }
 
-DLLEXPORT_C bool isMatrix(const OGTerminal * terminal)
+bool isMatrix(const OGTerminal * terminal)
 {
   return !isScalar(terminal);
 }
 
-DLLEXPORT_C bool isReal(const OGTerminal * terminal)
+bool isReal(const OGTerminal * terminal)
 {
   if(terminal->asOGRealScalar()!=nullptr)
   {
@@ -59,7 +59,7 @@ DLLEXPORT_C bool isReal(const OGTerminal * terminal)
   return false;
 }
 
-DLLEXPORT_C bool isComplex(const OGTerminal * terminal)
+bool isComplex(const OGTerminal * terminal)
 {
   return !isReal(terminal);
 }

--- a/src/librdag/iss.cc
+++ b/src/librdag/iss.cc
@@ -1,0 +1,67 @@
+/**
+ * Copyright (C) 2013 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+#include "iss.hh"
+
+namespace librdag {
+
+DLLEXPORT_C bool isScalar(const OGTerminal * terminal)
+{
+  if(terminal->asOGRealScalar()!=nullptr)
+  {
+    return true;
+  }
+  if(terminal->asOGComplexScalar()!=nullptr)
+  {
+    return true;
+  }
+  if(terminal->asOGIntegerScalar()!=nullptr)
+  {
+    return true;
+  }
+  return false;
+}
+
+DLLEXPORT_C bool isMatrix(const OGTerminal * terminal)
+{
+  return !isScalar(terminal);
+}
+
+DLLEXPORT_C bool isReal(const OGTerminal * terminal)
+{
+  if(terminal->asOGRealScalar()!=nullptr)
+  {
+    return true;
+  }
+  if(terminal->asOGLogicalMatrix()!=nullptr)
+  {
+    return true;
+  }
+  if(terminal->asOGRealMatrix()!=nullptr)
+  {
+    return true;
+  }
+  if(terminal->asOGRealDiagonalMatrix()!=nullptr)
+  {
+    return true;
+  }
+  if(terminal->asOGRealSparseMatrix()!=nullptr)
+  {
+    return true;
+  }
+  if(terminal->asOGIntegerScalar()!=nullptr)
+  {
+    return true;
+  }
+  return false;
+}
+
+DLLEXPORT_C bool isComplex(const OGTerminal * terminal)
+{
+  return !isReal(terminal);
+}
+
+}

--- a/src/librdag/templates.py
+++ b/src/librdag/templates.py
@@ -53,21 +53,22 @@ binary_runner_class_definition = """\
 class %(nodename)sRunner: public DispatchVoidBinaryOp, private Uncopyable
 {
   public:
-    using DispatchBinaryOp<void>::run;
-    virtual void run(RegContainer* reg0, const OGComplexMatrix* arg0, const OGComplexMatrix* arg1) const override;
-    virtual void run(RegContainer* reg0, const OGRealMatrix*    arg0, const OGRealMatrix*    arg1) const override;
-    virtual void run(RegContainer* reg0, const OGRealScalar*    arg0, const OGRealScalar*    arg1) const override;
+    using DispatchBinaryOp<void *>::run;
+    virtual void * run(RegContainer* reg0, const OGComplexMatrix* arg0, const OGComplexMatrix* arg1) const override;
+    virtual void * run(RegContainer* reg0, const OGRealMatrix*    arg0, const OGRealMatrix*    arg1) const override;
+    virtual void * run(RegContainer* reg0, const OGRealScalar*    arg0, const OGRealScalar*    arg1) const override;
 };
 
 """
 
 binary_runner_function =  """\
-void
+void *
 %(nodename)sRunner::run(RegContainer* reg0, const %(arg0type)s* arg0, const %(arg1type)s* arg1) const
 {
   const %(returntype)s* ret;
 %(implementation)s
   reg0->push_back(ret);
+  return nullptr;
 }
 
 """
@@ -84,19 +85,20 @@ unary_runner_class_definition = """\
 class %(nodename)sRunner: public DispatchVoidUnaryOp, private Uncopyable
 {
   public:
-    virtual void run(RegContainer* reg, const OGRealScalar*    arg) const override;
-    virtual void run(RegContainer* reg, const OGRealMatrix*    arg) const override;
-    virtual void run(RegContainer* reg, const OGComplexMatrix* arg) const override;
+    virtual void * run(RegContainer* reg, const OGRealScalar*    arg) const override;
+    virtual void * run(RegContainer* reg, const OGRealMatrix*    arg) const override;
+    virtual void * run(RegContainer* reg, const OGComplexMatrix* arg) const override;
 };
 """
 
 unary_runner_function = """\
-void
+void *
 %(nodename)sRunner::run(RegContainer* reg, const %(argtype)s* arg) const
 {
   const %(returntype)s* ret;
 %(implementation)s
   reg->push_back(ret);
+  return nullptr;
 }
 
 """

--- a/src/librdag/test/CMakeLists.txt
+++ b/src/librdag/test/CMakeLists.txt
@@ -9,7 +9,7 @@ SET(CMAKE_FC_FLAGS  "${CMAKE_FC_FLAGS} ${GCC_COVERAGE_COMPILE_FLAGS} -cpp" )
 
 link_directories(${longdog_BINARY_DIR}/src/librdag})
 
-set(TESTS check_expressions check_containers check_execution check_rtti check_terminals check_entrypt check_dispatch check_equals check_numerictypes check_convertto)
+set(TESTS check_expressions check_containers check_execution check_rtti check_terminals check_entrypt check_dispatch check_equals check_numerictypes check_convertto check_iss)
 
 # Compile and link each test and add to the list of tests
 foreach(TEST ${TESTS})

--- a/src/librdag/test/check_convertto.cc
+++ b/src/librdag/test/check_convertto.cc
@@ -34,6 +34,43 @@ TEST(ConvertToTest, OGRealScalarConvertToOGRealMatrix) {
 
 }
 
+TEST(ConvertToTest, OGIntegerScalarConvertToOGRealMatrix) {
+
+  int value = 13;
+  OGIntegerScalar * scalar = new OGIntegerScalar(value);
+  real16 * data = new real16[1];
+  data[0]=value;
+  OGRealMatrix * expected = new OGRealMatrix(data,1,1);
+  ConvertTo * c = new ConvertTo();
+  OGOwningRealMatrix * answer = c->convertToOGRealMatrix(scalar);
+  ASSERT_TRUE(*expected==~*answer);
+
+  delete c;
+  delete scalar;
+  delete expected;
+  delete [] data;
+  delete answer;
+
+}
+
+TEST(ConvertToTest, OGLogicalMatrixConvertToOGRealMatrix) {
+
+  real16 * input_values = new real16[12] {1,0,1,0,1,0,1,0,1,0,1,0};
+  OGLogicalMatrix * input = new OGLogicalMatrix(input_values,3,4);
+  real16 * expected_values = new real16[12]{1,0,1,0,1,0,1,0,1,0,1,0};
+  OGRealMatrix * expected = new OGRealMatrix(expected_values,3,4);
+  ConvertTo * c = new ConvertTo();
+  OGOwningRealMatrix * answer = c->convertToOGRealMatrix(input);
+  ASSERT_TRUE(*expected==~*answer);
+
+  delete c;
+  delete [] input_values;
+  delete [] expected_values;
+  delete input;
+  delete expected;
+  delete answer;
+
+}
 
 TEST(ConvertToTest, OGRealDiagonalMatrixConvertToOGRealMatrix) {
 
@@ -91,6 +128,24 @@ TEST(ConvertToTest, OGRealScalarConvertToOGComplexMatrix) {
   OGOwningComplexMatrix * answer = c->convertToOGComplexMatrix(scalar);
   ASSERT_TRUE(*expected==~*answer);
 
+  delete c;
+  delete scalar;
+  delete expected;
+  delete [] data;
+  delete answer;
+
+}
+
+TEST(ConvertToTest, OGIntegerScalarConvertToOGComplexMatrix) {
+
+  int value = {13};
+  OGIntegerScalar * scalar = new OGIntegerScalar(13);
+  complex16 * data = new complex16[1];
+  data[0]=value;
+  OGComplexMatrix * expected = new OGComplexMatrix(data,1,1);
+  ConvertTo * c = new ConvertTo();
+  OGOwningComplexMatrix * answer = c->convertToOGComplexMatrix(scalar);
+  ASSERT_TRUE(*expected==~*answer);
 
   delete c;
   delete scalar;
@@ -222,6 +277,26 @@ TEST(ConvertToTest, OGRealMatrixConvertToOGComplexMatrix) {
   OGOwningComplexMatrix * answer = c->convertToOGComplexMatrix(input);
   ASSERT_TRUE(*expected==~*answer);
 
+
+  delete c;
+  delete [] input_values;
+  delete [] expected_values;
+  delete input;
+  delete expected;
+  delete answer;
+
+}
+
+
+TEST(ConvertToTest, OGRealMatrixConvertToOGLogicalMatrix) {
+
+  real16 * input_values = new real16[12] {1,0,1,0,1,0,1,0,1,0,1,0};
+  complex16 * expected_values = new complex16[12]{{1,0},{0,0},{1,0},{0,0},{1,0},{0,0},{1,0},{0,0},{1,0},{0,0},{1,0},{0,0}};
+  OGLogicalMatrix * input = new OGLogicalMatrix(input_values,4,3);
+  OGComplexMatrix * expected = new OGComplexMatrix(expected_values,4,3);
+  ConvertTo * c = new ConvertTo();
+  OGOwningComplexMatrix * answer = c->convertToOGComplexMatrix(input);
+  ASSERT_TRUE(*expected==~*answer);
 
   delete c;
   delete [] input_values;

--- a/src/librdag/test/check_equals.cc
+++ b/src/librdag/test/check_equals.cc
@@ -152,6 +152,10 @@ TEST(EqualsTest, OGRealScalar) {
   OGRealScalar * same = new OGRealScalar(1.0e0);
   OGRealScalar * baddata = new OGRealScalar(2.0e0);
   OGComplexScalar * badtype = new OGComplexScalar({1.0e0,2.0e0});
+  OGRealMatrix * r_comparable = new OGOwningRealMatrix(new real16[1]{1.e0},1,1);
+  OGRealMatrix * r_notcomparable = new OGOwningRealMatrix(new real16[2]{1.e0,2.e0},1,2);
+  OGComplexMatrix * c_comparable = new OGOwningComplexMatrix(new complex16[1]{{1.e0,0.e0}},1,1);
+  OGComplexMatrix * c_notcomparable = new OGOwningComplexMatrix(new complex16[1]{{1.e0,2.e0}},1,1);
 
   ASSERT_TRUE(scalar->equals(same));
   ASSERT_TRUE(*scalar==*same);
@@ -167,6 +171,20 @@ TEST(EqualsTest, OGRealScalar) {
   ASSERT_FALSE(scalar->fuzzyequals(badtype));
   ASSERT_TRUE(*scalar!=~*badtype);
 
+  ASSERT_FALSE(scalar->mathsequals(c_notcomparable));
+  ASSERT_FALSE(*scalar%*c_notcomparable);
+  ASSERT_TRUE(scalar->mathsequals(c_comparable));
+  ASSERT_TRUE(*scalar%*c_comparable);
+
+  ASSERT_FALSE(scalar->mathsequals(r_notcomparable));
+  ASSERT_FALSE(*scalar%*r_notcomparable);
+  ASSERT_TRUE(scalar->mathsequals(r_comparable));
+  ASSERT_TRUE(*scalar%*r_comparable);
+
+  delete r_comparable;
+  delete r_notcomparable;
+  delete c_comparable;
+  delete c_notcomparable;
   delete scalar;
   delete same;
   delete baddata;
@@ -181,6 +199,10 @@ TEST(EqualsTest, OGComplexScalar) {
   OGComplexScalar * same = new OGComplexScalar({1.0e0,2.0e0});
   OGComplexScalar * baddata = new OGComplexScalar({-1.0e0,2.0e0});
   OGRealScalar * badtype = new OGRealScalar(1.0e0);
+  OGRealMatrix * r_notcomparable = new OGOwningRealMatrix(new real16[2]{1.e0,2.e0},1,2);
+  OGComplexMatrix * c_comparable = new OGOwningComplexMatrix(new complex16[1]{{1.e0,2.e0}},1,1);
+  OGComplexMatrix * c_notcomparable = new OGOwningComplexMatrix(new complex16[2]{{1.e0,2.e0},{3.e0,4.e0}},2,1);
+
 
   ASSERT_TRUE(scalar->equals(same));
   ASSERT_TRUE(*scalar==*same);
@@ -196,6 +218,17 @@ TEST(EqualsTest, OGComplexScalar) {
   ASSERT_FALSE(scalar->fuzzyequals(badtype));
   ASSERT_TRUE(*scalar!=~*badtype);
 
+  ASSERT_FALSE(scalar->mathsequals(c_notcomparable));
+  ASSERT_FALSE(*scalar%*c_notcomparable);
+  ASSERT_TRUE(scalar->mathsequals(c_comparable));
+  ASSERT_TRUE(*scalar%*c_comparable);
+
+  ASSERT_FALSE(scalar->mathsequals(r_notcomparable));
+  ASSERT_FALSE(*scalar%*r_notcomparable);
+
+  delete r_notcomparable;
+  delete c_comparable;
+  delete c_notcomparable;
   delete scalar;
   delete same;
   delete baddata;
@@ -208,6 +241,10 @@ TEST(EqualsTest, OGIntegerScalar) {
   OGIntegerScalar * same = new OGIntegerScalar(1);
   OGIntegerScalar * baddata = new OGIntegerScalar(2);
   OGRealScalar * badtype = new OGRealScalar(1);
+  OGRealMatrix * r_comparable = new OGOwningRealMatrix(new real16[1]{1.e0},1,1);
+  OGRealMatrix * r_notcomparable = new OGOwningRealMatrix(new real16[2]{1.e0,2.e0},1,2);
+  OGComplexMatrix * c_comparable = new OGOwningComplexMatrix(new complex16[1]{{1.e0,0.e0}},1,1);
+  OGComplexMatrix * c_notcomparable = new OGOwningComplexMatrix(new complex16[1]{{1.e0,2.e0}},1,1);
 
   ASSERT_TRUE(scalar->equals(same));
   ASSERT_TRUE(*scalar==*same);
@@ -223,6 +260,20 @@ TEST(EqualsTest, OGIntegerScalar) {
   ASSERT_FALSE(scalar->fuzzyequals(badtype));
   ASSERT_TRUE(*scalar!=~*badtype);
 
+  ASSERT_FALSE(scalar->mathsequals(c_notcomparable));
+  ASSERT_FALSE(*scalar%*c_notcomparable);
+  ASSERT_TRUE(scalar->mathsequals(c_comparable));
+  ASSERT_TRUE(*scalar%*c_comparable);
+
+  ASSERT_FALSE(scalar->mathsequals(r_notcomparable));
+  ASSERT_FALSE(*scalar%*r_notcomparable);
+  ASSERT_TRUE(scalar->mathsequals(r_comparable));
+  ASSERT_TRUE(*scalar%*r_comparable);
+
+  delete r_comparable;
+  delete r_notcomparable;
+  delete c_comparable;
+  delete c_notcomparable;
   delete scalar;
   delete same;
   delete baddata;
@@ -239,6 +290,11 @@ TEST(EqualsTest, OGRealMatrix) {
   OGRealMatrix * badcols = new OGRealMatrix(r_data1,2,4);
   OGRealMatrix * baddata = new OGRealMatrix(r_data2,2,2);
   OGComplexMatrix * badtype = new OGComplexMatrix(c_data1,2,2);
+
+  OGRealMatrix * r_comparable = new OGOwningRealMatrix(new real16[4]{1.e0,2.e0,3.e0,4.e0},2,2);
+  OGRealMatrix * r_notcomparable = new OGOwningRealMatrix(new real16[4]{1.e0,2.e0,3.e0,5.e0},2,2);
+  OGComplexMatrix * c_comparable = new OGOwningComplexMatrix(new complex16[4]{{1.e0,0.e0},{2.e0,0.e0},{3.e0,0.e0},{4.e0,0.e0}},2,2);
+  OGComplexMatrix * c_notcomparable = new OGOwningComplexMatrix(new complex16[1]{{1.e0,2.e0}},1,1);
 
   ASSERT_TRUE(matrix->equals(same));
   ASSERT_TRUE(*matrix==*same);
@@ -262,6 +318,20 @@ TEST(EqualsTest, OGRealMatrix) {
   ASSERT_FALSE(matrix->fuzzyequals(badtype));
   ASSERT_TRUE(*matrix!=~*badtype);
 
+  ASSERT_FALSE(matrix->mathsequals(c_notcomparable));
+  ASSERT_FALSE(*matrix%*c_notcomparable);
+  ASSERT_TRUE(matrix->mathsequals(c_comparable));
+  ASSERT_TRUE(*matrix%*c_comparable);
+
+  ASSERT_FALSE(matrix->mathsequals(r_notcomparable));
+  ASSERT_FALSE(*matrix%*r_notcomparable);
+  ASSERT_TRUE(matrix->mathsequals(r_comparable));
+  ASSERT_TRUE(*matrix%*r_comparable);
+
+  delete r_comparable;
+  delete r_notcomparable;
+  delete c_comparable;
+  delete c_notcomparable;
   delete[] r_data1;
   delete[] r_data2;
   delete[] c_data1;
@@ -284,6 +354,9 @@ TEST(EqualsTest, OGComplexMatrix) {
   OGComplexMatrix * badcols = new OGComplexMatrix(c_data1,2,4);
   OGComplexMatrix * baddata = new OGComplexMatrix(c_data2,2,2);
   OGRealMatrix * badtype = new OGRealMatrix(r_data1,2,2);
+  OGRealMatrix * r_notcomparable = new OGOwningRealMatrix(new real16[4]{1.e0,2.e0,3.e0,5.e0},2,2);
+  OGComplexMatrix * c_comparable = new OGOwningComplexMatrix(new complex16[4]{{1.0e0,10.0e0},{2.0e0,20.0e0},{3.0e0,30.0e0},{4.0e0,40.0e0}},2,2);
+  OGComplexMatrix * c_notcomparable = new OGOwningComplexMatrix(new complex16[4]{{1.0e0,10.0e0},{2.0e0,20.0e0},{3.0e0,30.0e0},{5.0e0,50.0e0}},2,2);
 
   ASSERT_TRUE(matrix->equals(same));
   ASSERT_TRUE(*matrix==*same);
@@ -307,6 +380,17 @@ TEST(EqualsTest, OGComplexMatrix) {
   ASSERT_FALSE(matrix->fuzzyequals(badtype));
   ASSERT_TRUE(*matrix!=~*badtype);
 
+  ASSERT_FALSE(matrix->mathsequals(c_notcomparable));
+  ASSERT_FALSE(*matrix%*c_notcomparable);
+  ASSERT_TRUE(matrix->mathsequals(c_comparable));
+  ASSERT_TRUE(*matrix%*c_comparable);
+
+  ASSERT_FALSE(matrix->mathsequals(r_notcomparable));
+  ASSERT_FALSE(*matrix%*r_notcomparable);
+
+  delete r_notcomparable;
+  delete c_comparable;
+  delete c_notcomparable;
   delete[] c_data1;
   delete[] c_data2;
   delete[] r_data1;
@@ -336,6 +420,10 @@ TEST(EqualsTest, OGRealSparseMatrix) {
   OGRealSparseMatrix * badcolptr = new OGRealSparseMatrix(colPtr2, rowIdx, r_data1, rows, cols);
   OGRealSparseMatrix * badrowidx = new OGRealSparseMatrix(colPtr, rowIdx2, r_data1, rows, cols);
   OGRealScalar * badtype = new OGRealScalar(1.0e0);
+  OGRealSparseMatrix * r_comparable_sparse = new OGOwningRealSparseMatrix(new int[6] {0, 2, 4, 7, 7, 7}, new int[7] {0, 1, 0, 2, 1, 2, 3 }, new real16[7] {1.0e0, 3.0e0, 2.0e0, 5.0e0, 4.0e0, 6.0e0, 7.0e0 }, 5, 4);
+  OGRealMatrix * r_notcomparable = new OGOwningRealMatrix(new real16[4]{1.e0,2.e0,3.e0,5.e0},2,2);
+  OGComplexSparseMatrix * c_comparable_sparse = new OGOwningComplexSparseMatrix(new int[6] {0, 2, 4, 7, 7, 7}, new int[7] {0, 1, 0, 2, 1, 2, 3 }, new complex16[7] {{1.0e0,0.e0}, {3.0e0,0.e0}, {2.0e0,0.e0}, {5.0e0,0.e0}, {4.0e0,0.e0}, {6.0e0,0.e0}, {7.0e0,0.e0}}, 5, 4);
+  OGComplexDiagonalMatrix * c_notcomparable = new OGOwningComplexDiagonalMatrix(new complex16[4]{1.e0,2.e0,3.e0,5.e0},5,4);
 
   ASSERT_TRUE(matrix->equals(same));
   ASSERT_TRUE(*matrix==*same);
@@ -367,6 +455,21 @@ TEST(EqualsTest, OGRealSparseMatrix) {
   ASSERT_FALSE(matrix->fuzzyequals(badtype));
   ASSERT_TRUE(*matrix!=~*badtype);
 
+  ASSERT_FALSE(matrix->mathsequals(c_notcomparable));
+  ASSERT_FALSE(*matrix%*c_notcomparable);
+  ASSERT_TRUE(matrix->mathsequals(c_comparable_sparse));
+  ASSERT_TRUE(*matrix%*c_comparable_sparse);
+
+  ASSERT_TRUE(matrix->mathsequals(r_comparable_sparse));
+  ASSERT_TRUE(*matrix%*r_comparable_sparse);
+  ASSERT_FALSE(matrix->mathsequals(r_notcomparable));
+  ASSERT_FALSE(*matrix%*r_notcomparable);
+
+
+  delete r_comparable_sparse;
+  delete r_notcomparable;
+  delete c_comparable_sparse;
+  delete c_notcomparable;
   delete matrix;
   delete same;
   delete badrows;
@@ -400,6 +503,10 @@ TEST(EqualsTest, OGComplexSparseMatrix) {
   OGComplexSparseMatrix * badcolptr = new OGComplexSparseMatrix(colPtr2, rowIdx, c_data1, rows, cols);
   OGComplexSparseMatrix * badrowidx = new OGComplexSparseMatrix(colPtr, rowIdx2, c_data1, rows, cols);
   OGRealScalar * badtype = new OGRealScalar(1.0e0);
+  OGRealMatrix * r_notcomparable = new OGOwningRealMatrix(new real16[4]{1.e0,2.e0,3.e0,5.e0},2,2);
+  OGComplexSparseMatrix * c_comparable_sparse = new OGOwningComplexSparseMatrix(new int[6] {0, 2, 4, 7, 7, 7}, new int[7] {0, 1, 0, 2, 1, 2, 3 }, new complex16[7] {{1.0e0,10.0e0}, {3.0e0,30.0e0}, {2.0e0,20.0e0}, {5.0e0,50.0e0}, {4.0e0,40.0e0}, {6.0e0,60.0e0}, {7.0e0,70.0e0} }, 5, 4);
+  OGComplexDiagonalMatrix * c_notcomparable = new OGOwningComplexDiagonalMatrix(new complex16[4]{1.e0,2.e0,3.e0,5.e0},5,4);
+
 
   ASSERT_TRUE(matrix->equals(same));
   ASSERT_TRUE(*matrix==*same);
@@ -431,6 +538,18 @@ TEST(EqualsTest, OGComplexSparseMatrix) {
   ASSERT_FALSE(matrix->fuzzyequals(badtype));
   ASSERT_TRUE(*matrix!=~*badtype);
 
+  ASSERT_FALSE(matrix->mathsequals(c_notcomparable));
+  ASSERT_FALSE(*matrix%*c_notcomparable);
+  ASSERT_TRUE(matrix->mathsequals(c_comparable_sparse));
+  ASSERT_TRUE(*matrix%*c_comparable_sparse);
+
+  ASSERT_FALSE(matrix->mathsequals(r_notcomparable));
+  ASSERT_FALSE(*matrix%*r_notcomparable);
+
+
+  delete r_notcomparable;
+  delete c_comparable_sparse;
+  delete c_notcomparable;
   delete matrix;
   delete same;
   delete badrows;
@@ -451,12 +570,19 @@ TEST(EqualsTest, OGRealDiagonalMatrix) {
   real16 * r_data1 = new real16[4] {1.0e0,2.0e0,3.0e0,4.0e0};
   real16 * r_data2 = new real16[4] {-1.0e0,2.0e0,3.0e0,4.0e0};
   complex16 * c_data1 = new complex16[4] {{1.0e0,10.0e0},{2.0e0,20.0e0},{3.0e0,30.0e0},{4.0e0,40.0e0}};
+  real16 * r_fullmatrix = new real16[16]{1.e0,0.e0,0.e0,0.e0,0.e0,2.e0,0.e0,0.e0,0.e0,0.e0,3.e0,0.e0,0.e0,0.e0,0.e0,4.e0};
   OGRealDiagonalMatrix * matrix = new OGRealDiagonalMatrix(r_data1,4,4);
   OGRealDiagonalMatrix * same = new OGRealDiagonalMatrix(r_data1,4,4);
   OGRealDiagonalMatrix * badrows = new OGRealDiagonalMatrix(r_data1,12,4);
   OGRealDiagonalMatrix * badcols = new OGRealDiagonalMatrix(r_data1,4,12);
   OGRealDiagonalMatrix * baddata = new OGRealDiagonalMatrix(r_data2,4,4);
+  OGRealMatrix * comparable = new OGRealMatrix(r_fullmatrix,4,4);
   OGComplexMatrix * badtype = new OGComplexMatrix(c_data1,2,2);
+  OGRealSparseMatrix * r_comparable_sparse = new OGOwningRealSparseMatrix(new int[5] {0, 1, 2, 3, 4}, new int[4] {0, 1, 2, 3}, new real16[7] {1.0e0, 2.0e0, 3.0e0, 4.0e0}, 4, 4);
+  OGRealMatrix * r_notcomparable = new OGOwningRealMatrix(new real16[4]{1.e0,2.e0,3.e0,5.e0},2,2);
+  OGComplexDiagonalMatrix * c_comparable_diag = new OGOwningComplexDiagonalMatrix(new complex16[4] {{1.0e0,0.e0}, {2.0e0,0.e0}, {3.0e0,0.e0}, {4.0e0,0.e0}},4, 4);
+  OGComplexDiagonalMatrix * c_notcomparable = new OGOwningComplexDiagonalMatrix(new complex16[4]{1.e0,2.e0,3.e0,5.e0},4,4);
+
 
   ASSERT_TRUE(matrix->equals(same));
   ASSERT_TRUE(*matrix==*same);
@@ -480,11 +606,30 @@ TEST(EqualsTest, OGRealDiagonalMatrix) {
   ASSERT_FALSE(matrix->fuzzyequals(badtype));
   ASSERT_TRUE(*matrix!=~*badtype);
 
+  ASSERT_TRUE(matrix->mathsequals(comparable));
+  ASSERT_TRUE(*matrix%*comparable);
+
+  ASSERT_FALSE(matrix->mathsequals(c_notcomparable));
+  ASSERT_FALSE(*matrix%*c_notcomparable);
+  ASSERT_TRUE(matrix->mathsequals(c_comparable_diag));
+  ASSERT_TRUE(*matrix%*c_comparable_diag);
+
+  ASSERT_TRUE(matrix->mathsequals(r_comparable_sparse));
+  ASSERT_TRUE(*matrix%*r_comparable_sparse);
+  ASSERT_FALSE(matrix->mathsequals(r_notcomparable));
+  ASSERT_FALSE(*matrix%*r_notcomparable);
+
+  delete r_comparable_sparse;
+  delete r_notcomparable;
+  delete c_comparable_diag;
+  delete c_notcomparable;
   delete[] r_data1;
   delete[] r_data2;
   delete[] c_data1;
+  delete[] r_fullmatrix;
   delete matrix;
   delete same;
+  delete comparable;
   delete badrows;
   delete badcols;
   delete baddata;
@@ -503,6 +648,9 @@ TEST(EqualsTest, OGComplexDiagonalMatrix) {
   OGComplexDiagonalMatrix * badcols = new OGComplexDiagonalMatrix(c_data1,4,12);
   OGComplexDiagonalMatrix * baddata = new OGComplexDiagonalMatrix(c_data2,4,4);
   OGRealMatrix * badtype = new OGRealMatrix(r_data1,2,2);
+  OGRealMatrix * r_notcomparable = new OGOwningRealMatrix(new real16[4]{1.e0,2.e0,3.e0,5.e0},2,2);
+  OGComplexDiagonalMatrix * c_comparable_diag = new OGOwningComplexDiagonalMatrix(new complex16[4] {{1.0e0,10.e0}, {2.0e0,20.e0}, {3.0e0,30.e0}, {4.0e0,40.e0}},4, 4);
+  OGComplexDiagonalMatrix * c_notcomparable = new OGOwningComplexDiagonalMatrix(new complex16[4]{1.e0,2.e0,3.e0,5.e0},4,4);
 
   ASSERT_TRUE(matrix->equals(same));
   ASSERT_TRUE(*matrix==*same);
@@ -526,6 +674,17 @@ TEST(EqualsTest, OGComplexDiagonalMatrix) {
   ASSERT_FALSE(matrix->fuzzyequals(badtype));
   ASSERT_TRUE(*matrix!=~*badtype);
 
+  ASSERT_FALSE(matrix->mathsequals(c_notcomparable));
+  ASSERT_FALSE(*matrix%*c_notcomparable);
+  ASSERT_TRUE(matrix->mathsequals(c_comparable_diag));
+  ASSERT_TRUE(*matrix%*c_comparable_diag);
+
+  ASSERT_FALSE(matrix->mathsequals(r_notcomparable));
+  ASSERT_FALSE(*matrix%*r_notcomparable);
+
+  delete r_notcomparable;
+  delete c_comparable_diag;
+  delete c_notcomparable;
   delete[] c_data1;
   delete[] c_data2;
   delete[] r_data1;

--- a/src/librdag/test/check_iss.cc
+++ b/src/librdag/test/check_iss.cc
@@ -1,0 +1,140 @@
+/**
+ * Copyright (C) 2013 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+#include "gtest/gtest.h"
+#include "warningmacros.h"
+#include "iss.hh"
+#include "terminal.hh"
+#include <cfloat>
+#include <iostream>
+#include <cstdint>
+
+using namespace std;
+using namespace librdag;
+
+class issTest : public ::testing::Test
+{
+  protected:
+    OGRealScalar * _ogrealscalar = nullptr;
+    OGComplexScalar * _ogcomplexscalar = nullptr;
+    OGIntegerScalar * _ogintegerscalar = nullptr;
+    OGRealMatrix * _ogrealmatrix = nullptr;
+    OGComplexMatrix * _ogcomplexmatrix = nullptr;
+    OGLogicalMatrix * _oglogicalmatrix = nullptr;
+    OGRealDiagonalMatrix * _ogrealdiagonalmatrix = nullptr;
+    OGComplexDiagonalMatrix * _ogcomplexdiagonalmatrix = nullptr;
+    OGRealSparseMatrix * _ogrealsparsematrix = nullptr;
+    OGComplexSparseMatrix * _ogcomplexsparsematrix = nullptr;
+    OGOwningRealMatrix * _ogowningrealmatrix = nullptr;
+    OGOwningComplexMatrix * _ogowningcomplexmatrix = nullptr;
+    real16 * r_data;
+    complex16 * c_data;
+    int * colPtr;
+    int * rowIdx;
+    virtual void SetUp()
+  {
+    r_data = new real16[1]{12};
+    c_data = new complex16[1]{{12,34}};
+    rowIdx = new int[1]{0};
+    colPtr = new int[2]{0,1};
+    _ogrealscalar = new OGRealScalar(12);
+    _ogcomplexscalar = new OGComplexScalar({12,34});
+    _ogintegerscalar = new OGIntegerScalar(4);
+    _ogrealmatrix = new OGRealMatrix(r_data,1,1);
+    _ogcomplexmatrix = new OGComplexMatrix(c_data,1,1);
+    _oglogicalmatrix = new OGLogicalMatrix(r_data,1,1);
+    _ogrealdiagonalmatrix = new OGRealDiagonalMatrix(r_data,1,1);
+    _ogcomplexdiagonalmatrix = new OGComplexDiagonalMatrix(c_data,1,1);
+    _ogrealsparsematrix = new OGRealSparseMatrix(colPtr,rowIdx,r_data,1,1);
+    _ogcomplexsparsematrix = new OGComplexSparseMatrix(colPtr,rowIdx,c_data,1,1);
+    _ogowningrealmatrix = new OGOwningRealMatrix(new real16[1]{1},1,1);
+    _ogowningcomplexmatrix = new OGOwningComplexMatrix(new complex16[1]{{1,2}},1,1);
+  }
+
+  virtual void TearDown()
+  {
+    delete [] r_data;
+    delete [] c_data;
+    delete [] rowIdx;
+    delete [] colPtr;
+    delete _ogrealscalar;
+    delete _ogcomplexscalar;
+    delete _ogintegerscalar;
+    delete _ogrealmatrix;
+    delete _ogcomplexmatrix;
+    delete _oglogicalmatrix;
+    delete _ogrealdiagonalmatrix;
+    delete _ogcomplexdiagonalmatrix;
+    delete _ogrealsparsematrix;
+    delete _ogcomplexsparsematrix;
+    delete _ogowningrealmatrix;
+    delete _ogowningcomplexmatrix;
+  }
+};
+
+TEST_F(issTest, isReal)
+{
+  ASSERT_TRUE (isReal(_ogrealscalar));
+  ASSERT_FALSE(isReal(_ogcomplexscalar));
+  ASSERT_TRUE (isReal(_ogintegerscalar));
+  ASSERT_TRUE (isReal(_ogrealmatrix));
+  ASSERT_FALSE(isReal(_ogcomplexmatrix));
+  ASSERT_TRUE (isReal(_oglogicalmatrix));
+  ASSERT_TRUE (isReal(_ogrealdiagonalmatrix));
+  ASSERT_FALSE(isReal(_ogcomplexdiagonalmatrix));
+  ASSERT_TRUE (isReal(_ogrealsparsematrix));
+  ASSERT_FALSE(isReal(_ogcomplexsparsematrix));
+  ASSERT_TRUE (isReal(_ogowningrealmatrix));
+  ASSERT_FALSE(isReal(_ogowningcomplexmatrix));
+}
+
+TEST_F(issTest, isComplex)
+{
+  ASSERT_FALSE (isComplex(_ogrealscalar));
+  ASSERT_TRUE(isComplex(_ogcomplexscalar));
+  ASSERT_FALSE (isComplex(_ogintegerscalar));
+  ASSERT_FALSE (isComplex(_ogrealmatrix));
+  ASSERT_TRUE(isComplex(_ogcomplexmatrix));
+  ASSERT_FALSE (isComplex(_oglogicalmatrix));
+  ASSERT_FALSE (isComplex(_ogrealdiagonalmatrix));
+  ASSERT_TRUE(isComplex(_ogcomplexdiagonalmatrix));
+  ASSERT_FALSE (isComplex(_ogrealsparsematrix));
+  ASSERT_TRUE(isComplex(_ogcomplexsparsematrix));
+  ASSERT_FALSE (isComplex(_ogowningrealmatrix));
+  ASSERT_TRUE(isComplex(_ogowningcomplexmatrix));
+}
+
+
+TEST_F(issTest, isScalar)
+{
+  ASSERT_TRUE (isScalar(_ogrealscalar));
+  ASSERT_TRUE (isScalar(_ogcomplexscalar));
+  ASSERT_TRUE (isScalar(_ogintegerscalar));
+  ASSERT_FALSE(isScalar(_ogrealmatrix));
+  ASSERT_FALSE(isScalar(_ogcomplexmatrix));
+  ASSERT_FALSE(isScalar(_oglogicalmatrix));
+  ASSERT_FALSE(isScalar(_ogrealdiagonalmatrix));
+  ASSERT_FALSE(isScalar(_ogcomplexdiagonalmatrix));
+  ASSERT_FALSE(isScalar(_ogrealsparsematrix));
+  ASSERT_FALSE(isScalar(_ogcomplexsparsematrix));
+  ASSERT_FALSE(isScalar(_ogowningrealmatrix));
+  ASSERT_FALSE(isScalar(_ogowningcomplexmatrix));
+}
+TEST_F(issTest, isMatrix)
+{
+  ASSERT_FALSE(isMatrix(_ogrealscalar));
+  ASSERT_FALSE(isMatrix(_ogcomplexscalar));
+  ASSERT_FALSE (isMatrix(_ogintegerscalar));
+  ASSERT_TRUE (isMatrix(_ogrealmatrix));
+  ASSERT_TRUE (isMatrix(_ogcomplexmatrix));
+  ASSERT_TRUE (isMatrix(_oglogicalmatrix));
+  ASSERT_TRUE (isMatrix(_ogrealdiagonalmatrix));
+  ASSERT_TRUE (isMatrix(_ogcomplexdiagonalmatrix));
+  ASSERT_TRUE (isMatrix(_ogrealsparsematrix));
+  ASSERT_TRUE (isMatrix(_ogcomplexsparsematrix));
+  ASSERT_TRUE (isMatrix(_ogowningrealmatrix));
+  ASSERT_TRUE (isMatrix(_ogowningcomplexmatrix));
+}

--- a/src/librdag/test/check_terminals.cc
+++ b/src/librdag/test/check_terminals.cc
@@ -140,6 +140,15 @@ TEST(TerminalsTest, OGRealScalarTest) {
   // check ctor worked
   ASSERT_NE(tmp, nullptr); 
 
+  // check getRows is ok
+  ASSERT_EQ(tmp->getRows(), 1);
+
+  // check getCols is ok
+  ASSERT_EQ(tmp->getCols(), 1);
+
+  // check getDatalen is ok
+  ASSERT_EQ(tmp->getDatalen(), 1);
+
   // check getValue is ok
   ASSERT_EQ(tmp->getValue(), value);
 
@@ -200,11 +209,23 @@ TEST(TerminalsTest, OGComplexScalarTest) {
   // check ctor worked
   ASSERT_NE(tmp, nullptr); 
 
+  // check getRows is ok
+  ASSERT_EQ(tmp->getRows(), 1);
+
+  // check getCols is ok
+  ASSERT_EQ(tmp->getCols(), 1);
+
+  // check getDatalen is ok
+  ASSERT_EQ(tmp->getDatalen(), 1);
+
   // check getValue is ok
   ASSERT_EQ(tmp->getValue(), value);
 
   // check getType() is ok
   ASSERT_EQ(tmp->getType(), COMPLEX_SCALAR_ENUM);
+
+  // check can't promote as real
+  ASSERT_ANY_THROW(tmp->asFullOGRealMatrix());
 
   // wire up array for ArrOfArr test
   complex16 expectedtmp[1] = {{3.14e0, 0.00159e0}};
@@ -257,6 +278,15 @@ TEST(TerminalsTest, OGIntegerScalarTest) {
   tmp = new OGIntegerScalar(value);
   // check ctor worked
   ASSERT_NE(tmp, nullptr); 
+
+  // check getRows is ok
+  ASSERT_EQ(tmp->getRows(), 1);
+
+  // check getCols is ok
+  ASSERT_EQ(tmp->getCols(), 1);
+
+  // check getDatalen is ok
+  ASSERT_EQ(tmp->getDatalen(), 1);
 
   // check getValue is ok
   ASSERT_EQ(tmp->getValue(), value);
@@ -457,6 +487,9 @@ TEST(TerminalsTest, OGComplexMatrixTest) {
 
   // check getType() is ok
   ASSERT_EQ(tmp->getType(), COMPLEX_MATRIX_ENUM);    
+
+  // check can't promote as real
+  ASSERT_ANY_THROW(tmp->asFullOGRealMatrix());
 
   // wire up array for ArrOfArr test
   complex16 expectedtmp[12] = {{1e0,10e0},{4e0,40e0},{7e0,70e0},{10e0,100e0},{2e0,20e0},{5e0,50e0},{8e0,80e0},{11e0,110e0},{3e0,30e0},{6e0,60e0},{9e0,90e0},{12e0,120e0}};
@@ -739,6 +772,9 @@ TEST(TerminalsTest, OGComplexDiagonalMatrix) {
 
   // check getType() is ok
   ASSERT_EQ(tmp->getType(), COMPLEX_DIAGONAL_MATRIX_ENUM);  
+
+  // check can't promote as real
+  ASSERT_ANY_THROW(tmp->asFullOGRealMatrix());
 
   // wire up array for ArrOfArr test
   complex16 expectedtmp[12] = {{1e0,10e0},{0e0,0e0},{0e0,0e0},{0e0,0e0},{0e0,0e0},{2e0,20e0},{0e0,0e0},{0e0,0e0},{0e0,0e0},{0e0,0e0},{3e0,30e0},{0e0,0e0}};
@@ -1088,6 +1124,9 @@ TEST(TerminalsTest, OGComplexSparseMatrix) {
   // check getType() is ok
   ASSERT_EQ(tmp->getType(), COMPLEX_SPARSE_MATRIX_ENUM);  
 
+  // check can't promote as real
+  ASSERT_ANY_THROW(tmp->asFullOGRealMatrix());
+
   // wire up array for ArrOfArr test
   complex16 expectedtmp[20] = {
     {1,10},{2,20},{0,30},{0,0},
@@ -1227,6 +1266,8 @@ public:
     virtual void debug_print() const override {}
     virtual void accept(Visitor SUPPRESS_UNUSED &v) const override {}
     virtual OGNumeric* copy() const override { return nullptr; }
+    virtual OGOwningRealMatrix * asFullOGRealMatrix() const override { return nullptr; }
+    virtual OGOwningComplexMatrix * asFullOGComplexMatrix() const override { return nullptr; }
 };
 
 TEST(OGArrayTest, NegativeDatalen)


### PR DESCRIPTION
This is a rabbit hole PR. Was supposed to be adding code to make dispatch work by type conversion, however the need to test whether two data containers are mathematically equal, along with other general properties makes up most of the PR.
- Added converters for missing types
- Added isReal() isComplex() isScalar() isMatrix()
- Made it a requirement that dispatch returns a pointer type, this is to handle `T ret = foo(); return ret;` when `ret` is `void`
- Fixed a couple of minor but catastrophic bugs in the Materialise.toOGTerminal() code in the JNI shim.

BB PASS [http://devmaths-lx-1:8011/builders/nyqwk2-testing/builds/446](http://devmaths-lx-1:8011/builders/nyqwk2-testing/builds/446)
Coverage: librdag coverge: 88.5% (was 86.9%), jshim down 0.2% to 20.4% (added a couple of `toString()` methods which caused that!).
