### PR TITLE
Propagation of exceptions into Java (and other small fixes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,12 @@ set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules ${CMAKE_MODULE_PATH})
 set(CMAKE_C_FLAGS "-std=c99 -Wall -Werror -Wextra -pedantic ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_C_FLAGS}")
 set(CMAKE_CXX_FLAGS "-std=c++11 -Wall -Werror -Wextra -pedantic ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_CXX_FLAGS}")
 
+# On Linux, add -rdynamic for stack traces
+if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  set(CMAKE_C_FLAGS"${CMAKE_C_FLAGS} -rdynamic")
+  set(CMAKE_CXX_FLAGS"${CMAKE_CXX_FLAGS} -rdynamic")
+endif()
+
 # Use the native assembler on Apple in order to be able to generate AVX instructions.
 if(APPLE)
   set(CMAKE_C_FLAGS "-Wa,-q ${CMAKE_C_FLAGS}")
@@ -122,9 +128,9 @@ set(TARGET_TYPES dbg std sse41 avx1)
 set(FFAST_MATH_SAFE "-fno-math-errno  -fno-rounding-math -fno-signaling-nans -fcx-limited-range")
 
 set(OPT_FLAGS_dbg "-DDEBUG ${CMAKE_C_FLAGS_DEBUG}")
-set(OPT_FLAGS_std "${FFAST_MATH_SAFE} -O2 -funroll-loops -DNDEBUG")
-set(OPT_FLAGS_sse41 "${OPT_FLAGS_std} -march=core2 -msse4.1")
-set(OPT_FLAGS_avx1 "${OPT_FLAGS_std}  -march=corei7-avx -mavx256-split-unaligned-load -mavx256-split-unaligned-store")
+set(OPT_FLAGS_std "-g ${FFAST_MATH_SAFE} -O2 -funroll-loops -DNDEBUG")
+set(OPT_FLAGS_sse41 "-g ${OPT_FLAGS_std} -march=core2 -msse4.1")
+set(OPT_FLAGS_avx1 "-g ${OPT_FLAGS_std}  -march=corei7-avx -mavx256-split-unaligned-load -mavx256-split-unaligned-store")
 
 # Gtest
 add_subdirectory(external/gtest-1.6.0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ if(LAPACK_EXPORT)
   set(LAPACK_BUILDINFO ${LAPACK_EXPORT})
 else()
 #This is a temporary thing. Expect later to add in ExternalProject_add to get the code!!
-  message( FATAL_ERROR "LAPACK_EXPORT must be defined on the command line. e.g. -DLAPACK_EXPORT="/path/to/LAPACK_EXPORT.cmake"" )
+  message( FATAL_ERROR "LAPACK_EXPORT must be defined on the command line. e.g. -DLAPACK_EXPORT=\"/path/to/LAPACK_EXPORT.cmake\"" )
 endif()
 
 

--- a/cmake/modules/OpenGammaGTest.cmake
+++ b/cmake/modules/OpenGammaGTest.cmake
@@ -17,11 +17,11 @@ file(MAKE_DIRECTORY ${GTEST_XML_DIR})
 # Appropriate flags are added so that GTest outputs JUnit XML for later
 # processing. The target is appended to the list of tests that is used in the
 # add_gtest_report macro.
-macro(add_gtest TESTNAME)
+macro(add_gtest TESTNAME SUPPRESSIONS)
   get_target_property(TEST_LOC ${TESTNAME} LOCATION)
   add_test(${TESTNAME} ${TEST_LOC} --gtest_output=xml:${CMAKE_BINARY_DIR}/gtest-output/${TESTNAME}.xml)
   if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-    add_test(${TESTNAME}_valgrind valgrind --leak-check=full --error-exitcode=1 ${TEST_LOC})
+    add_test(${TESTNAME}_valgrind valgrind --leak-check=full --error-exitcode=1 --suppressions=${SUPPRESSIONS} ${TEST_LOC})
   endif()
   list(APPEND gtests ${TESTNAME})
   set(gtests ${gtests} CACHE INTERNAL "GTest tests to run")
@@ -30,10 +30,11 @@ endmacro()
 # Builds a test executable that uses Gtest from the specified SOURCES and links
 # it to any additional LINK_LIBRARIES. LINK_LIBRARIES does not need to include
 # the GTest libraries - these are added automatically. The sources are also
-# compiled with the specified COMPILE_DEFINITIONS.
+# compiled with the specified COMPILE_DEFINITIONS. Valgrinf is run on each test,
+# with the suppressions file SUPPRESSIONS.
 macro(add_multitarget_gtest TESTNAME)
   cmake_parse_arguments(MTGTEST "" ""
-                        "SOURCES;LINK_LIBRARIES;COMPILE_DEFINITIONS;TARGETS"
+                        "SOURCES;LINK_LIBRARIES;COMPILE_DEFINITIONS;TARGETS;SUPPRESSIONS"
                         ${ARGN})
   foreach(TARGET ${MTGTEST_TARGETS})
     if(SUPPORT_${TARGET})
@@ -47,7 +48,7 @@ macro(add_multitarget_gtest TESTNAME)
       foreach(COMPILE_DEFINITION ${MTGTEST_COMPILE_DEFINITIONS})
         set_target_properties(${TEST} PROPERTIES COMPILE_DEFINITIONS ${COMPILE_DEFINITION})
       endforeach()
-      add_gtest(${TEST})
+      add_gtest(${TEST} ${MTGTEST_SUPPRESSIONS})
     endif()
   endforeach()
 endmacro()

--- a/include/exceptions.hh
+++ b/include/exceptions.hh
@@ -57,6 +57,10 @@ class BacktraceElement
      */
     const string getFunction() const;
   private:
+    /**
+     * Converts any non-ascii characters to ascii characters
+     */
+    string asciiOnly(string s);
     const void* _address;
     string _object_file;
     string _function;

--- a/include/exceptions.hh
+++ b/include/exceptions.hh
@@ -10,6 +10,11 @@
 #include <exception>
 #include <stdexcept>
 
+/**
+ * Maximum number of frames to retrieve for a stack trace. A somewhat arbitrary
+ * choice, but probably more than 50 stack frames implies you have worse problems
+ * than needing to know what was going on in the 51st frame.
+ */
 #define FRAMEBUF_SIZE 50
 
 using namespace std;

--- a/include/exceptions.hh
+++ b/include/exceptions.hh
@@ -10,28 +10,111 @@
 #include <exception>
 #include <stdexcept>
 
+#define FRAMEBUF_SIZE 50
+
 using namespace std;
+
+namespace dogma_exceptions {
+
+/**
+ * Details of one stack frame in a backtrace.
+ */
+class BacktraceElement
+{
+  public:
+    /**
+     * Default constructor required for new[]
+     */
+    BacktraceElement();
+    /**
+     * Copy constructor
+     *
+     * @param other the BacktraceElement to copy
+     */
+    BacktraceElement(const BacktraceElement& other);
+    /**
+     * Constructor that is usually used for constructing a new BacktraceElement.
+     *
+     * @param backtrace_symbol a single description of a frame from backtrace_symbols()
+     * @param address the address of the instruction pointer for the frame
+     */
+    BacktraceElement(const string& backtrace_symbol, const void* address);
+    /**
+     * Get the address of the instruction pointer for the frame.
+     */
+    const void* getAddress() const;
+    /**
+     * Get the name and path of the object file that this frame is inside.
+     */
+    const string getObjectFile() const;
+    /**
+     * Get the name of the function that this frame is inside.
+     */
+    const string getFunction() const;
+  private:
+    const void* _address;
+    string _object_file;
+    string _function;
+};
+
+/**
+ * Any exception thrown during the execution of the DOGMA libraries
+ */
+class dogma_error: public runtime_error
+{
+  public:
+    /**
+     * The usual constructor for building a dogma_error.
+     *
+     * @param what Description of the exception, in a form suitable for printing to the user as the
+     *             stack trace in Java.
+     */
+    dogma_error(const string& what);
+    /**
+     * Copy constructor
+     *
+     * @param other the dogma_error to copy
+     */
+    dogma_error(const dogma_error& other);
+    /**
+     * Destructor. Deletes all the BacktraceElements that this exception holds.
+     */
+    virtual ~dogma_error();
+    /**
+     * Get an array of all frames in the backtrace. The array is owned (and deleted) by the dogma_error.
+     */
+    const BacktraceElement* getBacktrace() const;
+    /**
+     * Get the number of frames in the backtrace.
+     */
+    size_t getTraceSize() const;
+  private:
+    BacktraceElement* _backtrace;
+    size_t _traceSize;
+};
+
+} // end namespace dogma_exceptions
 
 namespace librdag {
 
 /*
- * General exception thing
+ * Exceptions thrown during DOGMA execution
  */
-class rdag_error: public runtime_error
+class rdag_error: public ::dogma_exceptions::dogma_error
 {
-  using runtime_error::runtime_error;
+  using ::dogma_exceptions::dogma_error::dogma_error;
 };
 
 } // namespace librdag
 
 namespace convert {
 
-/*
- * General exception thing
+/**
+ * Exceptions thrown during conversion from an OG-Maths AST (Java) to a DOGMA AST (C++)
  */
-class convert_error: public runtime_error
+class convert_error: public ::dogma_exceptions::dogma_error
 {
-  using runtime_error::runtime_error;
+  using ::dogma_exceptions::dogma_error::dogma_error;
 };
 
 } // namespace convert

--- a/include/fake_jni.h
+++ b/include/fake_jni.h
@@ -212,6 +212,18 @@ class JNIEnv_
     {
       return nullptr;
     }
+    virtual jstring NewStringUTF(const char SUPPRESS_UNUSED *bytes)
+    {
+      return nullptr;
+    }
+    virtual jint ThrowNew(jclass SUPPRESS_UNUSED clazz, const char SUPPRESS_UNUSED *msg)
+    {
+      return 0;
+    }
+    virtual jint Throw(jthrowable SUPPRESS_UNUSED throwable)
+    {
+      return 0;
+    }
     virtual jintArray NewIntArray(jsize SUPPRESS_UNUSED len)
     {
       return nullptr;

--- a/include/fake_jni.h
+++ b/include/fake_jni.h
@@ -145,6 +145,9 @@ class JNIEnv_
     {
       
     }
+    virtual jint EnsureLocalCapacity(jint SUPPRESS_UNUSED capacity) {
+      return 0;
+    }
     virtual jobject NewObject(jclass SUPPRESS_UNUSED clazz, jmethodID SUPPRESS_UNUSED methodID, ...) {
       return nullptr;
     }

--- a/include/jvmmanager.hh
+++ b/include/jvmmanager.hh
@@ -51,6 +51,8 @@ class JVMManager {
     DLLEXPORT_C static jclass getOGComplexDiagonalMatrixClazz();
     DLLEXPORT_C static jclass getOGRealSparseMatrixClazz();
     DLLEXPORT_C static jclass getOGComplexSparseMatrixClazz();
+    DLLEXPORT_C static jclass getMathsExceptionNativeConversionClazz();
+    DLLEXPORT_C static jclass getMathsExceptionNativeComputationClazz();
     DLLEXPORT_C static jmethodID getOGRealScalarClazz_init();
     DLLEXPORT_C static jmethodID getOGComplexScalarClazz_init();
     DLLEXPORT_C static jmethodID getOGRealDenseMatrixClazz_init();
@@ -74,6 +76,7 @@ class JVMManager {
     DLLEXPORT_C static jintArray newIntArray(JNIEnv *env, jsize len);
     DLLEXPORT_C static jdoubleArray newDoubleArray(JNIEnv *env, jsize len);
     DLLEXPORT_C static jobject newDouble(JNIEnv* env, jdouble v);
+    DLLEXPORT_C static jint throwNew(JNIEnv* env, jclass exClass, const char* msg);
     DLLEXPORT_C static void getEnv(void **penv);
     DLLEXPORT_C static jobject callObjectMethod(JNIEnv *env, jobject obj, jmethodID methodID, ...);
   private:
@@ -102,6 +105,8 @@ class JVMManager {
     static jclass _OGComplexDiagonalMatrixClazz;
     static jclass _OGRealSparseMatrixClazz;
     static jclass _OGComplexSparseMatrixClazz;
+    static jclass _MathsExceptionNativeConversionClazz;
+    static jclass _MathsExceptionNativeComputationClazz;
     static jmethodID _DoubleClazz_init;
     static jmethodID _OGRealScalarClazz_init;
     static jmethodID _OGComplexScalarClazz_init;

--- a/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsException.java
+++ b/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsException.java
@@ -9,7 +9,11 @@ package com.opengamma.longdog.exceptions;
  * Provides a manner in which maths exceptions relating to null pointer access can be thrown.
  */
 public class MathsException extends RuntimeException {
-  private static final long serialVersionUID = 1L;
+
+  /**
+   *  Serial ID
+   */
+  private static final long serialVersionUID = -5343624439409841980L;
 
   public MathsException() {
     super();

--- a/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionIllegalArgument.java
+++ b/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionIllegalArgument.java
@@ -9,7 +9,11 @@ package com.opengamma.longdog.exceptions;
  * Provides a manner in which maths exceptions relating illegal arguments can be thrown
  */
 public class MathsExceptionIllegalArgument extends MathsException {
-  private static final long serialVersionUID = 1L;
+
+  /**
+   * Serial ID
+   */
+  private static final long serialVersionUID = -5130462724654601466L;
 
   public MathsExceptionIllegalArgument() {
     super();

--- a/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionNative.java
+++ b/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionNative.java
@@ -1,0 +1,73 @@
+package com.opengamma.longdog.exceptions;
+
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
+
+/**
+ * Base class for any exceptions that get thrown during the native code execution.
+ */
+public class MathsExceptionNative extends MathsException {
+
+  private static final long serialVersionUID = 1L;
+
+  private String _nativeMsg;
+  private StackTraceElement[] _nativeStackTrace;
+
+  public MathsExceptionNative() {
+    super();
+  }
+
+  /**
+   * This form of the constructor is used by the native code for generating the mixed-language backtrace.
+   * Frames are represented by 4 strings, containing the class name, method name, file name and line no.
+   * The Java side steps through this array to construct suitable StackTraceElement objects to push on
+   * top of the Java stack trace.
+   *
+   * @param msg The error message as presented to the user
+   * @param backtraceInfo strings describing each frame
+   */
+  public MathsExceptionNative(final String msg, final String[] backtraceInfo)
+  {
+    super(msg);
+    StackTraceElement[] javaStackTrace = getStackTrace();
+    if ((backtraceInfo.length % 4) != 0) {
+      // The backtrace information from C++ is "weird". We shall not attempt to use it.
+      System.err.println("WARNING: strange backtrace info received from native");
+      return;
+    }
+
+    int nNativeFrames = backtraceInfo.length / 4;
+    int nJavaFrames = javaStackTrace.length;
+    int nFrames = nJavaFrames + nNativeFrames;
+    StackTraceElement[] combinedStackTrace = new StackTraceElement[nFrames];
+    for (int i = 0; i < nNativeFrames; i++) {
+      int index = i * 4;
+      String className  = backtraceInfo[index + 0];
+      String methodName = backtraceInfo[index + 1];
+      String fileName   = backtraceInfo[index + 2];
+      int lineNo = Integer.parseInt(backtraceInfo[index + 3]);
+      combinedStackTrace[i] = new StackTraceElement(className, methodName, fileName, lineNo);
+    }
+
+    for (int i = 0; i < nJavaFrames; i++) {
+      combinedStackTrace[i + nNativeFrames] = javaStackTrace[i];
+    }
+
+    setStackTrace(combinedStackTrace);
+  }
+
+  public MathsExceptionNative(final String s) {
+    super(s);
+  }
+
+  public MathsExceptionNative(String s, Throwable cause) {
+    super(s, cause);
+  }
+
+  public MathsExceptionNative(Throwable cause) {
+    super(cause);
+  }
+}

--- a/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionNative.java
+++ b/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionNative.java
@@ -1,11 +1,5 @@
 package com.opengamma.longdog.exceptions;
 
-import java.io.PrintStream;
-import java.io.PrintWriter;
-import java.util.Collections;
-import java.util.IdentityHashMap;
-import java.util.Set;
-
 /**
  * Base class for any exceptions that get thrown during the native code execution.
  */

--- a/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionNative.java
+++ b/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionNative.java
@@ -13,10 +13,6 @@ public class MathsExceptionNative extends MathsException {
 
   private static final long serialVersionUID = 1L;
 
-  public MathsExceptionNative() {
-    super();
-  }
-
   /**
    * This form of the constructor is used by the native code for generating the mixed-language backtrace.
    * Frames are represented by 4 strings, containing the class name, method name, file name and line no.
@@ -54,17 +50,5 @@ public class MathsExceptionNative extends MathsException {
     }
 
     setStackTrace(combinedStackTrace);
-  }
-
-  public MathsExceptionNative(final String s) {
-    super(s);
-  }
-
-  public MathsExceptionNative(String s, Throwable cause) {
-    super(s, cause);
-  }
-
-  public MathsExceptionNative(Throwable cause) {
-    super(cause);
   }
 }

--- a/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionNative.java
+++ b/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionNative.java
@@ -13,9 +13,6 @@ public class MathsExceptionNative extends MathsException {
 
   private static final long serialVersionUID = 1L;
 
-  private String _nativeMsg;
-  private StackTraceElement[] _nativeStackTrace;
-
   public MathsExceptionNative() {
     super();
   }

--- a/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionNative.java
+++ b/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionNative.java
@@ -5,7 +5,10 @@ package com.opengamma.longdog.exceptions;
  */
 public class MathsExceptionNative extends MathsException {
 
-  private static final long serialVersionUID = 1L;
+  /**
+   * Serial ID
+   */
+  private static final long serialVersionUID = 2689725471014028060L;
 
   /**
    * This form of the constructor is used by the native code for generating the mixed-language backtrace.

--- a/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionNativeComputation.java
+++ b/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionNativeComputation.java
@@ -14,6 +14,15 @@ public class MathsExceptionNativeComputation extends MathsExceptionNative {
    */
   private static final long serialVersionUID = 4241344454052521906L;
 
+  /**
+   * This form of the constructor is used by the native code for generating the mixed-language backtrace.
+   * Frames are represented by 4 strings, containing the class name, method name, file name and line no.
+   * The Java side steps through this array to construct suitable StackTraceElement objects to push on
+   * top of the Java stack trace.
+   *
+   * @param msg The error message as presented to the user
+   * @param backtraceInfo strings describing each frame
+   */
   public MathsExceptionNativeComputation(String msg, String[] backtraceInfo) {
     super(msg, backtraceInfo);
   }

--- a/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionNativeComputation.java
+++ b/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionNativeComputation.java
@@ -9,6 +9,11 @@ package com.opengamma.longdog.exceptions;
  * Provides a manner in which maths exceptions relating to execution in native code can be thrown.
  */
 public class MathsExceptionNativeComputation extends MathsExceptionNative {
+  /**
+   * Serial ID
+   */
+  private static final long serialVersionUID = 4241344454052521906L;
+
   public MathsExceptionNativeComputation(String msg, String[] backtraceInfo) {
     super(msg, backtraceInfo);
   }

--- a/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionNativeComputation.java
+++ b/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionNativeComputation.java
@@ -12,20 +12,4 @@ public class MathsExceptionNativeComputation extends MathsExceptionNative {
   public MathsExceptionNativeComputation(String msg, String[] backtraceInfo) {
     super(msg, backtraceInfo);
   }
-
-  public MathsExceptionNativeComputation() {
-    super();
-  }
-
-  public MathsExceptionNativeComputation(final String s) {
-    super(s);
-  }
-
-  public MathsExceptionNativeComputation(final String s, final Throwable cause) {
-    super(s, cause);
-  }
-
-  public MathsExceptionNativeComputation(final Throwable cause) {
-    super(cause);
-  }
 }

--- a/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionNativeComputation.java
+++ b/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionNativeComputation.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) 2013 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.longdog.exceptions;
+
+/**
+ * Provides a manner in which maths exceptions relating to execution in native code can be thrown.
+ */
+public class MathsExceptionNativeComputation extends MathsExceptionNative {
+  public MathsExceptionNativeComputation(String msg, String[] backtraceInfo) {
+    super(msg, backtraceInfo);
+  }
+
+  public MathsExceptionNativeComputation() {
+    super();
+  }
+
+  public MathsExceptionNativeComputation(final String s) {
+    super(s);
+  }
+
+  public MathsExceptionNativeComputation(final String s, final Throwable cause) {
+    super(s, cause);
+  }
+
+  public MathsExceptionNativeComputation(final Throwable cause) {
+    super(cause);
+  }
+}

--- a/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionNativeConversion.java
+++ b/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionNativeConversion.java
@@ -9,6 +9,11 @@ package com.opengamma.longdog.exceptions;
  * Provides a manner in which maths exceptions relating to native code errors during the conversion from Java ASTs to C++ ASTs
  */
 public class MathsExceptionNativeConversion extends MathsExceptionNative {
+  /**
+   * Serial ID
+   */
+  private static final long serialVersionUID = -303234672217705296L;
+
   public MathsExceptionNativeConversion(String msg, String[] backtraceInfo) {
     super(msg, backtraceInfo);
   }

--- a/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionNativeConversion.java
+++ b/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionNativeConversion.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) 2013 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.longdog.exceptions;
+
+/**
+ * Provides a manner in which maths exceptions relating to native code errors during the conversion from Java ASTs to C++ ASTs
+ */
+public class MathsExceptionNativeConversion extends MathsExceptionNative {
+  public MathsExceptionNativeConversion(String msg, String[] backtraceInfo) {
+    super(msg, backtraceInfo);
+  }
+
+  public MathsExceptionNativeConversion() {
+    super();
+  }
+
+  public MathsExceptionNativeConversion(final String s) {
+    super(s);
+  }
+
+  public MathsExceptionNativeConversion(final String s, final Throwable cause) {
+    super(s, cause);
+  }
+
+  public MathsExceptionNativeConversion(final Throwable cause) {
+    super(cause);
+  }
+}

--- a/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionNativeConversion.java
+++ b/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionNativeConversion.java
@@ -12,20 +12,4 @@ public class MathsExceptionNativeConversion extends MathsExceptionNative {
   public MathsExceptionNativeConversion(String msg, String[] backtraceInfo) {
     super(msg, backtraceInfo);
   }
-
-  public MathsExceptionNativeConversion() {
-    super();
-  }
-
-  public MathsExceptionNativeConversion(final String s) {
-    super(s);
-  }
-
-  public MathsExceptionNativeConversion(final String s, final Throwable cause) {
-    super(s, cause);
-  }
-
-  public MathsExceptionNativeConversion(final Throwable cause) {
-    super(cause);
-  }
 }

--- a/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionNativeConversion.java
+++ b/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionNativeConversion.java
@@ -14,6 +14,15 @@ public class MathsExceptionNativeConversion extends MathsExceptionNative {
    */
   private static final long serialVersionUID = -303234672217705296L;
 
+  /**
+   * This form of the constructor is used by the native code for generating the mixed-language backtrace.
+   * Frames are represented by 4 strings, containing the class name, method name, file name and line no.
+   * The Java side steps through this array to construct suitable StackTraceElement objects to push on
+   * top of the Java stack trace.
+   *
+   * @param msg The error message as presented to the user
+   * @param backtraceInfo strings describing each frame
+   */
   public MathsExceptionNativeConversion(String msg, String[] backtraceInfo) {
     super(msg, backtraceInfo);
   }

--- a/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionNonConformance.java
+++ b/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionNonConformance.java
@@ -9,7 +9,11 @@ package com.opengamma.longdog.exceptions;
  * Provides a manner in which maths exceptions relating to data non conformance can be thrown
  */
 public class MathsExceptionNonConformance extends MathsException {
-  private static final long serialVersionUID = 1L;
+
+  /**
+   * Serial ID
+   */
+  private static final long serialVersionUID = 1918921932804868986L;
 
   public MathsExceptionNonConformance() {
     super();

--- a/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionNotImplemented.java
+++ b/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionNotImplemented.java
@@ -9,7 +9,11 @@ package com.opengamma.longdog.exceptions;
  * Provides a manner in which maths exceptions relating to not implemented features can be thrown
  */
 public class MathsExceptionNotImplemented extends MathsException {
-  private static final long serialVersionUID = 1L;
+
+  /**
+   * Serial ID
+   */
+  private static final long serialVersionUID = -4513146658517029099L;
 
   public MathsExceptionNotImplemented() {
     super();

--- a/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionNullPointer.java
+++ b/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionNullPointer.java
@@ -9,7 +9,11 @@ package com.opengamma.longdog.exceptions;
  * Provides a manner in which maths exceptions relating to null pointer access can be thrown
  */
 public class MathsExceptionNullPointer extends MathsException {
-  private static final long serialVersionUID = 1L;
+
+  /**
+   * Serial ID
+   */
+  private static final long serialVersionUID = 192180225138562639L;
 
   public MathsExceptionNullPointer() {
     super();

--- a/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionOnInitialization.java
+++ b/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionOnInitialization.java
@@ -11,9 +11,9 @@ package com.opengamma.longdog.exceptions;
 public class MathsExceptionOnInitialization extends RuntimeException {
 
   /**
-   * SID
+   * Serial ID
    */
-  private static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = -8519882973848004168L;
 
   public MathsExceptionOnInitialization() {
     super();

--- a/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionUnsupportedPlatform.java
+++ b/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionUnsupportedPlatform.java
@@ -12,9 +12,9 @@ package com.opengamma.longdog.exceptions;
 public class MathsExceptionUnsupportedPlatform extends RuntimeException {
 
   /**
-   * SID
+   * Serial ID
    */
-  private static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = -1105413990531662184L;
 
   public MathsExceptionUnsupportedPlatform() {
     super();

--- a/src/jshim/jshim.cc
+++ b/src/jshim/jshim.cc
@@ -4,6 +4,7 @@
  * Please see distribution for license.
  */
 
+#include <sstream>
 #include "com_opengamma_longdog_materialisers_Materialisers.h"
 #include "entrypt.hh"
 #include "jvmmanager.hh"
@@ -16,6 +17,63 @@
 #include <stdio.h>
 
 using namespace convert;
+using namespace dogma_exceptions;
+
+jobjectArray javaBacktrace(JNIEnv* env, const BacktraceElement* backtrace, size_t traceSize)
+{
+  // Create new array of strings for backtrace
+  jclass strClass = env->FindClass("java/lang/String");
+  jstring empty = env->NewStringUTF("");
+  size_t nStr = traceSize * 4; // File name, class, method, line number
+  jobjectArray btArray = env->NewObjectArray(nStr, strClass, empty);
+  checkEx(env);
+
+  for (size_t i = 0; i < traceSize; i++)
+  {
+    const BacktraceElement* frame = &backtrace[i];
+    jstring className = env->NewStringUTF(frame->getObjectFile().c_str());
+    jstring methodName = env->NewStringUTF(frame->getFunction().c_str());
+    stringstream ss;
+    ss << (long long unsigned) frame->getAddress();
+    jstring fileName = env->NewStringUTF(ss.str().c_str());
+    jstring lineNo = env->NewStringUTF("1");
+    env->SetObjectArrayElement(btArray, ((i * 4) + 0), className);
+    env->SetObjectArrayElement(btArray, ((i * 4) + 1), methodName);
+    env->SetObjectArrayElement(btArray, ((i * 4) + 2), fileName);
+    env->SetObjectArrayElement(btArray, ((i * 4) + 3), lineNo);
+    checkEx(env);
+  }
+
+  return btArray;
+}
+
+void convertExceptionJava(JNIEnv* env, convert_error& e)
+{
+#ifdef __MINGW32__
+  env->ThrowNew(JVMManager::getMathsExceptionNativeConversionClazz(), e.what());
+#else
+  jstring msg = env->NewStringUTF(e.what());
+  jmethodID ctor = env->GetMethodID(JVMManager::getMathsExceptionNativeConversionClazz(), "<init>", "(Ljava/lang/String;[Ljava/lang/String;)V");
+  checkEx(env);
+  jobjectArray btArray = javaBacktrace(env, e.getBacktrace(), e.getTraceSize());
+  jthrowable jex = (jthrowable) env->NewObject(JVMManager::getMathsExceptionNativeConversionClazz(), ctor, msg, btArray);
+  env->Throw(jex);
+#endif // __MINGW32__
+}
+
+void rdagExceptionJava(JNIEnv* env, rdag_error& e)
+{
+#ifdef __MINGW32__
+  env->ThrowNew(JVMManager::getMathsExceptionNativeConversionClazz(), e.what());
+#else
+  jstring msg = env->NewStringUTF(e.what());
+  jmethodID ctor = env->GetMethodID(JVMManager::getMathsExceptionNativeComputationClazz(), "<init>", "(Ljava/lang/String;[Ljava/lang/String;)V");
+  checkEx(env);
+  jobjectArray btArray = javaBacktrace(env, e.getBacktrace(), e.getTraceSize());
+  jthrowable jex = (jthrowable) env->NewObject(JVMManager::getMathsExceptionNativeComputationClazz(), ctor, msg, btArray);
+  env->Throw(jex);
+#endif // __MINGW32__
+}
 
 #ifdef __cplusplus
 extern "C" {
@@ -31,23 +89,38 @@ JNIEXPORT jobjectArray JNICALL Java_com_opengamma_longdog_materialisers_Material
 {
   DEBUG_PRINT("Entering materialise function\n");
 
-  DEBUG_PRINT("Calling convert::createExpression\n");
-  // convert obj to OGNumeric objs
-  librdag::OGNumeric * chain = convert::createExpression(obj);
+  librdag::OGNumeric* chain;
+  jobjectArray returnVal;
 
-  DEBUG_PRINT("Check for exception before entrypt\n");
-  checkEx(env);
-  DEBUG_PRINT("Calling entrypt function\n");
-  const librdag::OGTerminal* answer = entrypt(chain);
-  DEBUG_PRINT("Returning from entrypt function\n");
-  
-  DispatchToReal16ArrayOfArrays *visitor = new DispatchToReal16ArrayOfArrays();
-  answer->accept(*visitor);
+  try
+  {
+    // convert obj to OGNumeric objs
+    DEBUG_PRINT("Calling convert::createExpression\n");
+    chain = convert::createExpression(obj);
+    DEBUG_PRINT("Check for exception before entrypt\n");
+    checkEx(env);
+    DEBUG_PRINT("Calling entrypt function\n");
+    const librdag::OGTerminal* answer = entrypt(chain);
+    DEBUG_PRINT("Returning from entrypt function\n");
 
-  jobjectArray returnVal = convertCreal16ArrOfArr2JDoubleArrOfArr(env, visitor->getData(), visitor->getRows(), visitor->getCols());
+    DispatchToReal16ArrayOfArrays *visitor = new DispatchToReal16ArrayOfArrays();
+    answer->accept(*visitor);
+
+    returnVal = convertCreal16ArrOfArr2JDoubleArrOfArr(env, visitor->getData(), visitor->getRows(), visitor->getCols());
+    delete visitor;
+  }
+  catch (convert_error e)
+  {
+    convertExceptionJava(env, e);
+    return nullptr;
+  }
+  catch (rdag_error e)
+  {
+    rdagExceptionJava(env, e);
+    return nullptr;
+  }
 
   delete chain;
-  delete visitor;
 
   DEBUG_PRINT("Returning\n");
   return returnVal;
@@ -64,28 +137,45 @@ JNIEXPORT jobject JNICALL Java_com_opengamma_longdog_materialisers_Materialisers
   DEBUG_PRINT("materialiseToJComplexArrayContainer\n");
   DEBUG_PRINT("Entering materialise function\n");
 
-  DEBUG_PRINT("Calling convert::createExpression\n");
-  // convert obj to OGNumeric objs
-  librdag::OGNumeric * chain = convert::createExpression(obj);
+  librdag::OGNumeric * chain;
+  jobject returnVal;
 
-  DEBUG_PRINT("Check for exception before entrypt\n");
-  checkEx(env);
-  DEBUG_PRINT("Calling entrypt function\n");
-  const librdag::OGTerminal* answer = entrypt(chain);
+  try
+  {
+    DEBUG_PRINT("Calling convert::createExpression\n");
+    // convert obj to OGNumeric objs
+    chain = convert::createExpression(obj);
+
+    DEBUG_PRINT("Check for exception before entrypt\n");
+    checkEx(env);
+    DEBUG_PRINT("Calling entrypt function\n");
+    const librdag::OGTerminal* answer = entrypt(chain);
 
 
-  DispatchToComplex16ArrayOfArrays *visitor = new DispatchToComplex16ArrayOfArrays();
-  answer->accept(*visitor);
+    DispatchToComplex16ArrayOfArrays *visitor = new DispatchToComplex16ArrayOfArrays();
+    answer->accept(*visitor);
 
-  jobjectArray realPart = extractRealPartOfCcomplex16ArrOfArr2JDoubleArrOfArr(env, visitor->getData(), visitor->getRows(), visitor->getCols());
-  jobjectArray complexPart = extractImagPartOfCcomplex16ArrOfArr2JDoubleArrOfArr(env, visitor->getData(), visitor->getRows(), visitor->getCols());
+    jobjectArray realPart = extractRealPartOfCcomplex16ArrOfArr2JDoubleArrOfArr(env, visitor->getData(), visitor->getRows(), visitor->getCols());
+    jobjectArray complexPart = extractImagPartOfCcomplex16ArrOfArr2JDoubleArrOfArr(env, visitor->getData(), visitor->getRows(), visitor->getCols());
 
-  jobject returnVal = env->NewObject(JVMManager::getComplexArrayContainerClazz(),
-                                     JVMManager::getComplexArrayContainerClazz_ctor_DAoA_DAoA(),
-                                     realPart, complexPart);
+    delete visitor;
+
+    returnVal = env->NewObject(JVMManager::getComplexArrayContainerClazz(),
+                               JVMManager::getComplexArrayContainerClazz_ctor_DAoA_DAoA(),
+                               realPart, complexPart);
+  }
+  catch (convert_error e)
+  {
+    convertExceptionJava(env, e);
+    return nullptr;
+  }
+  catch (rdag_error e)
+  {
+    rdagExceptionJava(env, e);
+    return nullptr;
+  }
 
   delete chain;
-  delete visitor;
 
   DEBUG_PRINT("Returning\n");
   return returnVal;
@@ -108,20 +198,36 @@ Java_com_opengamma_longdog_materialisers_Materialisers_materialiseToOGTerminal(J
 {
   DEBUG_PRINT("materialiseToOGTerminal\n");
   DEBUG_PRINT("Calling convert::createExpression\n");
+  librdag::OGNumeric * chain;
+  jobject result;
+
+  try
+  {
   // convert obj to OGNumeric objs
-  librdag::OGNumeric * chain = convert::createExpression(obj);
+    chain = convert::createExpression(obj);
 
-  DEBUG_PRINT("Check for exception before entrypt\n");
-  checkEx(env);
-  DEBUG_PRINT("Calling entrypt function\n");
-  const librdag::OGTerminal* answer = entrypt(chain);
+    DEBUG_PRINT("Check for exception before entrypt\n");
+    checkEx(env);
+    DEBUG_PRINT("Calling entrypt function\n");
+    const librdag::OGTerminal* answer = entrypt(chain);
 
-  DispatchToOGTerminal *visitor = new DispatchToOGTerminal(env);
-  answer->accept(*visitor);
-  jobject result = visitor->getObject();
+    DispatchToOGTerminal *visitor = new DispatchToOGTerminal(env);
+    answer->accept(*visitor);
+    result = visitor->getObject();
+    delete visitor;
+  }
+  catch (convert_error e)
+  {
+    convertExceptionJava(env, e);
+    return nullptr;
+  }
+  catch (rdag_error e)
+  {
+    rdagExceptionJava(env, e);
+    return nullptr;
+  }
 
   delete chain;
-  delete visitor;
 
   DEBUG_PRINT("Returning\n");
   return result;

--- a/src/jshim/jshim.cc
+++ b/src/jshim/jshim.cc
@@ -19,27 +19,89 @@
 using namespace convert;
 using namespace dogma_exceptions;
 
+/* Used to signal if something has gone wrong in our exception reporting code.
+ * If this has happened, we are in real trouble (probably out of memory).
+ */
+typedef enum {
+  EXCEPTION_OK = 0,
+  EXCEPTION_ERROR = 1
+} exc_handle_status;
+
+/**
+ * Check for local capacity and describe the Java exception if the EnsureLocalCapacity
+ * call fails.
+ *
+ * @param env the JNI environment pointer
+ * @param capacity the number of local refs to ensure
+ * @return EXCEPTION_OK if capacity is ensured, EXCEPTION_ERROR otherwise
+ */
+exc_handle_status checkedLocalCapacity(JNIEnv* env, jint capacity)
+{
+  jint capStatus;
+  capStatus = env->EnsureLocalCapacity(capacity); // for new exception/new string
+  if (capStatus < 0)
+  {
+    // If capStatus < 0 then an OutOfMemoryError has been thrown.
+    cerr << "Exception in native code, but cannot create Java exception. Exception in EnsureLocalCapacity." << endl;
+    return EXCEPTION_ERROR;
+  }
+  return EXCEPTION_OK;
+}
+
+/**
+ * Macro for checked calls. If the call fails, we need to exit with nullptr returned
+ * as soon as possible.
+ */
+#define JNI_RETONFAIL(arg) if ((arg) == nullptr) return nullptr
+
+/**
+ * Build an array of strings suitable for passing to the MathsExceptionNative constructor.
+ * Since we're already dealing with an exception here, if anything goes wrong in this
+ * function, we just return null, since throwing another exception isn't going to do us
+ * much good.
+ *
+ * @param env The JNI environment pointer
+ * @param backtrace the native stack
+ * @param traceSize the number of frames in the native stack
+ * @return a Java array of strings representing the backtrace, or nullptr if something went wrong.
+ */
 jobjectArray javaBacktrace(JNIEnv* env, const BacktraceElement* backtrace, size_t traceSize)
 {
+  // 4 strings per stack frame, plus the array of strings, the string class,
+  // and an empty string to populate the array with
+  if (checkedLocalCapacity(env, (traceSize * 4) + 3) == EXCEPTION_ERROR)
+  {
+    return nullptr;
+  }
+
+  jclass strClass;
+  jstring empty;
+  jobjectArray btArray;
+
   // Create new array of strings for backtrace
-  jclass strClass = env->FindClass("java/lang/String");
-  jstring empty = env->NewStringUTF("");
   size_t nStr = traceSize * 4; // File name, class, method, line number
-  jobjectArray btArray = env->NewObjectArray(nStr, strClass, empty);
-  checkEx(env);
+  JNI_RETONFAIL(strClass = env->FindClass("java/lang/String"));
+  JNI_RETONFAIL(empty = env->NewStringUTF(""));
+  JNI_RETONFAIL(btArray = env->NewObjectArray(nStr, strClass, empty));
 
   for (size_t i = 0; i < traceSize; i++)
   {
+    jstring className, methodName, fileName, lineNo;
     const BacktraceElement* frame = &backtrace[i];
-    jstring className = env->NewStringUTF(frame->getObjectFile().c_str());
-    jstring methodName = env->NewStringUTF(frame->getFunction().c_str());
+
     stringstream ss;
     ss << (long long unsigned) frame->getAddress();
-    jstring fileName = env->NewStringUTF(ss.str().c_str());
-    jstring lineNo = env->NewStringUTF("1");
+
+    JNI_RETONFAIL(className = env->NewStringUTF(frame->getObjectFile().c_str()));
+    JNI_RETONFAIL(methodName = env->NewStringUTF(frame->getFunction().c_str()));
+    JNI_RETONFAIL(fileName = env->NewStringUTF(ss.str().c_str()));
+    JNI_RETONFAIL(lineNo = env->NewStringUTF("1"));
     env->SetObjectArrayElement(btArray, ((i * 4) + 0), className);
+    checkEx(env);
     env->SetObjectArrayElement(btArray, ((i * 4) + 1), methodName);
+    checkEx(env);
     env->SetObjectArrayElement(btArray, ((i * 4) + 2), fileName);
+    checkEx(env);
     env->SetObjectArrayElement(btArray, ((i * 4) + 3), lineNo);
     checkEx(env);
   }
@@ -47,32 +109,92 @@ jobjectArray javaBacktrace(JNIEnv* env, const BacktraceElement* backtrace, size_
   return btArray;
 }
 
-void convertExceptionJava(JNIEnv* env, convert_error& e)
+/**
+ * Macro for checked calls in exceptionJava. If the call fails, we need to exit with
+ * EXCEPTION_ERROR returned as soon as possible.
+ */
+#define JNI_ERRONFAIL(arg) if ((arg) == nullptr) return EXCEPTION_ERROR
+
+/**
+ * Throw a new java exception with the backtrace from native code. On Windows, a backtrace
+ * is not provided.
+ *
+ * @param env The JNI environment pointer
+ * @param e the thrown native exception
+ * @param exClass the class of the Java exception to construct
+ * @return EXCEPTION_OK if the exception was successfully thrown in Java. EXCEPTION_ERROR otherwise.
+ */
+exc_handle_status exceptionJava(JNIEnv* env, dogma_error& e, jclass exClass)
 {
+  // Make sure we have capacity for a new exception (Windows) or new string, method ID,
+  // and new exception (others)
+  if (checkedLocalCapacity(env, 3) == EXCEPTION_ERROR)
+  {
+    return EXCEPTION_ERROR;
+  }
+
+  jint throwStatus;
 #ifdef __MINGW32__
-  env->ThrowNew(JVMManager::getMathsExceptionNativeConversionClazz(), e.what());
+  throwStatus = env->ThrowNew(exClass, e.what());
 #else
-  jstring msg = env->NewStringUTF(e.what());
-  jmethodID ctor = env->GetMethodID(JVMManager::getMathsExceptionNativeConversionClazz(), "<init>", "(Ljava/lang/String;[Ljava/lang/String;)V");
-  checkEx(env);
-  jobjectArray btArray = javaBacktrace(env, e.getBacktrace(), e.getTraceSize());
-  jthrowable jex = (jthrowable) env->NewObject(JVMManager::getMathsExceptionNativeConversionClazz(), ctor, msg, btArray);
-  env->Throw(jex);
+  jstring msg;
+  jmethodID ctor;
+  jobjectArray btArray;
+  jthrowable jex;
+
+  JNI_ERRONFAIL(msg = env->NewStringUTF(e.what()));
+  JNI_ERRONFAIL(ctor = env->GetMethodID(JVMManager::getMathsExceptionNativeConversionClazz(), "<init>", "(Ljava/lang/String;[Ljava/lang/String;)V"));
+  JNI_ERRONFAIL(btArray = javaBacktrace(env, e.getBacktrace(), e.getTraceSize()));
+  JNI_ERRONFAIL(jex = (jthrowable) env->NewObject(exClass, ctor, msg, btArray));
+  throwStatus = env->Throw(jex);
 #endif // __MINGW32__
+
+  if (throwStatus)
+  {
+    return EXCEPTION_ERROR;
+  }
+  else
+  {
+    return EXCEPTION_OK;
+  }
 }
 
+/**
+ * Throw a new Java MathsExceptionNativeConversion from a native convert_error. If the
+ * Java throw fails, stderr receives a warning and the what() of the exception because
+ * there is little else that can be done.
+ *
+ * @param env the JNI environment pointer
+ * @param e the native exception.
+ */
+void convertExceptionJava(JNIEnv* env, convert_error& e)
+{
+  exc_handle_status stat;
+  stat = exceptionJava(env, e, JVMManager::getMathsExceptionNativeConversionClazz());
+  if (stat == EXCEPTION_ERROR)
+  {
+    cerr << "Error creating Java exception from convert_error." << endl;
+    cerr << e.what();
+  }
+}
+
+/**
+ * Throw a new Java MathsExceptionNativeComputation from a native rdag_error. If the
+ * Java throw fails, stderr receives a warning and the what() of the exception because
+ * there is little else that can be done.
+ *
+ * @param env the JNI environment pointer
+ * @param e the native exception.
+ */
 void rdagExceptionJava(JNIEnv* env, rdag_error& e)
 {
-#ifdef __MINGW32__
-  env->ThrowNew(JVMManager::getMathsExceptionNativeConversionClazz(), e.what());
-#else
-  jstring msg = env->NewStringUTF(e.what());
-  jmethodID ctor = env->GetMethodID(JVMManager::getMathsExceptionNativeComputationClazz(), "<init>", "(Ljava/lang/String;[Ljava/lang/String;)V");
-  checkEx(env);
-  jobjectArray btArray = javaBacktrace(env, e.getBacktrace(), e.getTraceSize());
-  jthrowable jex = (jthrowable) env->NewObject(JVMManager::getMathsExceptionNativeComputationClazz(), ctor, msg, btArray);
-  env->Throw(jex);
-#endif // __MINGW32__
+  exc_handle_status stat;
+  stat = exceptionJava(env, e, JVMManager::getMathsExceptionNativeComputationClazz());
+  if (stat == EXCEPTION_ERROR)
+  {
+    cerr << "Error creating Java exception from rdag_error." << endl;
+    cerr << e.what();
+  }
 }
 
 #ifdef __cplusplus

--- a/src/jshim/jshim.cc
+++ b/src/jshim/jshim.cc
@@ -97,13 +97,13 @@ jobjectArray javaBacktrace(JNIEnv* env, const BacktraceElement* backtrace, size_
     JNI_RETONFAIL(fileName = env->NewStringUTF(ss.str().c_str()));
     JNI_RETONFAIL(lineNo = env->NewStringUTF("1"));
     env->SetObjectArrayElement(btArray, ((i * 4) + 0), className);
-    checkEx(env);
+    if(env->ExceptionCheck() == JNI_TRUE) return nullptr;
     env->SetObjectArrayElement(btArray, ((i * 4) + 1), methodName);
-    checkEx(env);
+    if(env->ExceptionCheck() == JNI_TRUE) return nullptr;
     env->SetObjectArrayElement(btArray, ((i * 4) + 2), fileName);
-    checkEx(env);
+    if(env->ExceptionCheck() == JNI_TRUE) return nullptr;
     env->SetObjectArrayElement(btArray, ((i * 4) + 3), lineNo);
-    checkEx(env);
+    if(env->ExceptionCheck() == JNI_TRUE) return nullptr;
   }
 
   return btArray;

--- a/src/jshim/jvmmanager.cc
+++ b/src/jshim/jvmmanager.cc
@@ -101,6 +101,8 @@ JVMManager::registerReferences()
   registerGlobalClassReference("com/opengamma/longdog/datacontainers/matrix/OGComplexDiagonalMatrix", &_OGComplexDiagonalMatrixClazz);
   registerGlobalClassReference("com/opengamma/longdog/datacontainers/matrix/OGRealSparseMatrix", &_OGRealSparseMatrixClazz);
   registerGlobalClassReference("com/opengamma/longdog/datacontainers/matrix/OGComplexSparseMatrix", &_OGComplexSparseMatrixClazz);
+  registerGlobalClassReference("com/opengamma/longdog/exceptions/MathsExceptionNativeConversion", &_MathsExceptionNativeConversionClazz);
+  registerGlobalClassReference("com/opengamma/longdog/exceptions/MathsExceptionNativeComputation", &_MathsExceptionNativeComputationClazz);
 
   //
   // REGISTER METHOD REFERENCES
@@ -234,6 +236,10 @@ jclass JVMManager::getOGComplexSparseMatrixClazz()
 { return _OGComplexSparseMatrixClazz; }
 jclass JVMManager::getOGExprTypeEnumClazz()
 { return _OGExprTypeEnumClazz; }
+jclass JVMManager::getMathsExceptionNativeConversionClazz()
+{ return _MathsExceptionNativeConversionClazz; }
+jclass JVMManager::getMathsExceptionNativeComputationClazz()
+{ return _MathsExceptionNativeComputationClazz; }
 jmethodID JVMManager::getOGRealScalarClazz_init()
 { return _OGRealScalarClazz_init; }
 jmethodID JVMManager::getOGComplexScalarClazz_init()
@@ -294,6 +300,8 @@ jclass JVMManager::_OGRealDiagonalMatrixClazz = nullptr;
 jclass JVMManager::_OGComplexDiagonalMatrixClazz = nullptr;
 jclass JVMManager::_OGRealSparseMatrixClazz = nullptr;
 jclass JVMManager::_OGComplexSparseMatrixClazz = nullptr;
+jclass JVMManager::_MathsExceptionNativeConversionClazz = nullptr;
+jclass JVMManager::_MathsExceptionNativeComputationClazz = nullptr;
 jmethodID JVMManager::_DoubleClazz_init = nullptr;
 jmethodID JVMManager::_OGRealScalarClazz_init = nullptr;
 jmethodID JVMManager::_OGComplexScalarClazz_init = nullptr;
@@ -387,6 +395,13 @@ JVMManager::newDouble(JNIEnv* env, jdouble v)
     throw convert_error("newDouble call failed.");
   }
   return ret;
+}
+
+
+jint
+JVMManager::throwNew(JNIEnv* env, jclass exClass, const char* msg)
+{
+  return env->ThrowNew(exClass, msg);
 }
 
 } // namespace convert

--- a/src/jshim/test/CMakeLists.txt
+++ b/src/jshim/test/CMakeLists.txt
@@ -20,6 +20,7 @@ foreach(TEST ${TESTS})
                         SOURCES ${TEST}.cc
                         LINK_LIBRARIES jshimtest
                         TARGETS ${TARGET_TYPES}
-                        COMPILE_DEFINITIONS _FAKE_JNI_H=1)
+                        COMPILE_DEFINITIONS _FAKE_JNI_H=1
+                        SUPPRESSIONS ${longdog_SOURCE_DIR}/src/librdag/test/valgrind.supp)
 endforeach()
 

--- a/src/librdag/CMakeLists.txt
+++ b/src/librdag/CMakeLists.txt
@@ -18,6 +18,7 @@ set(RDAG_SOURCES containers.cc
                  customrunners.cc
                  entrypt.cc
                  equals.cc
+                 exceptions.cc
                  execution.cc
                  expressionbase.cc
                  iss.cc

--- a/src/librdag/exceptions.cc
+++ b/src/librdag/exceptions.cc
@@ -1,0 +1,235 @@
+/**
+ * Copyright (C) 2013 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+#include <sstream>
+#include <iostream>
+#include <string.h>
+#include <regex>
+
+#ifndef __MINGW32__
+#include <execinfo.h>
+#include <cxxabi.h>
+#endif // __MINGW32__
+
+#include "exceptions.hh"
+#include "debug.h"
+
+using namespace std;
+
+namespace dogma_exceptions {
+
+#ifdef __APPLE__
+vector<string> tokenize_backtrace(const string &backtrace_string)
+{
+  istringstream s(backtrace_string);
+  vector<string> trace{istream_iterator<string>{s}, istream_iterator<string>{}};
+  if (trace.size() != 6)
+  {
+    // Parse fail. Return empty vector.
+    return vector<string>();
+  }
+  else
+  {
+    // Parse is OK.
+    return trace;
+  }
+}
+#endif // __APPLE__
+
+string get_file(const string& backtrace_string)
+{
+#ifdef __APPLE__
+  vector<string> tokens = tokenize_backtrace(backtrace_string);
+  if (tokens.size() != 0)
+  {
+    return tokens[1];
+  }
+  else
+  {
+    return string("");
+  }
+#else
+  size_t bracket = backtrace_string.find("(");
+  if (bracket == string::npos)
+  {
+    return "";
+  }
+  return backtrace_string.substr(0, bracket);
+#endif // __APPLE__
+}
+
+string get_fname(const string& backtrace_string)
+{
+  string fname;
+
+#ifdef __APPLE__
+  vector<string> tokens = tokenize_backtrace(backtrace_string);
+  if (tokens.size() != 0)
+  {
+    fname = tokens[3];
+  }
+  else
+  {
+    fname = "";
+  }
+#else
+  size_t begin = backtrace_string.find("(");
+  if (begin == string::npos)
+  {
+    return "";
+  }
+
+  // Step over the bracket
+  begin += 1;
+  size_t end = backtrace_string.find(")");
+  if (end == string::npos)
+  {
+    return "";
+  }
+
+  fname = backtrace_string.substr(begin, end-begin);
+
+  // Get rid of the offset if there is one
+  size_t offset = fname.find("+");
+  if (offset != string::npos)
+  {
+    fname = fname.substr(0, offset);
+  }
+#endif // __APPLE__
+
+  return fname;
+}
+
+const string demangle_fname(const string& fname, int* status)
+{
+  string ret = fname;
+#ifndef __MINGW32__
+  char* demangled = abi::__cxa_demangle(fname.c_str(), nullptr, 0, status);
+  switch (*status)
+  {
+  case 0:
+    ret = string(demangled); // Success
+    free(demangled);
+    break;
+  case 1:
+    DEBUG_PRINT("DEMANGLE_MALLOC_FAILED");
+    break;
+  case 2:
+    DEBUG_PRINT("DEMANGLE_INVALID_MANGLED_NAME");
+    break;
+  case 3:
+    DEBUG_PRINT("DEMANGLE_INVALID_ARGUMENT");
+    break;
+  default:
+    DEBUG_PRINT("DEMANGLE_UNKNOWN_ERROR");
+    break;
+  }
+#else
+  *status = 0;
+#endif // __MINGW32__
+  return ret;
+}
+
+/**
+ * BacktraceElement
+ */
+
+BacktraceElement::BacktraceElement()
+{
+  _address = nullptr;
+  _function = string("<function>");
+  _object_file = string("<object file>");
+}
+
+BacktraceElement::BacktraceElement(const BacktraceElement& other)
+{
+  _address = other.getAddress();
+  _function = other.getFunction();
+  _object_file = other.getObjectFile();
+}
+
+BacktraceElement::BacktraceElement(const string& backtrace_symbol, const void* address)
+{
+  _address = address;
+  _object_file = get_file(backtrace_symbol);
+  int status = 0;
+  _function = demangle_fname(get_fname(backtrace_symbol), &status);
+  _object_file = get_file(backtrace_symbol);
+}
+
+const void*
+BacktraceElement::getAddress() const
+{
+  return _address;
+}
+
+const string
+BacktraceElement::getObjectFile() const
+{
+  return _object_file;
+}
+
+const string
+BacktraceElement::getFunction() const
+{
+  return _function;
+}
+
+/**
+ * dogma_error
+ */
+
+dogma_error::dogma_error(const string& what): runtime_error(what)
+{
+#ifndef __MINGW32__
+  void *frameBuf[FRAMEBUF_SIZE];
+  char **strings;
+  _traceSize = backtrace(frameBuf, FRAMEBUF_SIZE);
+  strings = backtrace_symbols(frameBuf, _traceSize);
+
+  _backtrace = new BacktraceElement[_traceSize];
+
+  for (size_t i = 0; i < _traceSize; i++)
+  {
+    _backtrace[i] = BacktraceElement(strings[i], frameBuf[i]);
+  }
+
+  free(strings);
+#endif // __MINGW32__
+}
+
+dogma_error::dogma_error(const dogma_error& other): runtime_error::runtime_error(other)
+{
+#ifndef __MINGW32__
+  _traceSize = other.getTraceSize();
+  _backtrace = new BacktraceElement[_traceSize];
+  for (size_t i = 0; i < _traceSize; i++)
+  {
+    _backtrace[i] = BacktraceElement(other._backtrace[i]);
+  }
+#endif // __MINGW32__
+}
+
+dogma_error::~dogma_error()
+{
+#ifndef __MINGW32__
+  delete[] _backtrace;
+#endif // __MINGW32__
+}
+
+const BacktraceElement*
+dogma_error::getBacktrace() const
+{
+  return _backtrace;
+}
+
+size_t
+dogma_error::getTraceSize() const
+{
+  return _traceSize;
+}
+
+} // end namespace dogma_exceptions

--- a/src/librdag/exceptions.cc
+++ b/src/librdag/exceptions.cc
@@ -154,10 +154,9 @@ BacktraceElement::BacktraceElement(const BacktraceElement& other)
 BacktraceElement::BacktraceElement(const string& backtrace_symbol, const void* address)
 {
   _address = address;
-  _object_file = get_file(backtrace_symbol);
+  _object_file = asciiOnly(get_file(backtrace_symbol));
   int status = 0;
-  _function = demangle_fname(get_fname(backtrace_symbol), &status);
-  _object_file = get_file(backtrace_symbol);
+  _function = asciiOnly(demangle_fname(get_fname(backtrace_symbol), &status));
 }
 
 const void*
@@ -176,6 +175,20 @@ const string
 BacktraceElement::getFunction() const
 {
   return _function;
+}
+
+string
+BacktraceElement::asciiOnly(string s)
+{
+  char* c = (char*) malloc(sizeof(char) * s.size()+1);
+  for (size_t i = 0; i < s.size(); i++)
+  {
+    c[i] = s[i] & 0x7F;
+  }
+  c[s.size()] = 0;
+  string s1 = string(c);
+  free(c);
+  return s1;
 }
 
 /**

--- a/src/librdag/test/CMakeLists.txt
+++ b/src/librdag/test/CMakeLists.txt
@@ -11,6 +11,10 @@ link_directories(${longdog_BINARY_DIR}/src/librdag)
 
 set(TESTS check_expressions check_containers check_execution check_rtti check_terminals check_entrypt check_dispatch check_equals check_numerictypes check_convertto check_iss)
 
+if(NOT WIN32)
+  set(TESTS ${TESTS} check_exceptions)
+endif()
+
 # Compile and link each test and add to the list of tests
 foreach(TEST ${TESTS})
   add_multitarget_gtest(${TEST}

--- a/src/librdag/test/CMakeLists.txt
+++ b/src/librdag/test/CMakeLists.txt
@@ -16,7 +16,8 @@ foreach(TEST ${TESTS})
   add_multitarget_gtest(${TEST}
                         SOURCES ${TEST}.cc
                         LINK_LIBRARIES rdag
-                        TARGETS ${TARGET_TYPES})
+                        TARGETS ${TARGET_TYPES}
+                        SUPPRESSIONS ${CMAKE_CURRENT_SOURCE_DIR}/valgrind.supp)
 endforeach()
 
 add_subdirectory(nodes)

--- a/src/librdag/test/check_exceptions.cc
+++ b/src/librdag/test/check_exceptions.cc
@@ -86,10 +86,8 @@ class DogmaErrorTest: public ::testing::Test
 
 TEST_F(DogmaErrorTest, Constructor)
 {
-  // The number of stack frames may vary with GTest versions - hence this may need
-  // updating from time to time.
-  //constexpr int NUM_FRAMES = 14;
-  //EXPECT_EQ(_error->getTraceSize(), NUM_FRAMES);
+  // The number of stack frames varies often depending on platform/versions,
+  // so we just check the what() method here.
   EXPECT_STREQ(_error->what(), "An error");
 }
 

--- a/src/librdag/test/check_exceptions.cc
+++ b/src/librdag/test/check_exceptions.cc
@@ -114,6 +114,7 @@ TEST_F(DogmaErrorTest, Copy)
   ASSERT_EQ(_error->getTraceSize(), e2.getTraceSize());
   const BacktraceElement* trace1 = _error->getBacktrace();
   const BacktraceElement* trace2 = e2.getBacktrace();
+  EXPECT_NE(trace1, trace2);
 
   for (size_t i = 0; i < e2.getTraceSize(); i++)
   {
@@ -134,6 +135,7 @@ TEST_F(DogmaErrorTest, Assign)
   ASSERT_EQ(_error->getTraceSize(), e2.getTraceSize());
   const BacktraceElement* trace1 = _error->getBacktrace();
   const BacktraceElement* trace2 = e2.getBacktrace();
+  EXPECT_NE(trace1, trace2);
 
   for (size_t i = 0; i < e2.getTraceSize(); i++)
   {

--- a/src/librdag/test/check_exceptions.cc
+++ b/src/librdag/test/check_exceptions.cc
@@ -1,0 +1,146 @@
+/**
+ * Copyright (C) 2013 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+/**
+ * We check both copy and assign in these tests since they may be called implicitly
+ * when exceptions are propagated. The assignment operator is not defined for these
+ * classes, but should use the copy constructor - if it does, then these tests
+ * should pass. If it does not, some tests will fail.
+ */
+
+#include "gtest/gtest.h"
+#include "exceptions.hh"
+
+using namespace dogma_exceptions;
+
+#ifdef __APPLE__
+const string backtrace_symbol = "2   librdag_dbg.0.dylib                 0x0000000102edcc48 _ZNK7librdag10OGTerminal21toReal16ArrayOfArraysEv + 150";
+const void* address = (void*) 0x0000000102edcc48;
+#else
+const string backtrace_symbol = "/tmp/og-maths-720755781067700325/libjshim_sse41.so.0(_ZN7convert16createExpressionEP8_jobject+0x37) [0x7f35c0b765b7]";
+const void* address = (void*) 0x7f35c0b765b7;
+#endif // __APPLE__
+
+class BacktraceElementTest: public ::testing::Test
+{
+  protected:
+    virtual void SetUp()
+    {
+      _element = new BacktraceElement(backtrace_symbol, address);
+    }
+
+    virtual void TearDown()
+    {
+      delete _element;
+    }
+
+    BacktraceElement* _element;
+};
+
+TEST_F(BacktraceElementTest, Constructor)
+{
+  EXPECT_EQ(_element->getAddress(), address);
+#ifdef __APPLE__
+  EXPECT_EQ("librdag_dbg.0.dylib", _element->getObjectFile());
+  EXPECT_EQ("librdag::OGTerminal::toReal16ArrayOfArrays() const", _element->getFunction());
+#else
+  EXPECT_EQ("/tmp/og-maths-720755781067700325/libjshim_sse41.so.0", _element->getObjectFile());
+  EXPECT_EQ("convert::createExpression(_jobject*)", _element->getFunction());
+#endif // __APPLE__
+}
+
+TEST_F(BacktraceElementTest, Copy)
+{
+  BacktraceElement e2(*_element);
+  EXPECT_EQ(e2.getAddress(), _element->getAddress());
+  EXPECT_EQ(e2.getObjectFile(), _element->getObjectFile());
+  EXPECT_EQ(e2.getFunction(), _element->getFunction());
+}
+
+TEST_F(BacktraceElementTest, Assign)
+{
+  BacktraceElement e2 = *_element;
+  EXPECT_EQ(e2.getAddress(), _element->getAddress());
+  EXPECT_EQ(e2.getObjectFile(), _element->getObjectFile());
+  EXPECT_EQ(e2.getFunction(), _element->getFunction());
+}
+
+class DogmaErrorTest: public ::testing::Test
+{
+  protected:
+    virtual void SetUp()
+    {
+      _error = new dogma_error("An error");
+    }
+
+    virtual void TearDown()
+    {
+      delete _error;
+    }
+
+    dogma_error* _error;
+};
+
+TEST_F(DogmaErrorTest, Constructor)
+{
+  // The number of stack frames may vary with GTest versions - hence this may need
+  // updating from time to time.
+  //constexpr int NUM_FRAMES = 14;
+  //EXPECT_EQ(_error->getTraceSize(), NUM_FRAMES);
+  EXPECT_STREQ(_error->what(), "An error");
+}
+
+TEST_F(DogmaErrorTest, Frames)
+{
+  // We just look at the function names of the first two frames. Other things (addresses, filename) we
+  // can't rely on the value of, and further frames are inside GTest.
+  // On apple only the first frame is non-gtest, so ignore it in that case.
+  const BacktraceElement* trace = _error->getBacktrace();
+  EXPECT_STREQ("dogma_exceptions::dogma_error::dogma_error(std::string const&)", trace[0].getFunction().c_str());
+#ifndef __APPLE__
+  EXPECT_STREQ("DogmaErrorTest::SetUp()",                                        trace[1].getFunction().c_str());
+#endif // __APPLE__
+}
+
+TEST_F(DogmaErrorTest, Copy)
+{
+  dogma_error e2(*_error);
+
+  // Check what is the same
+  EXPECT_STREQ(_error->what(), e2.what());
+
+  // Check for distinct but equal backtraces
+  ASSERT_EQ(_error->getTraceSize(), e2.getTraceSize());
+  const BacktraceElement* trace1 = _error->getBacktrace();
+  const BacktraceElement* trace2 = e2.getBacktrace();
+
+  for (size_t i = 0; i < e2.getTraceSize(); i++)
+  {
+    EXPECT_EQ(trace1[i].getAddress(),    trace2[i].getAddress());
+    EXPECT_EQ(trace1[i].getObjectFile(), trace2[i].getObjectFile());
+    EXPECT_EQ(trace1[i].getFunction(),   trace2[i].getFunction());
+  }
+}
+
+TEST_F(DogmaErrorTest, Assign)
+{
+  dogma_error e2 = *_error;
+
+  // Check what is the same
+  EXPECT_STREQ(_error->what(), e2.what());
+
+  // Check for distinct but equal backtraces
+  ASSERT_EQ(_error->getTraceSize(), e2.getTraceSize());
+  const BacktraceElement* trace1 = _error->getBacktrace();
+  const BacktraceElement* trace2 = e2.getBacktrace();
+
+  for (size_t i = 0; i < e2.getTraceSize(); i++)
+  {
+    EXPECT_EQ(trace1[i].getAddress(),    trace2[i].getAddress());
+    EXPECT_EQ(trace1[i].getObjectFile(), trace2[i].getObjectFile());
+    EXPECT_EQ(trace1[i].getFunction(),   trace2[i].getFunction());
+  }
+}

--- a/src/librdag/test/nodes/CMakeLists.txt
+++ b/src/librdag/test/nodes/CMakeLists.txt
@@ -30,5 +30,6 @@ foreach(TEST ${TESTS})
   add_multitarget_gtest(${TEST}
                         SOURCES ${TEST}.cc
                         LINK_LIBRARIES testhelper rdag
-                        TARGETS ${TARGET_TYPES})
+                        TARGETS ${TARGET_TYPES}
+                        SUPPRESSIONS ${CMAKE_CURRENT_SOURCE_DIR}/../valgrind.supp)
 endforeach()

--- a/src/librdag/test/valgrind.supp
+++ b/src/librdag/test/valgrind.supp
@@ -1,0 +1,25 @@
+{
+  <dlopen>
+   Memcheck:Leak
+   fun:malloc
+   fun:_dl_map_object_deps
+   fun:dl_open_worker
+   fun:_dl_catch_error
+   fun:_dl_open
+   fun:dlopen_doit
+   fun:_dl_catch_error
+   fun:_dlerror_run
+}
+
+{
+   <dlopen2>
+   Memcheck:Leak
+   fun:malloc
+   fun:_dl_map_object_deps
+   fun:dl_open_worker
+   fun:_dl_catch_error
+   fun:_dl_open
+   fun:do_dlopen
+   fun:_dl_catch_error
+   fun:dlerror_run
+}


### PR DESCRIPTION
On the RDAG side, exceptions with a backtrace are added:

This required exceptions to be split into a separate namespace,
dogma_exceptions, since it contains code common to librdag and
convert.

The exceptions use GNU execinfo to construct a backtrace and
record this in BacktraceElement objects, one for each frame.

The existing rdag_error and convert_error classes are now direct
subclasses of dogma_error.

Some testing is added to check the exception classes where
possible. Since the stack can vary from one environment to the
next, only the topmost frames are examined for their function
names (addresses and filenames can vary from run to run). In the
case of assignment and copy, comparisons are made between the
original and new object to avoid this inconsistency between
machines/runs being a problem.

On the JShim/Java side:

The C++ exceptions are caught by try-catch blocks in the highest
level JNI methods, and convert any caught exception to the
appropriate corresponding Java exception.

The MathsExceptionNative class inserts the backtrace passed to its
constructor by the JNI code into the Java stack trace. This is the
base for exceptions in native code. Conversion or computation
exceptions actuall instantiate MathsExceptionNativeConversion or
MathsExceptionNativeComputation.

This does not address release of resources in the presence of
exceptions - i.e leaks are still possible. Exception safety against
memory leaks remains to be addressed in future.

Other small fixes include:

Addition of valgrind suppressions for apparent leaks in dlopen.
Adding missing checks of the return code from Lapack in the norm runner, and fixes to the names of the called functions in the comments.

Buildbot pass: http://devmaths-lx-1:8011/builders/nyqwk2-testing/builds/646
Coverage: RDAG: 91.5%, jshim 19%, Java 80%.
