### PR TITLE
[MAT-323] add owning copiers

### DIFF
--- a/include/terminal.hh
+++ b/include/terminal.hh
@@ -150,8 +150,8 @@ class OGRealScalar: public OGScalar<real16>
     virtual ExprType_t getType() const override;
     virtual OGOwningRealMatrix * asFullOGRealMatrix() const override;
     virtual OGOwningComplexMatrix * asFullOGComplexMatrix() const override;
-    virtual OGTerminal * createOwningCopy() const;
-    virtual OGTerminal * createComplexOwningCopy() const;
+    virtual OGTerminal * createOwningCopy() const override;
+    virtual OGTerminal * createComplexOwningCopy() const override;
 };
 
 
@@ -166,8 +166,8 @@ class OGComplexScalar: public OGScalar<complex16>
     virtual ExprType_t getType() const override;
     virtual OGOwningRealMatrix * asFullOGRealMatrix() const override;
     virtual OGOwningComplexMatrix * asFullOGComplexMatrix() const override;
-    virtual OGTerminal * createOwningCopy() const;
-    virtual OGTerminal * createComplexOwningCopy() const;
+    virtual OGTerminal * createOwningCopy() const override;
+    virtual OGTerminal * createComplexOwningCopy() const override;
 };
 
 class OGIntegerScalar: public OGScalar<int>
@@ -180,8 +180,8 @@ class OGIntegerScalar: public OGScalar<int>
     virtual ExprType_t getType() const override;
     virtual OGOwningRealMatrix * asFullOGRealMatrix() const override;
     virtual OGOwningComplexMatrix * asFullOGComplexMatrix() const override;
-    virtual OGTerminal * createOwningCopy() const;
-    virtual OGTerminal * createComplexOwningCopy() const;
+    virtual OGTerminal * createOwningCopy() const override;
+    virtual OGTerminal * createComplexOwningCopy() const override;
 };
 
 
@@ -234,8 +234,8 @@ class OGRealMatrix: public OGMatrix<real16>
     virtual ExprType_t getType() const override;
     virtual OGOwningRealMatrix * asFullOGRealMatrix() const override;
     virtual OGOwningComplexMatrix * asFullOGComplexMatrix() const override;
-    virtual OGTerminal * createOwningCopy() const;
-    virtual OGTerminal * createComplexOwningCopy() const;
+    virtual OGTerminal * createOwningCopy() const override;
+    virtual OGTerminal * createComplexOwningCopy() const override;
 };
 
 class OGOwningRealMatrix: public OGRealMatrix
@@ -257,8 +257,8 @@ class OGComplexMatrix: public OGMatrix<complex16>
     virtual ExprType_t getType() const override;
     virtual OGOwningRealMatrix * asFullOGRealMatrix() const override;
     virtual OGOwningComplexMatrix * asFullOGComplexMatrix() const override;
-    virtual OGTerminal * createOwningCopy() const;
-    virtual OGTerminal * createComplexOwningCopy() const;
+    virtual OGTerminal * createOwningCopy() const override;
+    virtual OGTerminal * createComplexOwningCopy() const override;
 };
 
 class OGOwningComplexMatrix: public OGComplexMatrix
@@ -304,8 +304,8 @@ class OGRealDiagonalMatrix: public OGDiagonalMatrix<real16>
     virtual ExprType_t getType() const override;
     virtual OGOwningRealMatrix * asFullOGRealMatrix() const override;
     virtual OGOwningComplexMatrix * asFullOGComplexMatrix() const override;
-    virtual OGTerminal * createOwningCopy() const;
-    virtual OGTerminal * createComplexOwningCopy() const;
+    virtual OGTerminal * createOwningCopy() const override;
+    virtual OGTerminal * createComplexOwningCopy() const override;
 };
 
 class OGOwningRealDiagonalMatrix: public OGRealDiagonalMatrix
@@ -327,8 +327,8 @@ class OGComplexDiagonalMatrix: public OGDiagonalMatrix<complex16>
     virtual ExprType_t getType() const override;
     virtual OGOwningRealMatrix * asFullOGRealMatrix() const override;
     virtual OGOwningComplexMatrix * asFullOGComplexMatrix() const override;
-    virtual OGTerminal * createOwningCopy() const;
-    virtual OGTerminal * createComplexOwningCopy() const;
+    virtual OGTerminal * createOwningCopy() const override;
+    virtual OGTerminal * createComplexOwningCopy() const override;
 };
 
 class OGOwningComplexDiagonalMatrix: public OGComplexDiagonalMatrix
@@ -375,8 +375,8 @@ class OGRealSparseMatrix: public OGSparseMatrix<real16>
     virtual ExprType_t getType() const override;
     virtual OGOwningRealMatrix * asFullOGRealMatrix() const override;
     virtual OGOwningComplexMatrix * asFullOGComplexMatrix() const override;
-    virtual OGTerminal * createOwningCopy() const;
-    virtual OGTerminal * createComplexOwningCopy() const;
+    virtual OGTerminal * createOwningCopy() const override;
+    virtual OGTerminal * createComplexOwningCopy() const override;
 };
 
 class OGOwningRealSparseMatrix: public OGRealSparseMatrix
@@ -398,8 +398,8 @@ class OGComplexSparseMatrix: public OGSparseMatrix<complex16>
     virtual ExprType_t getType() const override;
     virtual OGOwningRealMatrix * asFullOGRealMatrix() const override;
     virtual OGOwningComplexMatrix * asFullOGComplexMatrix() const override;
-    virtual OGTerminal * createOwningCopy() const;
-    virtual OGTerminal * createComplexOwningCopy() const;
+    virtual OGTerminal * createOwningCopy() const override;
+    virtual OGTerminal * createComplexOwningCopy() const override;
 };
 
 class OGOwningComplexSparseMatrix: public OGComplexSparseMatrix

--- a/include/terminal.hh
+++ b/include/terminal.hh
@@ -84,6 +84,15 @@ class OGTerminal: public OGNumeric
      */
     virtual bool fuzzyequals(const OGTerminal *)const = 0;
     /**
+     * Create a copy of this terminal that owns its own data.
+     */
+    virtual OGTerminal * createOwningCopy() const = 0;
+    /**
+     * Create a complex space terminal version of this terminal that owns its own data.
+     */
+    virtual OGTerminal * createComplexOwningCopy() const = 0;
+
+    /**
      * Checks if two data containers are mathematically equal, regardless of thier underlying data representation.
      */
     virtual bool mathsequals(const OGTerminal *)const;
@@ -104,7 +113,6 @@ class OGTerminal: public OGNumeric
     detail::FuzzyCompareOGTerminalContainer * _fuzzyref = nullptr;
     const ConvertTo * _converter = nullptr;
 };
-
 
 /**
  * Things that extend OGScalar
@@ -142,6 +150,8 @@ class OGRealScalar: public OGScalar<real16>
     virtual ExprType_t getType() const override;
     virtual OGOwningRealMatrix * asFullOGRealMatrix() const override;
     virtual OGOwningComplexMatrix * asFullOGComplexMatrix() const override;
+    virtual OGTerminal * createOwningCopy() const;
+    virtual OGTerminal * createComplexOwningCopy() const;
 };
 
 
@@ -156,6 +166,8 @@ class OGComplexScalar: public OGScalar<complex16>
     virtual ExprType_t getType() const override;
     virtual OGOwningRealMatrix * asFullOGRealMatrix() const override;
     virtual OGOwningComplexMatrix * asFullOGComplexMatrix() const override;
+    virtual OGTerminal * createOwningCopy() const;
+    virtual OGTerminal * createComplexOwningCopy() const;
 };
 
 class OGIntegerScalar: public OGScalar<int>
@@ -168,6 +180,8 @@ class OGIntegerScalar: public OGScalar<int>
     virtual ExprType_t getType() const override;
     virtual OGOwningRealMatrix * asFullOGRealMatrix() const override;
     virtual OGOwningComplexMatrix * asFullOGComplexMatrix() const override;
+    virtual OGTerminal * createOwningCopy() const;
+    virtual OGTerminal * createComplexOwningCopy() const;
 };
 
 
@@ -220,6 +234,8 @@ class OGRealMatrix: public OGMatrix<real16>
     virtual ExprType_t getType() const override;
     virtual OGOwningRealMatrix * asFullOGRealMatrix() const override;
     virtual OGOwningComplexMatrix * asFullOGComplexMatrix() const override;
+    virtual OGTerminal * createOwningCopy() const;
+    virtual OGTerminal * createComplexOwningCopy() const;
 };
 
 class OGOwningRealMatrix: public OGRealMatrix
@@ -241,11 +257,14 @@ class OGComplexMatrix: public OGMatrix<complex16>
     virtual ExprType_t getType() const override;
     virtual OGOwningRealMatrix * asFullOGRealMatrix() const override;
     virtual OGOwningComplexMatrix * asFullOGComplexMatrix() const override;
+    virtual OGTerminal * createOwningCopy() const;
+    virtual OGTerminal * createComplexOwningCopy() const;
 };
 
 class OGOwningComplexMatrix: public OGComplexMatrix
 {
   public:
+    OGOwningComplexMatrix(real16 * data, int rows, int cols);
     OGOwningComplexMatrix(int rows, int cols);
     virtual ~OGOwningComplexMatrix() override;
     using OGComplexMatrix::OGComplexMatrix;
@@ -285,6 +304,8 @@ class OGRealDiagonalMatrix: public OGDiagonalMatrix<real16>
     virtual ExprType_t getType() const override;
     virtual OGOwningRealMatrix * asFullOGRealMatrix() const override;
     virtual OGOwningComplexMatrix * asFullOGComplexMatrix() const override;
+    virtual OGTerminal * createOwningCopy() const;
+    virtual OGTerminal * createComplexOwningCopy() const;
 };
 
 class OGOwningRealDiagonalMatrix: public OGRealDiagonalMatrix
@@ -306,6 +327,8 @@ class OGComplexDiagonalMatrix: public OGDiagonalMatrix<complex16>
     virtual ExprType_t getType() const override;
     virtual OGOwningRealMatrix * asFullOGRealMatrix() const override;
     virtual OGOwningComplexMatrix * asFullOGComplexMatrix() const override;
+    virtual OGTerminal * createOwningCopy() const;
+    virtual OGTerminal * createComplexOwningCopy() const;
 };
 
 class OGOwningComplexDiagonalMatrix: public OGComplexDiagonalMatrix
@@ -352,6 +375,8 @@ class OGRealSparseMatrix: public OGSparseMatrix<real16>
     virtual ExprType_t getType() const override;
     virtual OGOwningRealMatrix * asFullOGRealMatrix() const override;
     virtual OGOwningComplexMatrix * asFullOGComplexMatrix() const override;
+    virtual OGTerminal * createOwningCopy() const;
+    virtual OGTerminal * createComplexOwningCopy() const;
 };
 
 class OGOwningRealSparseMatrix: public OGRealSparseMatrix
@@ -373,6 +398,8 @@ class OGComplexSparseMatrix: public OGSparseMatrix<complex16>
     virtual ExprType_t getType() const override;
     virtual OGOwningRealMatrix * asFullOGRealMatrix() const override;
     virtual OGOwningComplexMatrix * asFullOGComplexMatrix() const override;
+    virtual OGTerminal * createOwningCopy() const;
+    virtual OGTerminal * createComplexOwningCopy() const;
 };
 
 class OGOwningComplexSparseMatrix: public OGComplexSparseMatrix

--- a/src/librdag/terminal.cc
+++ b/src/librdag/terminal.cc
@@ -13,6 +13,7 @@
 #include "iss.hh"
 #include "convertto.hh"
 #include <iostream>
+
 namespace librdag {
 
 /**
@@ -292,6 +293,18 @@ OGRealScalar::asFullOGComplexMatrix() const
   return getConvertTo()->convertToOGComplexMatrix(this);
 }
 
+OGTerminal *
+OGRealScalar::createOwningCopy() const
+{
+  return new OGRealScalar(this->getValue());
+}
+
+OGTerminal *
+OGRealScalar::createComplexOwningCopy() const
+{
+  return new OGComplexScalar(this->getValue());
+}
+
 /**
  * OGComplexScalar
  */
@@ -340,6 +353,19 @@ OGComplexScalar::asFullOGComplexMatrix() const
   return getConvertTo()->convertToOGComplexMatrix(this);
 }
 
+OGTerminal *
+OGComplexScalar::createOwningCopy() const
+{
+  return new OGComplexScalar(this->getValue());
+}
+
+OGTerminal *
+OGComplexScalar::createComplexOwningCopy() const
+{
+  return this->createOwningCopy();
+}
+
+
 /**
  * OGIntegerScalar
  */
@@ -381,6 +407,19 @@ OGIntegerScalar::asFullOGComplexMatrix() const
 {
   return getConvertTo()->convertToOGComplexMatrix(this);
 }
+
+OGTerminal *
+OGIntegerScalar::createOwningCopy() const
+{
+  return new OGIntegerScalar(this->getValue());
+}
+
+OGTerminal *
+OGIntegerScalar::createComplexOwningCopy() const
+{
+  return new OGComplexScalar(this->getValue());
+}
+
 
 /**
  * OGArray
@@ -617,6 +656,21 @@ OGRealMatrix::asFullOGComplexMatrix() const
   return getConvertTo()->convertToOGComplexMatrix(this);
 }
 
+OGTerminal *
+OGRealMatrix::createOwningCopy() const
+{
+  real16 * newdata =  new real16[this->getDatalen()];
+  std::copy(this->getData(), this->getData()+this->getDatalen(), newdata);
+  return new OGOwningRealMatrix(newdata, this->getRows(), this->getCols());
+}
+
+OGTerminal *
+OGRealMatrix::createComplexOwningCopy() const
+{
+  complex16 * newdata =  new complex16[this->getDatalen()];
+  std::copy(this->getData(), this->getData()+this->getDatalen(), newdata);
+  return new OGOwningComplexMatrix(newdata, this->getRows(), this->getCols());
+}
 
 /**
  * OGOwningRealMatrix
@@ -702,7 +756,19 @@ OGComplexMatrix::asFullOGComplexMatrix() const
   return new OGOwningComplexMatrix(ret,this->getRows(),this->getCols());
 }
 
+OGTerminal *
+OGComplexMatrix::createOwningCopy() const
+{
+  complex16 * newdata =  new complex16[this->getDatalen()];
+  std::copy(this->getData(), this->getData()+this->getDatalen(), newdata);
+  return new OGOwningComplexMatrix(newdata, this->getRows(), this->getCols());
+}
 
+OGTerminal *
+OGComplexMatrix::createComplexOwningCopy() const
+{
+  return this->createOwningCopy();
+}
 
 /**
  * OGOwningComplexMatrix
@@ -710,6 +776,11 @@ OGComplexMatrix::asFullOGComplexMatrix() const
 OGOwningComplexMatrix::OGOwningComplexMatrix(int rows, int cols): OGComplexMatrix(new complex16[rows*cols](),rows,cols)
 {
 
+}
+
+OGOwningComplexMatrix::OGOwningComplexMatrix(real16 * data, int rows, int cols):OGComplexMatrix(new complex16[rows*cols](),rows,cols)
+{
+ std::copy(data, data+(rows*cols), this->getData());
 }
 
 OGOwningComplexMatrix::~OGOwningComplexMatrix()
@@ -847,6 +918,22 @@ OGRealDiagonalMatrix::asFullOGComplexMatrix() const
   return getConvertTo()->convertToOGComplexMatrix(this);
 }
 
+OGTerminal *
+OGRealDiagonalMatrix::createOwningCopy() const
+{
+  real16 * newdata =  new real16[this->getDatalen()];
+  std::copy(this->getData(), this->getData()+this->getDatalen(), newdata);
+  return new OGOwningRealDiagonalMatrix(newdata, this->getRows(), this->getCols());
+}
+
+OGTerminal *
+OGRealDiagonalMatrix::createComplexOwningCopy() const
+{
+  complex16 * newdata =  new complex16[this->getDatalen()];
+  std::copy(this->getData(), this->getData()+this->getDatalen(), newdata);
+  return new OGOwningComplexDiagonalMatrix(newdata, this->getRows(), this->getCols());
+}
+
 /**
  * OGOwningRealDiagonalMatrix
  */
@@ -933,6 +1020,22 @@ OGComplexDiagonalMatrix::asFullOGComplexMatrix() const
 {
   return getConvertTo()->convertToOGComplexMatrix(this);
 }
+
+
+OGTerminal *
+OGComplexDiagonalMatrix::createOwningCopy() const
+{
+  complex16 * newdata =  new complex16[this->getDatalen()];
+  std::copy(this->getData(), this->getData()+this->getDatalen(), newdata);
+  return new OGOwningComplexDiagonalMatrix(newdata, this->getRows(), this->getCols());
+}
+
+OGTerminal *
+OGComplexDiagonalMatrix::createComplexOwningCopy() const
+{
+  return this->createOwningCopy();
+}
+
 
 /**
  * OGOwningComplexDiagonalMatrix
@@ -1134,6 +1237,30 @@ OGRealSparseMatrix::asFullOGComplexMatrix() const
   return getConvertTo()->convertToOGComplexMatrix(this);
 }
 
+OGTerminal *
+OGRealSparseMatrix::createOwningCopy() const
+{
+  real16 * newdata =  new real16[this->getDatalen()];
+  std::copy(this->getData(), this->getData()+this->getDatalen(), newdata);
+  int * newColPtr = new int[this->getCols()+1];
+  std::copy(this->getColPtr(), this->getColPtr()+this->getCols()+1, newColPtr);
+  int * newRowIdx = new int[this->getDatalen()];
+  std::copy(this->getRowIdx(), this->getRowIdx()+this->getDatalen(), newRowIdx);
+  return new OGOwningRealSparseMatrix(newColPtr, newRowIdx, newdata, this->getRows(), this->getCols());
+}
+
+OGTerminal *
+OGRealSparseMatrix::createComplexOwningCopy() const
+{
+  complex16 * newdata =  new complex16[this->getDatalen()];
+  std::copy(this->getData(), this->getData()+this->getDatalen(), newdata);
+  int * newColPtr = new int[this->getCols()+1];
+  std::copy(this->getColPtr(), this->getColPtr()+this->getCols()+1, newColPtr);
+  int * newRowIdx = new int[this->getDatalen()];
+  std::copy(this->getRowIdx(), this->getRowIdx()+this->getDatalen(), newRowIdx);
+  return new OGOwningComplexSparseMatrix(newColPtr, newRowIdx, newdata, this->getRows(), this->getCols());
+}
+
 /**
  * OGOwningRealSparseMatrix
  */
@@ -1207,6 +1334,26 @@ OGComplexSparseMatrix::asFullOGComplexMatrix() const
 {
   return getConvertTo()->convertToOGComplexMatrix(this);
 }
+
+OGTerminal *
+OGComplexSparseMatrix::createOwningCopy() const
+{
+  complex16 * newdata =  new complex16[this->getDatalen()];
+  std::copy(this->getData(), this->getData()+this->getDatalen(), newdata);
+  int * newColPtr = new int[this->getCols()+1];
+  std::copy(this->getColPtr(), this->getColPtr()+this->getCols()+1, newColPtr);
+  int * newRowIdx = new int[this->getDatalen()];
+  std::copy(this->getRowIdx(), this->getRowIdx()+this->getDatalen(), newRowIdx);
+  return new OGOwningComplexSparseMatrix(newColPtr, newRowIdx, newdata, this->getRows(), this->getCols());
+}
+
+OGTerminal *
+OGComplexSparseMatrix::createComplexOwningCopy() const
+{
+  return this->createOwningCopy();
+}
+
+
 
 /**
  * OGOwningComplexSparseMatrix

--- a/src/librdag/test/check_terminals.cc
+++ b/src/librdag/test/check_terminals.cc
@@ -441,6 +441,7 @@ TEST(TerminalsTest, OGRealMatrixTest) {
   OGTerminal * owningComplexCopy = tmp->createComplexOwningCopy();
   OGComplexMatrix * cmplx_tmp = new OGOwningComplexMatrix(data, rows, cols);
   ASSERT_TRUE(*cmplx_tmp->asOGTerminal()==~*owningComplexCopy);
+  ASSERT_FALSE(tmp->getData()==reinterpret_cast<double *>(owningComplexCopy->asOGComplexMatrix()->getData())); // make sure the data is unique
   delete cmplx_tmp;
   delete owningComplexCopy;
 
@@ -749,6 +750,7 @@ TEST(TerminalsTest, OGRealDiagonalMatrix) {
   std::copy(data, data+tmp->getDatalen(), cmplx_data);
   OGComplexDiagonalMatrix * cmplx_tmp = new OGOwningComplexDiagonalMatrix(cmplx_data, rows, cols);
   ASSERT_TRUE(*cmplx_tmp->asOGTerminal()==~*owningComplexCopy);
+  ASSERT_FALSE(tmp->getData()==reinterpret_cast<double *>(owningComplexCopy->asOGComplexDiagonalMatrix()->getData())); // make sure the data is unique
   delete cmplx_tmp;
   delete owningComplexCopy;
 
@@ -1099,6 +1101,7 @@ TEST(TerminalsTest, OGRealSparseMatrix) {
   // check createComplexOwningCopy
   OGTerminal * owningComplexCopy = tmp->createComplexOwningCopy();
   ASSERT_TRUE(*tmp->asOGTerminal()%*owningComplexCopy);
+  ASSERT_TRUE(owningComplexCopy->asOGComplexSparseMatrix()!=nullptr); // check type is correct as % was used to compare
   ASSERT_FALSE(tmp->getData()==reinterpret_cast<double *>(owningComplexCopy->asOGComplexSparseMatrix()->getData())); // make sure the data is unique
   ASSERT_FALSE(tmp->asOGRealSparseMatrix()->getColPtr()==owningComplexCopy->asOGComplexSparseMatrix()->getColPtr()); // make sure the colptr data is unique
   ASSERT_FALSE(tmp->asOGRealSparseMatrix()->getRowIdx()==owningComplexCopy->asOGComplexSparseMatrix()->getRowIdx()); // make sure the rowidx data is unique
@@ -1303,6 +1306,7 @@ TEST(TerminalsTest, OGComplexSparseMatrix) {
   // check createComplexOwningCopy
   OGTerminal * owningComplexCopy = tmp->createComplexOwningCopy();
   ASSERT_TRUE(*tmp->asOGTerminal()%*owningComplexCopy);
+  ASSERT_TRUE(owningComplexCopy->asOGComplexSparseMatrix()!=nullptr); // check type is correct as % was used to compare
   ASSERT_FALSE(tmp->getData()==(owningComplexCopy->asOGComplexSparseMatrix()->getData())); // make sure the data is unique
   ASSERT_FALSE(tmp->asOGComplexSparseMatrix()->getColPtr()==owningComplexCopy->asOGComplexSparseMatrix()->getColPtr()); // make sure the colptr data is unique
   ASSERT_FALSE(tmp->asOGComplexSparseMatrix()->getRowIdx()==owningComplexCopy->asOGComplexSparseMatrix()->getRowIdx()); // make sure the rowidx data is unique

--- a/src/librdag/test/check_terminals.cc
+++ b/src/librdag/test/check_terminals.cc
@@ -187,6 +187,18 @@ TEST(TerminalsTest, OGRealScalarTest) {
   ASSERT_EQ(tmp->getValue(),copy->asOGRealScalar()->getValue());
   ASSERT_EQ(copy,copy->asOGRealScalar());
 
+  // check createOwningCopy
+  OGTerminal * owningCopy = tmp->createOwningCopy();
+  ASSERT_TRUE(*tmp->asOGTerminal()==~*owningCopy);
+  delete owningCopy;
+
+  // check createComplexOwningCopy
+  OGTerminal * owningComplexCopy = tmp->createComplexOwningCopy();
+  OGComplexScalar * cmplx_tmp = new OGComplexScalar(value);
+  ASSERT_TRUE(*cmplx_tmp->asOGTerminal()==~*owningComplexCopy);
+  delete cmplx_tmp;
+  delete owningComplexCopy;
+
   // Check debug string
   copy->debug_print();
 
@@ -258,6 +270,16 @@ TEST(TerminalsTest, OGComplexScalarTest) {
   ASSERT_EQ(tmp->getValue(),copy->asOGComplexScalar()->getValue());
   ASSERT_EQ(copy,copy->asOGComplexScalar());
 
+  // check createOwningCopy
+  OGTerminal * owningCopy = tmp->createOwningCopy();
+  ASSERT_TRUE(*tmp->asOGTerminal()==~*owningCopy);
+  delete owningCopy;
+
+  // check createComplexOwningCopy
+  OGTerminal * owningComplexCopy = tmp->createComplexOwningCopy();
+  ASSERT_TRUE(*tmp->asOGTerminal()==~*owningComplexCopy);
+  delete owningComplexCopy;
+
   // Check debug string
   copy->debug_print();
 
@@ -304,6 +326,18 @@ TEST(TerminalsTest, OGIntegerScalarTest) {
   OGNumeric * copy = tmp->copy();
   ASSERT_EQ(tmp->getValue(),copy->asOGIntegerScalar()->getValue());
   ASSERT_EQ(copy,copy->asOGIntegerScalar());
+
+  // check createOwningCopy
+  OGTerminal * owningCopy = tmp->createOwningCopy();
+  ASSERT_TRUE(*tmp->asOGTerminal()==~*owningCopy);
+  delete owningCopy;
+
+  // check createComplexOwningCopy
+  OGTerminal * owningComplexCopy = tmp->createComplexOwningCopy();
+  OGComplexScalar * cmplx_tmp = new OGComplexScalar(value);
+  ASSERT_TRUE(*cmplx_tmp->asOGTerminal()==~*owningComplexCopy);
+  delete cmplx_tmp;
+  delete owningComplexCopy;
 
   // Check debug string
   copy->debug_print();
@@ -396,6 +430,19 @@ TEST(TerminalsTest, OGRealMatrixTest) {
   ASSERT_EQ(tmp->getRows(),copy->asOGRealMatrix()->getRows());
   ASSERT_EQ(tmp->getCols(),copy->asOGRealMatrix()->getCols());
   ASSERT_EQ(copy,copy->asOGRealMatrix());
+
+  // check createOwningCopy
+  OGTerminal * owningCopy = tmp->createOwningCopy();
+  ASSERT_TRUE(*tmp->asOGTerminal()==~*owningCopy);
+  ASSERT_FALSE(tmp->getData()==owningCopy->asOGRealMatrix()->getData()); // make sure the data is unique
+  delete owningCopy;
+
+  // check createComplexOwningCopy
+  OGTerminal * owningComplexCopy = tmp->createComplexOwningCopy();
+  OGComplexMatrix * cmplx_tmp = new OGOwningComplexMatrix(data, rows, cols);
+  ASSERT_TRUE(*cmplx_tmp->asOGTerminal()==~*owningComplexCopy);
+  delete cmplx_tmp;
+  delete owningComplexCopy;
 
   // Check debug string
   copy->debug_print();
@@ -531,6 +578,18 @@ TEST(TerminalsTest, OGComplexMatrixTest) {
   ASSERT_EQ(tmp->getRows(),copy->asOGComplexMatrix()->getRows());
   ASSERT_EQ(tmp->getCols(),copy->asOGComplexMatrix()->getCols());
   ASSERT_EQ(copy,copy->asOGComplexMatrix());
+
+  // check createOwningCopy
+  OGTerminal * owningCopy = tmp->createOwningCopy();
+  ASSERT_TRUE(*tmp->asOGTerminal()==~*owningCopy);
+  ASSERT_FALSE(tmp->getData()==owningCopy->asOGComplexMatrix()->getData()); // make sure the data is unique
+  delete owningCopy;
+
+  // check createComplexOwningCopy
+  OGTerminal * owningComplexCopy = tmp->createComplexOwningCopy();
+  ASSERT_TRUE(*tmp->asOGTerminal()==~*owningComplexCopy);
+  ASSERT_FALSE(tmp->getData()==owningComplexCopy->asOGComplexMatrix()->getData());
+  delete owningComplexCopy;
 
   // Check debug string
   copy->debug_print();
@@ -677,6 +736,21 @@ TEST(TerminalsTest, OGRealDiagonalMatrix) {
   ASSERT_EQ(tmp->getRows(),copy->asOGRealDiagonalMatrix()->getRows());
   ASSERT_EQ(tmp->getCols(),copy->asOGRealDiagonalMatrix()->getCols());
   ASSERT_EQ(copy,copy->asOGRealDiagonalMatrix());
+
+  // check createOwningCopy
+  OGTerminal * owningCopy = tmp->createOwningCopy();
+  ASSERT_TRUE(*tmp->asOGTerminal()==~*owningCopy);
+  ASSERT_FALSE(tmp->getData()==owningCopy->asOGRealDiagonalMatrix()->getData()); // make sure the data is unique
+  delete owningCopy;
+
+  // check createComplexOwningCopy
+  OGTerminal * owningComplexCopy = tmp->createComplexOwningCopy();
+  complex16 * cmplx_data = new complex16[tmp->getDatalen()];
+  std::copy(data, data+tmp->getDatalen(), cmplx_data);
+  OGComplexDiagonalMatrix * cmplx_tmp = new OGOwningComplexDiagonalMatrix(cmplx_data, rows, cols);
+  ASSERT_TRUE(*cmplx_tmp->asOGTerminal()==~*owningComplexCopy);
+  delete cmplx_tmp;
+  delete owningComplexCopy;
 
   // Check debug string
   copy->debug_print();
@@ -829,6 +903,18 @@ TEST(TerminalsTest, OGComplexDiagonalMatrix) {
   ASSERT_EQ(tmp->getRows(),copy->asOGComplexDiagonalMatrix()->getRows());
   ASSERT_EQ(tmp->getCols(),copy->asOGComplexDiagonalMatrix()->getCols());
   ASSERT_EQ(copy,copy->asOGComplexDiagonalMatrix());
+
+  // check createOwningCopy
+  OGTerminal * owningCopy = tmp->createOwningCopy();
+  ASSERT_TRUE(*tmp->asOGTerminal()==~*owningCopy);
+  ASSERT_FALSE(tmp->getData()==owningCopy->asOGComplexDiagonalMatrix()->getData()); // make sure the data is unique
+  delete owningCopy;
+
+  // check createComplexOwningCopy
+  OGTerminal * owningComplexCopy = tmp->createComplexOwningCopy();
+  ASSERT_TRUE(*tmp->asOGTerminal()==~*owningComplexCopy);
+  ASSERT_FALSE(tmp->getData()==owningComplexCopy->asOGComplexDiagonalMatrix()->getData());
+  delete owningComplexCopy;
 
   // Check debug string
   copy->debug_print();
@@ -1001,6 +1087,22 @@ TEST(TerminalsTest, OGRealSparseMatrix) {
   ASSERT_EQ(tmp->getColPtr(),copy->asOGRealSparseMatrix()->getColPtr());
   ASSERT_TRUE(ArrayEquals(tmp->getColPtr(),copy->asOGRealSparseMatrix()->getColPtr(),6));
   ASSERT_EQ(copy,copy->asOGRealSparseMatrix());
+
+  // check createOwningCopy
+  OGTerminal * owningCopy = tmp->createOwningCopy();
+  ASSERT_TRUE(*tmp->asOGTerminal()==~*owningCopy);
+  ASSERT_FALSE(tmp->getData()==owningCopy->asOGRealSparseMatrix()->getData()); // make sure the data is unique
+  ASSERT_FALSE(tmp->asOGRealSparseMatrix()->getColPtr()==owningCopy->asOGRealSparseMatrix()->getColPtr()); // make sure the colptr data is unique
+  ASSERT_FALSE(tmp->asOGRealSparseMatrix()->getRowIdx()==owningCopy->asOGRealSparseMatrix()->getRowIdx()); // make sure the rowidx data is unique
+  delete owningCopy;
+
+  // check createComplexOwningCopy
+  OGTerminal * owningComplexCopy = tmp->createComplexOwningCopy();
+  ASSERT_TRUE(*tmp->asOGTerminal()%*owningComplexCopy);
+  ASSERT_FALSE(tmp->getData()==reinterpret_cast<double *>(owningComplexCopy->asOGComplexSparseMatrix()->getData())); // make sure the data is unique
+  ASSERT_FALSE(tmp->asOGRealSparseMatrix()->getColPtr()==owningComplexCopy->asOGComplexSparseMatrix()->getColPtr()); // make sure the colptr data is unique
+  ASSERT_FALSE(tmp->asOGRealSparseMatrix()->getRowIdx()==owningComplexCopy->asOGComplexSparseMatrix()->getRowIdx()); // make sure the rowidx data is unique
+  delete owningComplexCopy;
 
   // Check debug string
   copy->debug_print();
@@ -1190,6 +1292,22 @@ TEST(TerminalsTest, OGComplexSparseMatrix) {
   ASSERT_TRUE(ArrayEquals(tmp->getColPtr(),copy->asOGComplexSparseMatrix()->getColPtr(),6));
   ASSERT_EQ(copy,copy->asOGComplexSparseMatrix());
 
+  // check createOwningCopy
+  OGTerminal * owningCopy = tmp->createOwningCopy();
+  ASSERT_TRUE(*tmp->asOGTerminal()==~*owningCopy);
+  ASSERT_FALSE(tmp->getData()==owningCopy->asOGComplexSparseMatrix()->getData()); // make sure the data is unique
+  ASSERT_FALSE(tmp->asOGComplexSparseMatrix()->getColPtr()==owningCopy->asOGComplexSparseMatrix()->getColPtr()); // make sure the colptr data is unique
+  ASSERT_FALSE(tmp->asOGComplexSparseMatrix()->getRowIdx()==owningCopy->asOGComplexSparseMatrix()->getRowIdx()); // make sure the rowidx data is unique
+  delete owningCopy;
+
+  // check createComplexOwningCopy
+  OGTerminal * owningComplexCopy = tmp->createComplexOwningCopy();
+  ASSERT_TRUE(*tmp->asOGTerminal()%*owningComplexCopy);
+  ASSERT_FALSE(tmp->getData()==(owningComplexCopy->asOGComplexSparseMatrix()->getData())); // make sure the data is unique
+  ASSERT_FALSE(tmp->asOGComplexSparseMatrix()->getColPtr()==owningComplexCopy->asOGComplexSparseMatrix()->getColPtr()); // make sure the colptr data is unique
+  ASSERT_FALSE(tmp->asOGComplexSparseMatrix()->getRowIdx()==owningComplexCopy->asOGComplexSparseMatrix()->getRowIdx()); // make sure the rowidx data is unique
+  delete owningComplexCopy;
+
   // Check debug string
   copy->debug_print();
 
@@ -1268,6 +1386,8 @@ public:
     virtual OGNumeric* copy() const override { return nullptr; }
     virtual OGOwningRealMatrix * asFullOGRealMatrix() const override { return nullptr; }
     virtual OGOwningComplexMatrix * asFullOGComplexMatrix() const override { return nullptr; }
+    virtual OGTerminal * createOwningCopy() const override { return nullptr; }
+    virtual OGTerminal * createComplexOwningCopy() const override { return nullptr;}
 };
 
 TEST(OGArrayTest, NegativeDatalen)


### PR DESCRIPTION
This PR addresses MAT-323, the creation of owning copies. The purpose of these copies is so that at any point in execution a terminal can be extracted to a clean data-owning copy by duplication. This is so that part or all of an execution tree can be deleted, manipulated or indeed just mangled with no bearing on the "liveness" of an output terminal.
- Adds `createOwningCopy()` which creates an exact data-owning copy of the terminal.
- Adds `createComplexOwningCopy()` which creates a complex type variant of a terminal with data-owning properties.
- Adds the convenience ctor `OGOwningComplexMatrix(real16 * data, int rows, int cols);` due to its prolific use potential.

BB Multi-Pass: [http://devmaths-lx-1:8011/builders/nyqwk2-testing/builds/659](http://devmaths-lx-1:8011/builders/nyqwk2-testing/builds/659).
Coverage: librdag 92.4%, jshim 20.5% (slight improvement in librdag)
Java coverage: 82% (unchanged)
