### PR TITLE
Mat 317

### DIFF
--- a/include/fake_jni.h
+++ b/include/fake_jni.h
@@ -220,6 +220,14 @@ class JNIEnv_
     {
       return &allClasses;
     }
+    virtual jboolean ExceptionCheck()
+    {
+      return JNI_FALSE;
+    }
+    virtual void ExceptionClear()
+    {
+
+    }
     virtual ~JNIEnv_()
     {
       

--- a/include/jbindings.hh
+++ b/include/jbindings.hh
@@ -27,15 +27,15 @@ T* bindOGArrayData(jobject obj);
  * @param obj the java object from which the native data is pinned
  */
 template <typename nativeT, typename javaT>
-void unbindOGArrayData(nativeT* nativeData, jobject obj);
+DLLEXPORT_C void unbindOGArrayData(nativeT* nativeData, jobject obj);
 
-extern template void
+extern template DLLEXPORT_C  void
 unbindOGArrayData<real16, jdoubleArray>(real16* nativeData, jobject obj);
 
-extern template void
+extern template DLLEXPORT_C  void
 unbindOGArrayData<complex16, jdoubleArray>(complex16* nativeData, jobject obj);
 
-extern template void
+extern template DLLEXPORT_C  void
 unbindOGArrayData<jint, jintArray>(jint* nativeData, jobject obj);
 
 /**
@@ -47,15 +47,15 @@ unbindOGArrayData<jint, jintArray>(jint* nativeData, jobject obj);
  * @return a pointer to a native version of the data
  */
 template <typename nativeT, typename javaT>
-nativeT* bindPrimitiveArrayData(jobject obj, jmethodID method);
+DLLEXPORT_C nativeT* bindPrimitiveArrayData(jobject obj, jmethodID method);
 
-extern template real16*
+extern template DLLEXPORT_C real16*
 bindPrimitiveArrayData<real16, jdoubleArray>(jobject obj, jmethodID method);
 
-extern template complex16*
+extern template DLLEXPORT_C complex16*
 bindPrimitiveArrayData<complex16, jdoubleArray>(jobject obj, jmethodID method);
 
-extern template int*
+extern template DLLEXPORT_C int*
 bindPrimitiveArrayData<int, jintArray>(jobject obj, jmethodID method);
 
 /**
@@ -67,15 +67,15 @@ bindPrimitiveArrayData<int, jintArray>(jobject obj, jmethodID method);
  * @param method the method that refers to the pinned data
  */
 template <typename nativeT, typename javaT>
-void unbindPrimitiveArrayData(nativeT * nativeData, jobject obj, jmethodID method);
+DLLEXPORT_C void unbindPrimitiveArrayData(nativeT * nativeData, jobject obj, jmethodID method);
 
-extern template void
+extern template DLLEXPORT_C void
 unbindPrimitiveArrayData<real16, jdoubleArray>(real16* nativeData, jobject obj, jmethodID method);
 
-extern template void
+extern template DLLEXPORT_C void
 unbindPrimitiveArrayData<complex16, jdoubleArray>(complex16* nativeData, jobject obj, jmethodID method);
 
-extern template void
+extern template DLLEXPORT_C void
 unbindPrimitiveArrayData<jint, jintArray>(jint* nativeData, jobject obj, jmethodID method);
 
 } // namespace convert

--- a/include/jdispatch.hh
+++ b/include/jdispatch.hh
@@ -13,6 +13,7 @@
 #include "warningmacros.h"
 #include "exceptions.hh"
 #include "jvmmanager.hh"
+#include "modifiermacros.h"
 
 namespace convert {
 
@@ -22,7 +23,7 @@ jobjectArray convertCreal16ArrOfArr2JDoubleArrOfArr(JNIEnv * env, real16 ** inpu
 jobjectArray extractRealPartOfCcomplex16ArrOfArr2JDoubleArrOfArr(JNIEnv * env, complex16 ** inputData, int rows, int cols);
 jobjectArray extractImagPartOfCcomplex16ArrOfArr2JDoubleArrOfArr(JNIEnv * env, complex16 ** inputData, int rows, int cols);
 
-class DispatchToReal16ArrayOfArrays: public librdag::Visitor
+class DLLEXPORT_C DispatchToReal16ArrayOfArrays: public librdag::Visitor
 {
   public:
     virtual ~DispatchToReal16ArrayOfArrays();
@@ -51,7 +52,7 @@ class DispatchToReal16ArrayOfArrays: public librdag::Visitor
 
 
 
-class DispatchToComplex16ArrayOfArrays: public librdag::Visitor
+class DLLEXPORT_C DispatchToComplex16ArrayOfArrays: public librdag::Visitor
 {
   public:
     virtual ~DispatchToComplex16ArrayOfArrays();
@@ -77,7 +78,7 @@ class DispatchToComplex16ArrayOfArrays: public librdag::Visitor
     int cols;    
 };
   
-class DispatchToOGTerminal: public librdag::Visitor
+class DLLEXPORT_C DispatchToOGTerminal: public librdag::Visitor
 {
   public:
     DispatchToOGTerminal(JNIEnv* env);

--- a/include/jterminals.hh
+++ b/include/jterminals.hh
@@ -14,6 +14,12 @@ namespace convert {
 
 using namespace librdag;
 
+/**
+ * helper function to get ints from int getFOO() in java
+ */
+jint getIntFromVoidJMethod(jmethodID id, jobject obj);
+
+
 /*
  * An OGRealScalar backed by data pinned from a Java based OGRealScalar.
  * Note that _dataref is assigned on construction of the OGRealScalar base class,

--- a/include/jterminals.hh
+++ b/include/jterminals.hh
@@ -17,7 +17,7 @@ using namespace librdag;
 /**
  * helper function to get ints from int getFOO() in java
  */
-jint getIntFromVoidJMethod(jmethodID id, jobject obj);
+DLLEXPORT_C jint getIntFromVoidJMethod(jmethodID id, jobject obj);
 
 
 /*
@@ -26,7 +26,7 @@ jint getIntFromVoidJMethod(jmethodID id, jobject obj);
  * this is to keep JNI calls to a minimum by holding reference to the data pointer needed
  * to free via the ReleasePrimitiveArrayCritical() function.
  */
-class JOGRealScalar: public OGRealScalar
+class DLLEXPORT_C JOGRealScalar: public OGRealScalar
 {
   public:
     using OGRealScalar::OGRealScalar;
@@ -44,7 +44,7 @@ class JOGRealScalar: public OGRealScalar
  * this is to keep JNI calls to a minimum by holding reference to the data pointer needed
  * to free via the ReleasePrimitiveArrayCritical() function.
  */
-class JOGComplexScalar: public OGComplexScalar
+class DLLEXPORT_C JOGComplexScalar: public OGComplexScalar
 {
   public:
     using OGComplexScalar::OGComplexScalar;
@@ -62,7 +62,7 @@ class JOGComplexScalar: public OGComplexScalar
  * this is to keep JNI calls to a minimum by holding reference to the data pointer needed
  * to free via the ReleasePrimitiveArrayCritical() function.
  */
-class JOGIntegerScalar: public OGIntegerScalar
+class DLLEXPORT_C JOGIntegerScalar: public OGIntegerScalar
 {
   public:
     using OGIntegerScalar::OGIntegerScalar;
@@ -77,7 +77,7 @@ class JOGIntegerScalar: public OGIntegerScalar
 /*
  * An OGRealMatrix backed by data pinned from a Java based OGRealMatrix
  */
-class JOGRealMatrix: public OGRealMatrix
+class DLLEXPORT_C JOGRealMatrix: public OGRealMatrix
 {
   public:
     using OGRealMatrix::OGRealMatrix;
@@ -91,7 +91,7 @@ class JOGRealMatrix: public OGRealMatrix
 /*
  * An OGComplexMatrix backed by data pinned from a Java based OGComplexMatrix
  */
-class JOGComplexMatrix: public OGComplexMatrix
+class DLLEXPORT_C JOGComplexMatrix: public OGComplexMatrix
 {
   public:
     JOGComplexMatrix(jobject obj);
@@ -104,7 +104,7 @@ class JOGComplexMatrix: public OGComplexMatrix
 /*
  * An OGLogicalMatrix backed by data pinned from a Java based OGLogicalMatrix
  */
-class JOGLogicalMatrix: public OGLogicalMatrix
+class DLLEXPORT_C JOGLogicalMatrix: public OGLogicalMatrix
 {
   public:
     using OGLogicalMatrix::OGLogicalMatrix;
@@ -118,7 +118,7 @@ class JOGLogicalMatrix: public OGLogicalMatrix
 /*
  * An OGRealSparseMatrix backed by data pinned from a Java based OGRealSparseMatrix
  */
-class JOGRealSparseMatrix: public OGRealSparseMatrix
+class DLLEXPORT_C JOGRealSparseMatrix: public OGRealSparseMatrix
 {
   public:
     JOGRealSparseMatrix(jobject obj);
@@ -133,7 +133,7 @@ class JOGRealSparseMatrix: public OGRealSparseMatrix
 /*
  * An OGComplexSparseMatrix backed by data pinned from a Java based OGComplexSparseMatrix
  */
-class JOGComplexSparseMatrix: public OGComplexSparseMatrix
+class DLLEXPORT_C JOGComplexSparseMatrix: public OGComplexSparseMatrix
 {
   public:
     JOGComplexSparseMatrix(jobject obj);
@@ -148,7 +148,7 @@ class JOGComplexSparseMatrix: public OGComplexSparseMatrix
 /*
  * An OGRealDiagonalMatrix backed by data pinned from a Java based OGRealDiagonalMatrix
  */
-class JOGRealDiagonalMatrix: public OGRealDiagonalMatrix
+class DLLEXPORT_C JOGRealDiagonalMatrix: public OGRealDiagonalMatrix
 {
   public:
     JOGRealDiagonalMatrix(jobject obj);
@@ -161,7 +161,7 @@ class JOGRealDiagonalMatrix: public OGRealDiagonalMatrix
 /*
  * An OGComplexDiagonalMatrix backed by data pinned from a Java based OGComplexDiagonalMatrix
  */
-class JOGComplexDiagonalMatrix: public OGComplexDiagonalMatrix
+class DLLEXPORT_C JOGComplexDiagonalMatrix: public OGComplexDiagonalMatrix
 {
   public:
     JOGComplexDiagonalMatrix(jobject obj);

--- a/include/jvmmanager.hh
+++ b/include/jvmmanager.hh
@@ -23,7 +23,7 @@ namespace convert {
 /*
  * Check for exception
  */
-void checkEx(JNIEnv* env);
+DLLEXPORT_C void checkEx(JNIEnv* env);
 
 /*
  * Caches static classes methods, fields and the JVM pointer.

--- a/include/test/fake_jvm.hh
+++ b/include/test/fake_jvm.hh
@@ -1,0 +1,71 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+#include "jvmmanager.hh"
+#include "warningmacros.h"
+
+//
+// Contains concrete impls of fake jvm and fake jni env
+//
+
+// mock JVM
+class Fake_JavaVM: public JavaVM
+{
+  public:
+    virtual ~Fake_JavaVM(){};
+    virtual int GetEnv(void ** env, int SUPPRESS_UNUSED version) override
+    {
+     *env = _env;
+     return JNI_OK;
+    }
+    void setEnv(JNIEnv * env)
+    {
+        this->_env = env;
+    }
+    JNIEnv * getEnv()
+    {
+        return this->_env;
+    }
+    virtual jint AttachCurrentThread(void **penv, void SUPPRESS_UNUSED *args)
+    {
+      *penv = this->_env;
+      return JNI_OK;
+    }
+};
+
+// mock JNIEnv
+class Fake_JNIEnv: public JNIEnv
+{
+  public:
+    Fake_JNIEnv()
+    {
+      _someNonClass = new _jclass();
+      _someNonMethodID = new _jmethodID();
+      _someNonFieldID = new _jfieldID();
+    }
+    virtual ~Fake_JNIEnv()
+    {
+      delete _someNonMethodID;
+      delete _someNonFieldID;
+      delete _someNonClass;
+    }
+    virtual jclass FindClass(const char SUPPRESS_UNUSED * name)
+    {
+      return _someNonClass;
+    }
+    virtual jmethodID GetMethodID(jclass SUPPRESS_UNUSED clazz, const char SUPPRESS_UNUSED *name, const char SUPPRESS_UNUSED *sig) override
+    {
+      return _someNonMethodID;
+    }
+    virtual jfieldID GetFieldID(jclass SUPPRESS_UNUSED clazz, const char SUPPRESS_UNUSED *name, const char SUPPRESS_UNUSED *sig) override
+    {
+      return _someNonFieldID;
+    }
+private:
+    jclass _someNonClass;
+    jmethodID _someNonMethodID;
+    jfieldID _someNonFieldID;
+};

--- a/src/jshim/jbindings.cc
+++ b/src/jshim/jbindings.cc
@@ -26,10 +26,7 @@ template<typename nativeT = real16, typename javaT = jdoubleArray>
 real16* getArrayFromJava(JNIEnv *env, jdoubleArray arr)
 {
   real16* p = env->GetDoubleArrayElements(arr, NULL);
-  if (p == nullptr)
-  {
-    throw convert_error("Null pointer returned by GetDoubleArrayElements");
-  }
+  checkEx(env);
   return p;
 }
 
@@ -37,10 +34,7 @@ template<typename nativeT = jint, typename javaT = jintArray>
 jint* getArrayFromJava(JNIEnv *env, jintArray arr)
 {
   jint* p = env->GetIntArrayElements(arr, NULL);
-  if (p == nullptr)
-  {
-    throw convert_error("Null pointer returned by GetIntArrayElements");
-  }
+  checkEx(env);
   return p;
 }
 
@@ -98,10 +92,7 @@ template <typename nativeT, typename javaT> DLLEXPORT_C nativeT * bindPrimitiveA
   }
   jobject dataobj = NULL;
   dataobj = env->CallObjectMethod(obj, method);
-  if(dataobj == nullptr)
-  {
-    throw convert_error("CallObjectMethod failed");
-  }
+  checkEx(env);
   javaT * array = reinterpret_cast<javaT *>(&dataobj);
   nativeT * _dataptr = (nativeT*) getArrayFromJava<nativeT, javaT>(env, *array);
   return _dataptr;
@@ -143,10 +134,7 @@ template <typename nativeT, typename javaT> DLLEXPORT_C void unbindPrimitiveArra
     throw convert_error("Thread attach failed");
   }
   jobject dataobj = env->CallObjectMethod(obj, method);
-  if(dataobj == nullptr)
-  {
-    throw convert_error("CallObjectMethod failed");
-  }
+  checkEx(env);
   javaT * array = reinterpret_cast<javaT *>(&dataobj);
   releaseArrayFromJava<nativeT, javaT>(env, nativeData, *array);
 }

--- a/src/jshim/jbindings.cc
+++ b/src/jshim/jbindings.cc
@@ -79,11 +79,11 @@ void releaseArrayFromJava(JNIEnv* env, jint* nativeArr, jintArray arr)
 
 template <typename nativeT, typename javaT> nativeT * bindPrimitiveArrayData(jobject obj, jmethodID method)
 {
-  if(!obj)
+  if(obj == nullptr)
   {
     throw convert_error("bindPrimitiveArrayData: null obj");
   }
-  if(!method)
+  if(method == nullptr)
   {
     throw convert_error("bindPrimitiveArrayData: null method");
   }
@@ -97,7 +97,7 @@ template <typename nativeT, typename javaT> nativeT * bindPrimitiveArrayData(job
   }
   jobject dataobj = NULL;
   dataobj = env->CallObjectMethod(obj, method);
-  if(!dataobj)
+  if(dataobj == nullptr)
   {
     throw convert_error("CallObjectMethod failed");
   }
@@ -121,15 +121,15 @@ bindPrimitiveArrayData<jint, jintArray>(jobject obj, jmethodID method);
 
 template <typename nativeT, typename javaT> void unbindPrimitiveArrayData(nativeT * nativeData, jobject obj, jmethodID method)
 {
-  if(!nativeData)
+  if(nativeData == nullptr)
   {
     throw convert_error("unbindPrimitiveArrayData: null nativeData");
   }
-  if(!obj)
+  if(obj == nullptr)
   {
     throw convert_error("unbindPrimitiveArrayData: null obj");
   }
-  if(!method)
+  if(method == nullptr)
   {
     throw convert_error("unbindPrimitiveArrayData: null method");
   }
@@ -142,6 +142,10 @@ template <typename nativeT, typename javaT> void unbindPrimitiveArrayData(native
     throw convert_error("Thread attach failed");
   }
   jobject dataobj = env->CallObjectMethod(obj, method);
+  if(dataobj == nullptr)
+  {
+    throw convert_error("CallObjectMethod failed");
+  }
   javaT * array = reinterpret_cast<javaT *>(&dataobj);
   releaseArrayFromJava<nativeT, javaT>(env, nativeData, *array);
 }
@@ -161,17 +165,7 @@ unbindPrimitiveArrayData<jint, jintArray>(jint* nativeData, jobject obj, jmethod
 
 template <typename nativeT, typename javaT> void unbindOGArrayData(nativeT * nativeData, jobject obj)
 {
-  JNIEnv *env = NULL;
-  jint jStatus = 0;
-  VAL64BIT_PRINT("Unbinding for OGArrayData", obj);
-  jStatus=JVMManager::getJVM()->AttachCurrentThread((void **)&env, NULL);  // NOP to get env ptr
-  if(jStatus)
-  {
-    throw convert_error("Thread attach failed");
-  }
-  jobject dataobj = env->CallObjectMethod(obj, JVMManager::getOGTerminalClazz_getData());
-  javaT * array = reinterpret_cast<javaT *>(&dataobj);
-  releaseArrayFromJava<nativeT, javaT>(env, nativeData, *array);
+  unbindPrimitiveArrayData<nativeT, javaT>(nativeData, obj, JVMManager::getOGTerminalClazz_getData());
 }
 
 template void

--- a/src/jshim/jbindings.cc
+++ b/src/jshim/jbindings.cc
@@ -38,7 +38,7 @@ jint* getArrayFromJava(JNIEnv *env, jintArray arr)
   jint* p = env->GetIntArrayElements(arr, NULL);
   if (p == nullptr)
   {
-    throw convert_error("Null pointer returned by GetDoubleArrayElements");
+    throw convert_error("Null pointer returned by GetIntArrayElements");
   }
   return p;
 }

--- a/src/jshim/jbindings.cc
+++ b/src/jshim/jbindings.cc
@@ -5,6 +5,7 @@
  */
 
 #include "debug.h"
+#include "modifiermacros.h"
 #include "jbindings.hh"
 #include "jvmmanager.hh"
 #include "exceptions.hh"
@@ -77,7 +78,7 @@ void releaseArrayFromJava(JNIEnv* env, jint* nativeArr, jintArray arr)
  * bindPrimitiveArrayData
  */
 
-template <typename nativeT, typename javaT> nativeT * bindPrimitiveArrayData(jobject obj, jmethodID method)
+template <typename nativeT, typename javaT> DLLEXPORT_C nativeT * bindPrimitiveArrayData(jobject obj, jmethodID method)
 {
   if(obj == nullptr)
   {
@@ -119,7 +120,7 @@ bindPrimitiveArrayData<jint, jintArray>(jobject obj, jmethodID method);
  * unbindPrimitiveArrayData
  */
 
-template <typename nativeT, typename javaT> void unbindPrimitiveArrayData(nativeT * nativeData, jobject obj, jmethodID method)
+template <typename nativeT, typename javaT> DLLEXPORT_C void unbindPrimitiveArrayData(nativeT * nativeData, jobject obj, jmethodID method)
 {
   if(nativeData == nullptr)
   {

--- a/src/jshim/jdispatch.cc
+++ b/src/jshim/jdispatch.cc
@@ -146,7 +146,7 @@ void DispatchToComplex16ArrayOfArrays::visit(librdag::OGScalar<complex16> const 
 }
 void DispatchToComplex16ArrayOfArrays::visit(librdag::OGScalar<real16> const SUPPRESS_UNUSED  *thing)
 {
-    throw std::runtime_error("DispatchToComplex16ArrayOfArrays::visit(librdag::OGScalar<real16>)");
+    throw std::runtime_error("DispatchToComplex16ArrayOfArrays::visit(librdag::OGScalar<int>)");
 }
 void DispatchToComplex16ArrayOfArrays::visit(librdag::OGScalar<int> const SUPPRESS_UNUSED *thing)
 {

--- a/src/jshim/jdispatch.cc
+++ b/src/jshim/jdispatch.cc
@@ -28,9 +28,9 @@ DispatchToReal16ArrayOfArrays::~DispatchToReal16ArrayOfArrays()
 
         for(int i=0; i<this->getRows(); i++)
         {
-            delete arr[i];
+            delete[] arr[i];
         }
-        delete arr;
+        delete[] arr;
     }
 }
 
@@ -127,12 +127,11 @@ DispatchToComplex16ArrayOfArrays::~DispatchToComplex16ArrayOfArrays()
     complex16 ** arr = this->getData();
     if(arr)
     {
-
         for(int i=0; i<this->getRows(); i++)
         {
-            delete arr[i];
+            delete[] arr[i];
         }
-        delete arr;
+        delete[] arr;
     }
 }
 void DispatchToComplex16ArrayOfArrays::visit(librdag::OGExpr const SUPPRESS_UNUSED *thing)

--- a/src/jshim/jdispatch.cc
+++ b/src/jshim/jdispatch.cc
@@ -36,7 +36,7 @@ DispatchToReal16ArrayOfArrays::~DispatchToReal16ArrayOfArrays()
 
 void DispatchToReal16ArrayOfArrays::visit(librdag::OGExpr const SUPPRESS_UNUSED *thing)
 {
-    throw std::runtime_error("DispatchToReal16ArrayOfArrays::visit(librdag::OGExpr)");
+    throw convert_error("DispatchToReal16ArrayOfArrays::visit(librdag::OGExpr)");
 }
 
 void DispatchToReal16ArrayOfArrays::visit(librdag::OGScalar<real16> const  *thing)
@@ -48,11 +48,11 @@ void DispatchToReal16ArrayOfArrays::visit(librdag::OGScalar<real16> const  *thin
 
 void DispatchToReal16ArrayOfArrays::visit(librdag::OGScalar<complex16> const SUPPRESS_UNUSED  *thing)
 {
-    throw std::runtime_error("DispatchToReal16ArrayOfArrays::visit(librdag::OGScalar<complex16>)");
+    throw convert_error("DispatchToReal16ArrayOfArrays::visit(librdag::OGScalar<complex16>)");
 }
 void DispatchToReal16ArrayOfArrays::visit(librdag::OGScalar<int> const SUPPRESS_UNUSED  *thing)
 {
-    throw std::runtime_error("DispatchToReal16ArrayOfArrays::visit(librdag::OGScalar<int>)");
+    throw convert_error("DispatchToReal16ArrayOfArrays::visit(librdag::OGScalar<int>)");
 }
 
 void DispatchToReal16ArrayOfArrays::visit(librdag::OGMatrix<real16> const *thing)
@@ -64,7 +64,7 @@ void DispatchToReal16ArrayOfArrays::visit(librdag::OGMatrix<real16> const *thing
 
 void DispatchToReal16ArrayOfArrays::visit(librdag::OGMatrix<complex16> const SUPPRESS_UNUSED *thing)
 {
-    throw std::runtime_error("DispatchToReal16ArrayOfArrays::visit(librdag::OGMatrix<complex16>)");
+    throw convert_error("DispatchToReal16ArrayOfArrays::visit(librdag::OGMatrix<complex16>)");
 }
 void DispatchToReal16ArrayOfArrays::visit(librdag::OGDiagonalMatrix<real16> const *thing)
 {
@@ -74,7 +74,7 @@ void DispatchToReal16ArrayOfArrays::visit(librdag::OGDiagonalMatrix<real16> cons
 }
 void DispatchToReal16ArrayOfArrays::visit(librdag::OGDiagonalMatrix<complex16> const SUPPRESS_UNUSED  *thing)
 {
-    throw std::runtime_error("DispatchToReal16ArrayOfArrays::visit(librdag::OGDiagonalMatrix<complex16>)");
+    throw convert_error("DispatchToReal16ArrayOfArrays::visit(librdag::OGDiagonalMatrix<complex16>)");
 }
 
 void DispatchToReal16ArrayOfArrays::visit(librdag::OGSparseMatrix<real16> const *thing)
@@ -85,7 +85,7 @@ void DispatchToReal16ArrayOfArrays::visit(librdag::OGSparseMatrix<real16> const 
 }
 void DispatchToReal16ArrayOfArrays::visit(librdag::OGSparseMatrix<complex16> const SUPPRESS_UNUSED  *thing)
 {
-    throw std::runtime_error("DispatchToReal16ArrayOfArrays::visit(librdag::OGSparseMatrix<complex16>)");
+    throw convert_error("DispatchToReal16ArrayOfArrays::visit(librdag::OGSparseMatrix<complex16>)");
 }
 
 void DispatchToReal16ArrayOfArrays::setData(real16 ** data)
@@ -136,7 +136,7 @@ DispatchToComplex16ArrayOfArrays::~DispatchToComplex16ArrayOfArrays()
 }
 void DispatchToComplex16ArrayOfArrays::visit(librdag::OGExpr const SUPPRESS_UNUSED *thing)
 {
-    throw std::runtime_error("DispatchToComplex16ArrayOfArrays::visit(librdag::OGExpr)");
+    throw convert_error("DispatchToComplex16ArrayOfArrays::visit(librdag::OGExpr)");
 }
 void DispatchToComplex16ArrayOfArrays::visit(librdag::OGScalar<complex16> const *thing)
 {
@@ -146,11 +146,11 @@ void DispatchToComplex16ArrayOfArrays::visit(librdag::OGScalar<complex16> const 
 }
 void DispatchToComplex16ArrayOfArrays::visit(librdag::OGScalar<real16> const SUPPRESS_UNUSED  *thing)
 {
-    throw std::runtime_error("DispatchToComplex16ArrayOfArrays::visit(librdag::OGScalar<int>)");
+    throw convert_error("DispatchToComplex16ArrayOfArrays::visit(librdag::OGScalar<real16>)");
 }
 void DispatchToComplex16ArrayOfArrays::visit(librdag::OGScalar<int> const SUPPRESS_UNUSED *thing)
 {
-    throw std::runtime_error("DispatchToComplex16ArrayOfArrays::visit(librdag::OGScalar<int>)");
+    throw convert_error("DispatchToComplex16ArrayOfArrays::visit(librdag::OGScalar<int>)");
 }
 void DispatchToComplex16ArrayOfArrays::visit(librdag::OGMatrix<complex16> const *thing)
 {
@@ -161,7 +161,7 @@ void DispatchToComplex16ArrayOfArrays::visit(librdag::OGMatrix<complex16> const 
 }
 void DispatchToComplex16ArrayOfArrays::visit(librdag::OGMatrix<real16> const SUPPRESS_UNUSED *thing)
 {
-    throw std::runtime_error("DispatchToComplex16ArrayOfArrays::visit(librdag::OGMatrix<real16>)");
+    throw convert_error("DispatchToComplex16ArrayOfArrays::visit(librdag::OGMatrix<real16>)");
 }
 void DispatchToComplex16ArrayOfArrays::visit(librdag::OGDiagonalMatrix<complex16> const *thing)
 {
@@ -172,7 +172,7 @@ void DispatchToComplex16ArrayOfArrays::visit(librdag::OGDiagonalMatrix<complex16
 }
 void DispatchToComplex16ArrayOfArrays::visit(librdag::OGDiagonalMatrix<real16> const SUPPRESS_UNUSED *thing)
 {
-    throw std::runtime_error("DispatchToComplex16ArrayOfArrays::visit(librdag::OGDiagonalMatrix<real16>)");
+    throw convert_error("DispatchToComplex16ArrayOfArrays::visit(librdag::OGDiagonalMatrix<real16>)");
 }
 void DispatchToComplex16ArrayOfArrays::visit(librdag::OGSparseMatrix<complex16> const *thing)
 {
@@ -183,7 +183,7 @@ void DispatchToComplex16ArrayOfArrays::visit(librdag::OGSparseMatrix<complex16> 
 }
 void DispatchToComplex16ArrayOfArrays::visit(librdag::OGSparseMatrix<real16> const SUPPRESS_UNUSED *thing)
 {
-    throw std::runtime_error("DispatchToComplex16ArrayOfArrays::visit(librdag::OGSparseMatrix<real16>)");
+    throw convert_error("DispatchToComplex16ArrayOfArrays::visit(librdag::OGSparseMatrix<real16>)");
 }
 void DispatchToComplex16ArrayOfArrays::setData(complex16 ** data)
 {

--- a/src/jshim/jterminals.cc
+++ b/src/jshim/jterminals.cc
@@ -8,13 +8,14 @@
 #include "jterminals.hh"
 #include "jbindings.hh"
 #include "exceptions.hh"
+#include "modifiermacros.h"
 
 namespace convert {
 
 /**
  * helper function to get ints from int getFOO() in java
  */
-jint getIntFromVoidJMethod(jmethodID id, jobject obj)
+DLLEXPORT_C jint getIntFromVoidJMethod(jmethodID id, jobject obj)
 {
   if(id==nullptr)
   {

--- a/src/jshim/jterminals.cc
+++ b/src/jshim/jterminals.cc
@@ -7,6 +7,7 @@
 #include "jvmmanager.hh"
 #include "jterminals.hh"
 #include "jbindings.hh"
+#include "exceptions.hh"
 
 namespace convert {
 
@@ -15,8 +16,20 @@ namespace convert {
  */
 jint getIntFromVoidJMethod(jmethodID id, jobject obj)
 {
-  JNIEnv *env = NULL;
+  if(id==nullptr)
+  {
+    throw convert_error("Null pointer for method id.");
+  }
+  if(obj==nullptr)
+  {
+    throw convert_error("Null pointer for jobject obj.");
+  }
+  JNIEnv *env = nullptr;
   JVMManager::getEnv((void **)&env);
+  if(env==nullptr)
+  {
+    throw convert_error("Null pointer for env from JVMManager::getEnv.");
+  }
   jint data = 0x7ff00000;
   data = env->CallIntMethod(obj, id);
   return data;

--- a/src/jshim/jterminals.cc
+++ b/src/jshim/jterminals.cc
@@ -235,17 +235,13 @@ JOGRealSparseMatrix::debug_print() const
 real16**
 JOGRealSparseMatrix::toReal16ArrayOfArrays() const
 {
-  // Returning null as no implementation yet.
-  double ** foo = NULL;
-  return foo;
+  throw convert_error("Not implemented");
 }
 
 complex16**
 JOGRealSparseMatrix::toComplex16ArrayOfArrays() const
 {
-  // Returning null as no implementation yet.
-  complex16 ** foo = NULL;
-  return foo;
+  throw convert_error("Not implemented");
 }
 
 /*
@@ -280,17 +276,13 @@ JOGComplexSparseMatrix::debug_print() const
 real16**
 JOGComplexSparseMatrix::toReal16ArrayOfArrays() const
 {
-  // Returning null as no implementation yet.
-  double ** foo = NULL;
-  return foo;
+  throw convert_error("Not implemented");
 }
 
 complex16**
 JOGComplexSparseMatrix::toComplex16ArrayOfArrays() const
 {
-  // Returning null as no implementation yet.
-  complex16 ** foo = NULL;
-  return foo;
+  throw convert_error("Not implemented");
 }
 
 /**

--- a/src/jshim/jvmmanager.cc
+++ b/src/jshim/jvmmanager.cc
@@ -350,7 +350,7 @@ void
 JVMManager::getEnv(void **penv)
 {
   jint status = _jvm->AttachCurrentThread(penv, nullptr);
-  if (status)
+  if (status!=JNI_OK)
   {
     throw convert_error("Error attaching current thread.");
   }
@@ -377,7 +377,12 @@ JVMManager::callObjectMethod(JNIEnv *env, jobject obj, jmethodID methodID, ...)
 jobject
 JVMManager::newDouble(JNIEnv* env, jdouble v)
 {
-  return env->NewObject(_DoubleClazz, _DoubleClazz_init, v);
+  jobject ret = env->NewObject(_DoubleClazz, _DoubleClazz_init, v);
+  if (!ret)
+  {
+    throw convert_error("newDouble call failed.");
+  }
+  return ret;
 }
 
 } // namespace convert

--- a/src/jshim/jvmmanager.cc
+++ b/src/jshim/jvmmanager.cc
@@ -19,10 +19,14 @@ namespace convert {
  */
 void checkEx(JNIEnv* env)
 {
-  jthrowable e = env->ExceptionOccurred();
-  if (e)
+  // Is there an exception pending?
+  if(env->ExceptionCheck()==JNI_TRUE)
   {
+    // describe it
     env->ExceptionDescribe();
+    // clear it
+    env->ExceptionClear();
+    // throw C++ exception so stack gets a chance to unwind
     throw convert_error("Java exception thrown in JNI.");
   }
 }

--- a/src/jshim/test/CMakeLists.txt
+++ b/src/jshim/test/CMakeLists.txt
@@ -10,6 +10,7 @@ SET(CMAKE_FC_FLAGS  "${CMAKE_FC_FLAGS} ${GCC_COVERAGE_COMPILE_FLAGS} -cpp" )
 set(TESTS
          check_jvmmanager_fakejni
          check_jterminals
+         check_jbindings
          )
 
 # Compile and link each test and add to the list of tests

--- a/src/jshim/test/CMakeLists.txt
+++ b/src/jshim/test/CMakeLists.txt
@@ -8,9 +8,10 @@ include_directories (${CMAKE_SOURCE_DIR}/include ${BIN_INCLUDE_DIR})
 SET(CMAKE_FC_FLAGS  "${CMAKE_FC_FLAGS} ${GCC_COVERAGE_COMPILE_FLAGS} -cpp" )
 
 set(TESTS
-         check_jvmmanager_fakejni
-         check_jterminals
          check_jbindings
+         check_jdispatch
+         check_jterminals
+         check_jvmmanager_fakejni
          )
 
 # Compile and link each test and add to the list of tests

--- a/src/jshim/test/CMakeLists.txt
+++ b/src/jshim/test/CMakeLists.txt
@@ -7,7 +7,10 @@
 include_directories (${CMAKE_SOURCE_DIR}/include ${BIN_INCLUDE_DIR})
 SET(CMAKE_FC_FLAGS  "${CMAKE_FC_FLAGS} ${GCC_COVERAGE_COMPILE_FLAGS} -cpp" )
 
-set(TESTS check_jvmmanager_fakejni)
+set(TESTS
+         check_jvmmanager_fakejni
+         check_jterminals
+         )
 
 # Compile and link each test and add to the list of tests
 foreach(TEST ${TESTS})

--- a/src/jshim/test/check_jbindings.cc
+++ b/src/jshim/test/check_jbindings.cc
@@ -35,7 +35,7 @@ class Fake_JavaVM: public JavaVM
     {
         return this->_env;
     }
-    virtual jint AttachCurrentThread(void SUPPRESS_UNUSED **penv, void SUPPRESS_UNUSED *args)
+    virtual jint AttachCurrentThread(void **penv, void SUPPRESS_UNUSED *args)
     {
       *penv = this->_env;
       return JNI_OK;
@@ -118,7 +118,7 @@ TEST(JBindings, Test_bindPrimitiveArrayData_bad_env)
 {
     class Fake_JavaVM_bad_env: public Fake_JavaVM
     {
-      virtual jint AttachCurrentThread(void SUPPRESS_UNUSED **penv, void SUPPRESS_UNUSED *args) override
+      virtual jint AttachCurrentThread(void **penv, void SUPPRESS_UNUSED *args) override
       {
         *penv = this->_env;
         return JNI_ERR;
@@ -143,9 +143,9 @@ TEST(JBindings, Test_bindPrimitiveArrayData_bad_callobjmethod)
 {
     class Fake_JNIEnv_bad_com: public Fake_JNIEnv
     {
-      virtual jobject CallObjectMethod(jobject SUPPRESS_UNUSED obj, jmethodID SUPPRESS_UNUSED methodID, ...) override
+      virtual jboolean ExceptionCheck() override
       {
-        return nullptr;
+        return JNI_TRUE;
       }
     };
     Fake_JavaVM * jvm = new Fake_JavaVM();
@@ -203,7 +203,7 @@ TEST(JBindings, Test_unbindPrimitiveArrayData_bad_env)
 {
     class Fake_JavaVM_bad_env: public Fake_JavaVM
     {
-      virtual jint AttachCurrentThread(void SUPPRESS_UNUSED **penv, void SUPPRESS_UNUSED *args) override
+      virtual jint AttachCurrentThread(void **penv, void SUPPRESS_UNUSED *args) override
       {
         *penv = this->_env;
         return JNI_ERR;
@@ -230,9 +230,9 @@ TEST(JBindings, Test_unbindPrimitiveArrayData_bad_callobjmethod)
 {
     class Fake_JNIEnv_bad_com: public Fake_JNIEnv
     {
-      virtual jobject CallObjectMethod(jobject SUPPRESS_UNUSED obj, jmethodID SUPPRESS_UNUSED methodID, ...) override
+      virtual jboolean ExceptionCheck() override
       {
-        return nullptr;
+        return JNI_TRUE;
       }
     };
     Fake_JavaVM * jvm = new Fake_JavaVM();

--- a/src/jshim/test/check_jbindings.cc
+++ b/src/jshim/test/check_jbindings.cc
@@ -13,68 +13,10 @@
 #include <iostream>
 #include "jvmmanager.hh"
 #include "debug.h"
+#include "test/fake_jvm.hh"
 
 using namespace std;
 using namespace convert;
-
-// mock JVM
-class Fake_JavaVM: public JavaVM
-{
-  public:
-    virtual ~Fake_JavaVM(){};
-    virtual int GetEnv(void ** env, int SUPPRESS_UNUSED version) override
-    {
-     *env = _env;
-     return JNI_OK;
-    }
-    void setEnv(JNIEnv * env)
-    {
-        this->_env = env;
-    }
-    JNIEnv * getEnv()
-    {
-        return this->_env;
-    }
-    virtual jint AttachCurrentThread(void **penv, void SUPPRESS_UNUSED *args)
-    {
-      *penv = this->_env;
-      return JNI_OK;
-    }
-};
-
-// mock JNIEnv
-class Fake_JNIEnv: public JNIEnv
-{
-  public:
-    Fake_JNIEnv()
-    {
-      _someNonClass = new _jclass();
-      _someNonMethodID = new _jmethodID();
-      _someNonFieldID = new _jfieldID();
-    }
-    virtual ~Fake_JNIEnv()
-    {
-      delete _someNonMethodID;
-      delete _someNonFieldID;
-      delete _someNonClass;
-    }
-    virtual jclass FindClass(const char SUPPRESS_UNUSED * name)
-    {
-      return _someNonClass;
-    }
-    virtual jmethodID GetMethodID(jclass SUPPRESS_UNUSED clazz, const char SUPPRESS_UNUSED *name, const char SUPPRESS_UNUSED *sig) override
-    {
-      return _someNonMethodID;
-    }
-    virtual jfieldID GetFieldID(jclass SUPPRESS_UNUSED clazz, const char SUPPRESS_UNUSED *name, const char SUPPRESS_UNUSED *sig) override
-    {
-      return _someNonFieldID;
-    }
-private:
-    jclass _someNonClass;
-    jmethodID _someNonMethodID;
-    jfieldID _someNonFieldID;
-};
 
 class bindRunner
 {

--- a/src/jshim/test/check_jbindings.cc
+++ b/src/jshim/test/check_jbindings.cc
@@ -1,0 +1,253 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+#include "terminal.hh"
+#include "jterminals.hh"
+#include "jbindings.hh"
+#include "gtest/gtest.h"
+#include <string>
+#include "warningmacros.h"
+#include <iostream>
+#include "jvmmanager.hh"
+#include "debug.h"
+
+using namespace std;
+using namespace convert;
+
+// mock JVM
+class Fake_JavaVM: public JavaVM
+{
+  public:
+    virtual ~Fake_JavaVM(){};
+    virtual int GetEnv(void ** env, int SUPPRESS_UNUSED version) override
+    {
+     *env = _env;
+     return JNI_OK;
+    }
+    void setEnv(JNIEnv * env)
+    {
+        this->_env = env;
+    }
+    JNIEnv * getEnv()
+    {
+        return this->_env;
+    }
+    virtual jint AttachCurrentThread(void SUPPRESS_UNUSED **penv, void SUPPRESS_UNUSED *args)
+    {
+      *penv = this->_env;
+      return JNI_OK;
+    }
+};
+
+// mock JNIEnv
+class Fake_JNIEnv: public JNIEnv
+{
+  public:
+    Fake_JNIEnv()
+    {
+      _someNonClass = new _jclass();
+      _someNonMethodID = new _jmethodID();
+      _someNonFieldID = new _jfieldID();
+    }
+    virtual ~Fake_JNIEnv()
+    {
+      delete _someNonMethodID;
+      delete _someNonFieldID;
+      delete _someNonClass;
+    }
+    virtual jclass FindClass(const char SUPPRESS_UNUSED * name)
+    {
+      return _someNonClass;
+    }
+    virtual jmethodID GetMethodID(jclass SUPPRESS_UNUSED clazz, const char SUPPRESS_UNUSED *name, const char SUPPRESS_UNUSED *sig) override
+    {
+      return _someNonMethodID;
+    }
+    virtual jfieldID GetFieldID(jclass SUPPRESS_UNUSED clazz, const char SUPPRESS_UNUSED *name, const char SUPPRESS_UNUSED *sig) override
+    {
+      return _someNonFieldID;
+    }
+private:
+    jclass _someNonClass;
+    jmethodID _someNonMethodID;
+    jfieldID _someNonFieldID;
+};
+
+class bindRunner
+{
+  public:
+    void run(jobject obj, jmethodID meth)
+    {
+      bindPrimitiveArrayData<real16, jdoubleArray>(obj, meth);
+    }
+};
+
+class unbindRunner
+{
+  public:
+    void run(real16 * nativedata, jobject obj, jmethodID meth)
+    {
+      unbindPrimitiveArrayData<real16, jdoubleArray>(nativedata,obj, meth);
+    }
+};
+
+TEST(JBindings, Test_bindPrimitiveArrayData_bad_obj)
+{
+    jobject obj = nullptr;
+    jmethodID meth = new _jmethodID();
+    bindRunner * clazz = new bindRunner();
+    ASSERT_ANY_THROW(clazz->run(obj,meth));
+    delete clazz;
+    delete meth;
+}
+
+TEST(JBindings, Test_bindPrimitiveArrayData_bad_method)
+{
+    jobject obj = new _jobject();
+    jmethodID meth = nullptr;
+    bindRunner * clazz = new bindRunner();
+    ASSERT_ANY_THROW(clazz->run(obj,meth));
+    delete obj;
+    delete clazz;
+}
+
+TEST(JBindings, Test_bindPrimitiveArrayData_bad_env)
+{
+    class Fake_JavaVM_bad_env: public Fake_JavaVM
+    {
+      virtual jint AttachCurrentThread(void SUPPRESS_UNUSED **penv, void SUPPRESS_UNUSED *args) override
+      {
+        *penv = this->_env;
+        return JNI_ERR;
+      }
+    };
+    Fake_JavaVM * jvm = new Fake_JavaVM_bad_env();
+    Fake_JNIEnv * env  = new Fake_JNIEnv();
+    jvm->setEnv(env);
+    JVMManager::initialize(jvm);
+    jobject obj = new _jobject();
+    jmethodID meth = new _jmethodID();
+    bindRunner * clazz = new bindRunner();
+    ASSERT_ANY_THROW(clazz->run(obj,meth));
+    delete jvm;
+    delete env;
+    delete obj;
+    delete meth;
+    delete clazz;
+}
+
+TEST(JBindings, Test_bindPrimitiveArrayData_bad_callobjmethod)
+{
+    class Fake_JNIEnv_bad_com: public Fake_JNIEnv
+    {
+      virtual jobject CallObjectMethod(jobject SUPPRESS_UNUSED obj, jmethodID SUPPRESS_UNUSED methodID, ...) override
+      {
+        return nullptr;
+      }
+    };
+    Fake_JavaVM * jvm = new Fake_JavaVM();
+    Fake_JNIEnv * env  = new Fake_JNIEnv_bad_com();
+    jvm->setEnv(env);
+    JVMManager::initialize(jvm);
+    jobject obj = new _jobject();
+    jmethodID meth = new _jmethodID();
+    bindRunner * clazz = new bindRunner();
+    ASSERT_ANY_THROW(clazz->run(obj,meth));
+    delete jvm;
+    delete env;
+    delete obj;
+    delete meth;
+    delete clazz;
+}
+
+TEST(JBindings, Test_unbindPrimitiveArrayData_bad_data)
+{
+  real16 * data = nullptr;
+  jobject obj = new _jobject();
+  jmethodID meth = new _jmethodID();
+  unbindRunner * clazz = new unbindRunner();
+  ASSERT_ANY_THROW(clazz->run(data,obj,meth));
+  delete obj;
+  delete meth;
+  delete clazz;
+}
+
+TEST(JBindings, Test_unbindPrimitiveArrayData_bad_obj)
+{
+  real16 * data = new real16[1];
+  jobject obj = nullptr;
+  jmethodID meth = new _jmethodID();
+  unbindRunner * clazz = new unbindRunner();
+  ASSERT_ANY_THROW(clazz->run(data,obj,meth));
+  delete[] data;
+  delete meth;
+  delete clazz;
+}
+
+TEST(JBindings, Test_unbindPrimitiveArrayData_bad_meth)
+{
+  real16 * data = new real16[1];
+  jobject obj = new _jobject();
+  jmethodID meth = nullptr;
+  unbindRunner * clazz = new unbindRunner();
+  ASSERT_ANY_THROW(clazz->run(data,obj,meth));
+  delete[] data;
+  delete obj;
+  delete clazz;
+}
+
+TEST(JBindings, Test_unbindPrimitiveArrayData_bad_env)
+{
+    class Fake_JavaVM_bad_env: public Fake_JavaVM
+    {
+      virtual jint AttachCurrentThread(void SUPPRESS_UNUSED **penv, void SUPPRESS_UNUSED *args) override
+      {
+        *penv = this->_env;
+        return JNI_ERR;
+      }
+    };
+    Fake_JavaVM * jvm = new Fake_JavaVM_bad_env();
+    Fake_JNIEnv * env  = new Fake_JNIEnv();
+    jvm->setEnv(env);
+    JVMManager::initialize(jvm);
+    real16 * data = new real16[1];
+    jobject obj = new _jobject();
+    jmethodID meth = new _jmethodID();
+    unbindRunner * clazz = new unbindRunner();
+    ASSERT_ANY_THROW(clazz->run(data,obj,meth));
+    delete jvm;
+    delete env;
+    delete[] data;
+    delete obj;
+    delete meth;
+    delete clazz;
+}
+
+TEST(JBindings, Test_unbindPrimitiveArrayData_bad_callobjmethod)
+{
+    class Fake_JNIEnv_bad_com: public Fake_JNIEnv
+    {
+      virtual jobject CallObjectMethod(jobject SUPPRESS_UNUSED obj, jmethodID SUPPRESS_UNUSED methodID, ...) override
+      {
+        return nullptr;
+      }
+    };
+    Fake_JavaVM * jvm = new Fake_JavaVM();
+    Fake_JNIEnv * env  = new Fake_JNIEnv_bad_com();
+    jvm->setEnv(env);
+    JVMManager::initialize(jvm);
+    real16 * data = new real16[1];
+    jobject obj = new _jobject();
+    jmethodID meth = new _jmethodID();
+    unbindRunner * clazz = new unbindRunner();
+    ASSERT_ANY_THROW(clazz->run(data,obj,meth));
+    delete jvm;
+    delete env;
+    delete[] data;
+    delete obj;
+    delete meth;
+    delete clazz;
+}

--- a/src/jshim/test/check_jdispatch.cc
+++ b/src/jshim/test/check_jdispatch.cc
@@ -313,3 +313,100 @@ TEST(JDispatch, Test_DispatchToComplex16ArrayOfArrays_OGComplexMatrix)
   delete d;
   delete mat;
 }
+
+TEST(JDispatch, Test_DispatchToComplex16ArrayOfArrays_OGRealMatrix)
+{
+  DispatchToComplex16ArrayOfArrays * d = new DispatchToComplex16ArrayOfArrays();
+  OGRealMatrix * mat = new OGOwningRealMatrix(new real16[4]{1,2,3,4},2,2);
+  ASSERT_ANY_THROW(d->visit(mat));
+  delete d;
+  delete mat;
+}
+
+TEST(JDispatch, Test_DispatchToComplex16ArrayOfArrays_OGComplexDiagonalMatrix)
+{
+  DispatchToComplex16ArrayOfArrays * d = new DispatchToComplex16ArrayOfArrays();
+  const int rows = 3;
+  const int cols = 2;
+  const int dlen = rows > cols ? cols:rows;
+  complex16 * data = new complex16[dlen]{10,20};
+  complex16 ** dataAoA = new complex16 * [rows];
+  dataAoA[0] = new complex16[cols]{10,0};
+  dataAoA[1] = new complex16[cols]{0,20};
+  dataAoA[2] = new complex16[cols]{0,0};
+  OGComplexDiagonalMatrix * mat = new OGComplexDiagonalMatrix(data,rows,cols);
+  d->visit(mat);
+  ASSERT_TRUE(d->getRows()==rows);
+  ASSERT_TRUE(d->getCols()==cols);
+  for(int k = 0; k < rows; k++)
+  {
+    ASSERT_TRUE(ArrayFuzzyEquals(d->getData()[k],dataAoA[k],cols));
+    delete[] dataAoA[k];
+  }
+  delete [] dataAoA;
+  delete [] data;
+  delete d;
+  delete mat;
+}
+
+TEST(JDispatch, Test_DispatchToComplex16ArrayOfArrays_OGRealDiagonalMatrix)
+{
+  DispatchToComplex16ArrayOfArrays * d = new DispatchToComplex16ArrayOfArrays();
+  real16 * data = new real16[1]{12};
+  OGRealDiagonalMatrix * mat = new OGRealDiagonalMatrix(data,1,1);
+  ASSERT_ANY_THROW(d->visit(mat));
+  delete d;
+  delete mat;
+  delete [] data;
+}
+
+TEST(JDispatch, Test_DispatchToComplex16ArrayOfArrays_OGComplexSparseMatrix)
+{
+  DispatchToComplex16ArrayOfArrays * d = new DispatchToComplex16ArrayOfArrays();
+  const int rows = 4;
+  const int cols = 3;
+  complex16 ** dataAoA = new complex16 * [rows];
+  dataAoA[0] = new complex16[cols]{ {1,10}, {2,20}, {0,0} };
+  dataAoA[1] = new complex16[cols]{ {0,0} , {3,30}, {0,0} };
+  dataAoA[2] = new complex16[cols]{ {4,40}, {0,0} , {0,0} };
+  dataAoA[3] = new complex16[cols]{ {0,0} , {0,0} , {5,50} };
+
+  complex16 * data= new complex16[5]{{1.0,10.0}, {4.0,40}, {2.0,20}, {3.0,30}, {5.0,50}};
+  int * rowInd=new int[5]{0, 2, 0, 1, 3};
+  int * colPtr=new int[4]{0, 2, 4, 5};
+
+  OGComplexSparseMatrix * mat = new OGComplexSparseMatrix(colPtr, rowInd, data, rows, cols);
+  d->visit(mat);
+  ASSERT_TRUE(d->getRows()==rows);
+  ASSERT_TRUE(d->getCols()==cols);
+  for(int k = 0; k < rows; k++)
+  {
+    ASSERT_TRUE(ArrayFuzzyEquals(d->getData()[k],dataAoA[k],cols));
+    delete[] dataAoA[k];
+  }
+  delete [] dataAoA;
+  delete d;
+  delete mat;
+  delete[] data;
+  delete[] rowInd;
+  delete[] colPtr;
+}
+
+TEST(JDispatch, Test_DispatchToComplex16ArrayOfArrays_OGRealSparseMatrix)
+{
+
+  DispatchToComplex16ArrayOfArrays * d = new DispatchToComplex16ArrayOfArrays();
+  const int rows = 4;
+  const int cols = 3;
+  real16 * data= new real16[5]{1,4,2,3,5};
+  int * rowInd=new int[5]{0, 2, 0, 1, 3};
+  int * colPtr=new int[4]{0, 2, 4, 5};
+
+  OGRealSparseMatrix * mat = new OGRealSparseMatrix(colPtr, rowInd, data, rows, cols);
+  ASSERT_ANY_THROW(d->visit(mat));
+  delete d;
+  delete mat;
+  delete[] data;
+  delete[] rowInd;
+  delete[] colPtr;
+}

--- a/src/jshim/test/check_jdispatch.cc
+++ b/src/jshim/test/check_jdispatch.cc
@@ -14,68 +14,10 @@
 #include "jvmmanager.hh"
 #include "debug.h"
 #include "equals.hh"
+#include "test/fake_jvm.hh"
 
 using namespace std;
 using namespace convert;
-
-// mock JVM
-class Fake_JavaVM: public JavaVM
-{
-  public:
-    virtual ~Fake_JavaVM(){};
-    virtual int GetEnv(void ** env, int SUPPRESS_UNUSED version) override
-    {
-     *env = _env;
-     return JNI_OK;
-    }
-    void setEnv(JNIEnv * env)
-    {
-        this->_env = env;
-    }
-    JNIEnv * getEnv()
-    {
-        return this->_env;
-    }
-    virtual jint AttachCurrentThread(void SUPPRESS_UNUSED **penv, void SUPPRESS_UNUSED *args)
-    {
-      *penv = this->_env;
-      return JNI_OK;
-    }
-};
-
-// mock JNIEnv
-class Fake_JNIEnv: public JNIEnv
-{
-  public:
-    Fake_JNIEnv()
-    {
-      _someNonClass = new _jclass();
-      _someNonMethodID = new _jmethodID();
-      _someNonFieldID = new _jfieldID();
-    }
-    virtual ~Fake_JNIEnv()
-    {
-      delete _someNonMethodID;
-      delete _someNonFieldID;
-      delete _someNonClass;
-    }
-    virtual jclass FindClass(const char SUPPRESS_UNUSED * name)
-    {
-      return _someNonClass;
-    }
-    virtual jmethodID GetMethodID(jclass SUPPRESS_UNUSED clazz, const char SUPPRESS_UNUSED *name, const char SUPPRESS_UNUSED *sig) override
-    {
-      return _someNonMethodID;
-    }
-    virtual jfieldID GetFieldID(jclass SUPPRESS_UNUSED clazz, const char SUPPRESS_UNUSED *name, const char SUPPRESS_UNUSED *sig) override
-    {
-      return _someNonFieldID;
-    }
-private:
-    jclass _someNonClass;
-    jmethodID _someNonMethodID;
-    jfieldID _someNonFieldID;
-};
 
 // test dispatch to real AoA
 

--- a/src/jshim/test/check_jdispatch.cc
+++ b/src/jshim/test/check_jdispatch.cc
@@ -77,6 +77,8 @@ private:
     jfieldID _someNonFieldID;
 };
 
+// test dispatch to real AoA
+
 TEST(JDispatch, Test_DispatchToReal16ArrayOfArrays_OGExpr)
 {
   DispatchToReal16ArrayOfArrays * d = new DispatchToReal16ArrayOfArrays();
@@ -190,6 +192,60 @@ TEST(JDispatch, Test_DispatchToReal16ArrayOfArrays_OGComplexDiagonalMatrix)
   delete mat;
   delete [] data;
 }
+
+
+TEST(JDispatch, Test_DispatchToReal16ArrayOfArrays_OGRealSparseMatrix)
+{
+  DispatchToReal16ArrayOfArrays * d = new DispatchToReal16ArrayOfArrays();
+  const int rows = 4;
+  const int cols = 3;
+  real16 ** dataAoA = new real16 * [rows];
+  dataAoA[0] = new real16[cols]{ 1, 2, 0 };
+  dataAoA[1] = new real16[cols]{ 0, 3, 0 };
+  dataAoA[2] = new real16[cols]{ 4, 0, 0 };
+  dataAoA[3] = new real16[cols]{ 0, 0, 5 };
+
+  real16 * data= new real16[5]{1.0, 4.0, 2.0, 3.0, 5.0};
+  int * rowInd=new int[5]{0, 2, 0, 1, 3};
+  int * colPtr=new int[4]{0, 2, 4, 5};
+
+  OGRealSparseMatrix * mat = new OGRealSparseMatrix(colPtr, rowInd, data, rows, cols);
+  d->visit(mat);
+  ASSERT_TRUE(d->getRows()==rows);
+  ASSERT_TRUE(d->getCols()==cols);
+  for(int k = 0; k < rows; k++)
+  {
+    ASSERT_TRUE(ArrayFuzzyEquals(d->getData()[k],dataAoA[k],cols));
+    delete[] dataAoA[k];
+  }
+  delete [] dataAoA;
+  delete d;
+  delete mat;
+  delete[] data;
+  delete[] rowInd;
+  delete[] colPtr;
+}
+
+TEST(JDispatch, Test_DispatchToReal16ArrayOfArrays_OGComplexSparseMatrix)
+{
+  DispatchToReal16ArrayOfArrays * d = new DispatchToReal16ArrayOfArrays();
+  const int rows = 4;
+  const int cols = 3;
+  complex16 * data= new complex16[5]{{1.0,10}, {4.0,40}, {2.0,20}, {3.0,30}, {5.0,50}};
+  int * rowInd=new int[5]{0, 2, 0, 1, 3};
+  int * colPtr=new int[4]{0, 2, 4, 5};
+
+  OGComplexSparseMatrix * mat = new OGComplexSparseMatrix(colPtr, rowInd, data, rows, cols);
+  ASSERT_ANY_THROW(d->visit(mat));
+  delete d;
+  delete mat;
+  delete[] data;
+  delete[] rowInd;
+  delete[] colPtr;
+}
+
+
+// test dispatch to complex AoA
 
 TEST(JDispatch, Test_DispatchToComplex16ArrayOfArrays_OGComplexMatrix)
 {

--- a/src/jshim/test/check_jdispatch.cc
+++ b/src/jshim/test/check_jdispatch.cc
@@ -77,6 +77,50 @@ private:
     jfieldID _someNonFieldID;
 };
 
+TEST(JDispatch, Test_DispatchToReal16ArrayOfArrays_OGExpr)
+{
+  DispatchToReal16ArrayOfArrays * d = new DispatchToReal16ArrayOfArrays();
+  OGRealScalar * scal = new OGRealScalar(10);
+  ArgContainer * args = new ArgContainer();
+  args->push_back(scal);
+  OGExpr * expr = new NORM2(args);
+  ASSERT_ANY_THROW(d->visit(expr));
+  delete d;
+  delete expr;
+}
+
+TEST(JDispatch, Test_DispatchToReal16ArrayOfArrays_OGRealScalar)
+{
+  DispatchToReal16ArrayOfArrays * d = new DispatchToReal16ArrayOfArrays();
+  real16 value = 1234;
+  OGRealScalar * scal = new OGRealScalar(value);
+  d->visit(scal);
+  ASSERT_TRUE(d->getRows()==1);
+  ASSERT_TRUE(d->getCols()==1);
+  ASSERT_TRUE(SingleValueFuzzyEquals(d->getData()[0][0],value));
+  delete d;
+  delete scal;
+}
+
+TEST(JDispatch, Test_DispatchToReal16ArrayOfArrays_OGComplexScalar)
+{
+  DispatchToReal16ArrayOfArrays * d = new DispatchToReal16ArrayOfArrays();
+  OGComplexScalar * scal = new OGComplexScalar({1,2});
+  ASSERT_ANY_THROW(d->visit(scal));
+  delete d;
+  delete scal;
+}
+
+TEST(JDispatch, Test_DispatchToReal16ArrayOfArrays_OGIntegerScalar)
+{
+  DispatchToReal16ArrayOfArrays * d = new DispatchToReal16ArrayOfArrays();
+  OGIntegerScalar * scal = new OGIntegerScalar(12);
+  ASSERT_ANY_THROW(d->visit(scal));
+  delete d;
+  delete scal;
+}
+
+
 TEST(JDispatch, Test_DispatchToReal16ArrayOfArrays_OGRealMatrix)
 {
   DispatchToReal16ArrayOfArrays * d = new DispatchToReal16ArrayOfArrays();
@@ -101,6 +145,52 @@ TEST(JDispatch, Test_DispatchToReal16ArrayOfArrays_OGRealMatrix)
   delete mat;
 }
 
+TEST(JDispatch, Test_DispatchToReal16ArrayOfArrays_OGComplexMatrix)
+{
+  DispatchToReal16ArrayOfArrays * d = new DispatchToReal16ArrayOfArrays();
+  OGOwningComplexMatrix * mat = new OGOwningComplexMatrix(new complex16[1]{12},1,1);
+  ASSERT_ANY_THROW(d->visit(mat));
+  delete d;
+  delete mat;
+}
+
+TEST(JDispatch, Test_DispatchToReal16ArrayOfArrays_OGRealDiagonalMatrix)
+{
+  DispatchToReal16ArrayOfArrays * d = new DispatchToReal16ArrayOfArrays();
+  const int rows = 3;
+  const int cols = 2;
+  const int dlen = rows > cols ? cols:rows;
+  real16 * data = new real16[dlen]{10,20};
+  real16 ** dataAoA = new real16 * [rows];
+  dataAoA[0] = new real16[cols]{10,0};
+  dataAoA[1] = new real16[cols]{0,20};
+  dataAoA[2] = new real16[cols]{0,0};
+  OGRealDiagonalMatrix * mat = new OGRealDiagonalMatrix(data,rows,cols);
+  d->visit(mat);
+  ASSERT_TRUE(d->getRows()==rows);
+  ASSERT_TRUE(d->getCols()==cols);
+  for(int k = 0; k < rows; k++)
+  {
+    ASSERT_TRUE(ArrayFuzzyEquals(d->getData()[k],dataAoA[k],cols));
+    delete[] dataAoA[k];
+  }
+  delete [] dataAoA;
+  delete [] data;
+  delete d;
+  delete mat;
+}
+
+TEST(JDispatch, Test_DispatchToReal16ArrayOfArrays_OGComplexDiagonalMatrix)
+{
+  DispatchToReal16ArrayOfArrays * d = new DispatchToReal16ArrayOfArrays();
+  complex16 * data = new complex16[1]{12};
+  OGComplexDiagonalMatrix * mat = new OGComplexDiagonalMatrix(data,1,1);
+  ASSERT_ANY_THROW(d->visit(mat));
+  delete d;
+  delete mat;
+  delete [] data;
+}
+
 TEST(JDispatch, Test_DispatchToComplex16ArrayOfArrays_OGComplexMatrix)
 {
   DispatchToComplex16ArrayOfArrays * d = new DispatchToComplex16ArrayOfArrays();
@@ -123,27 +213,4 @@ TEST(JDispatch, Test_DispatchToComplex16ArrayOfArrays_OGComplexMatrix)
   delete [] dataAoA;
   delete d;
   delete mat;
-}
-
-
-TEST(JDispatch, Test_DispatchToReal16ArrayOfArrays_OGRealScalar)
-{
-  DispatchToReal16ArrayOfArrays * d = new DispatchToReal16ArrayOfArrays();
-  real16 value = 1234;
-  OGRealScalar * scal = new OGRealScalar(value);
-  d->visit(scal);
-  ASSERT_TRUE(d->getRows()==1);
-  ASSERT_TRUE(d->getCols()==1);
-  ASSERT_TRUE(SingleValueFuzzyEquals(d->getData()[0][0],value));
-  delete d;
-  delete scal;
-}
-
-TEST(JDispatch, Test_DispatchToReal16ArrayOfArrays_OGComplexScalar)
-{
-  DispatchToReal16ArrayOfArrays * d = new DispatchToReal16ArrayOfArrays();
-  OGComplexScalar * scal = new OGComplexScalar({1,2});
-  ASSERT_ANY_THROW(d->visit(scal));
-  delete d;
-  delete scal;
 }

--- a/src/jshim/test/check_jdispatch.cc
+++ b/src/jshim/test/check_jdispatch.cc
@@ -247,6 +247,49 @@ TEST(JDispatch, Test_DispatchToReal16ArrayOfArrays_OGComplexSparseMatrix)
 
 // test dispatch to complex AoA
 
+TEST(JDispatch, Test_DispatchToComplex16ArrayOfArrays_OGExpr)
+{
+  DispatchToComplex16ArrayOfArrays * d = new DispatchToComplex16ArrayOfArrays();
+  OGRealScalar * scal = new OGRealScalar(10);
+  ArgContainer * args = new ArgContainer();
+  args->push_back(scal);
+  OGExpr * expr = new NORM2(args);
+  ASSERT_ANY_THROW(d->visit(expr));
+  delete d;
+  delete expr;
+}
+
+TEST(JDispatch, Test_DispatchToComplex16ArrayOfArrays_OGComplexScalar)
+{
+  DispatchToComplex16ArrayOfArrays * d = new DispatchToComplex16ArrayOfArrays();
+  complex16 value = {1234,5678};
+  OGComplexScalar * scal = new OGComplexScalar(value);
+  d->visit(scal);
+  ASSERT_TRUE(d->getRows()==1);
+  ASSERT_TRUE(d->getCols()==1);
+  ASSERT_TRUE(SingleValueFuzzyEquals(d->getData()[0][0],value));
+  delete d;
+  delete scal;
+}
+
+TEST(JDispatch, Test_DispatchToComplex16ArrayOfArrays_OGRealScalar)
+{
+  DispatchToComplex16ArrayOfArrays * d = new DispatchToComplex16ArrayOfArrays();
+  OGRealScalar * scal = new OGRealScalar(1234);
+  ASSERT_ANY_THROW(d->visit(scal));
+  delete d;
+  delete scal;
+}
+
+TEST(JDispatch, Test_DispatchToComplex16ArrayOfArrays_OGIntegerScalar)
+{
+  DispatchToComplex16ArrayOfArrays * d = new DispatchToComplex16ArrayOfArrays();
+  OGIntegerScalar * scal = new OGIntegerScalar(10);
+  ASSERT_ANY_THROW(d->visit(scal));
+  delete d;
+  delete scal;
+}
+
 TEST(JDispatch, Test_DispatchToComplex16ArrayOfArrays_OGComplexMatrix)
 {
   DispatchToComplex16ArrayOfArrays * d = new DispatchToComplex16ArrayOfArrays();

--- a/src/jshim/test/check_jdispatch.cc
+++ b/src/jshim/test/check_jdispatch.cc
@@ -1,0 +1,126 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+#include "terminal.hh"
+#include "jterminals.hh"
+#include "jdispatch.hh"
+#include "gtest/gtest.h"
+#include <string>
+#include "warningmacros.h"
+#include <iostream>
+#include "jvmmanager.hh"
+#include "debug.h"
+#include "equals.hh"
+
+using namespace std;
+using namespace convert;
+
+// mock JVM
+class Fake_JavaVM: public JavaVM
+{
+  public:
+    virtual ~Fake_JavaVM(){};
+    virtual int GetEnv(void ** env, int SUPPRESS_UNUSED version) override
+    {
+     *env = _env;
+     return JNI_OK;
+    }
+    void setEnv(JNIEnv * env)
+    {
+        this->_env = env;
+    }
+    JNIEnv * getEnv()
+    {
+        return this->_env;
+    }
+    virtual jint AttachCurrentThread(void SUPPRESS_UNUSED **penv, void SUPPRESS_UNUSED *args)
+    {
+      *penv = this->_env;
+      return JNI_OK;
+    }
+};
+
+// mock JNIEnv
+class Fake_JNIEnv: public JNIEnv
+{
+  public:
+    Fake_JNIEnv()
+    {
+      _someNonClass = new _jclass();
+      _someNonMethodID = new _jmethodID();
+      _someNonFieldID = new _jfieldID();
+    }
+    virtual ~Fake_JNIEnv()
+    {
+      delete _someNonMethodID;
+      delete _someNonFieldID;
+      delete _someNonClass;
+    }
+    virtual jclass FindClass(const char SUPPRESS_UNUSED * name)
+    {
+      return _someNonClass;
+    }
+    virtual jmethodID GetMethodID(jclass SUPPRESS_UNUSED clazz, const char SUPPRESS_UNUSED *name, const char SUPPRESS_UNUSED *sig) override
+    {
+      return _someNonMethodID;
+    }
+    virtual jfieldID GetFieldID(jclass SUPPRESS_UNUSED clazz, const char SUPPRESS_UNUSED *name, const char SUPPRESS_UNUSED *sig) override
+    {
+      return _someNonFieldID;
+    }
+private:
+    jclass _someNonClass;
+    jmethodID _someNonMethodID;
+    jfieldID _someNonFieldID;
+};
+
+TEST(JDispatch, Test_DispatchToReal16ArrayOfArrays_ctor_dtor)
+{
+  DispatchToReal16ArrayOfArrays * d = new DispatchToReal16ArrayOfArrays();
+  const int rows = 3;
+  const int cols = 2;
+  real16 * data = new real16[rows*cols]{1,3,5,2,4,6};
+  real16 ** dataAoA = new real16 * [rows];
+  dataAoA[0] = new real16[cols]{1,2};
+  dataAoA[1] = new real16[cols]{3,4};
+  dataAoA[2] = new real16[cols]{5,6};
+  OGRealMatrix * mat = new OGOwningRealMatrix(data,rows,cols);
+  d->visit(mat);
+  ASSERT_TRUE(d->getRows()==rows);
+  ASSERT_TRUE(d->getCols()==cols);
+  for(int k = 0; k < rows; k++)
+  {
+    ASSERT_TRUE(ArrayFuzzyEquals(d->getData()[k],dataAoA[k],cols));
+    delete[] dataAoA[k];
+  }
+  delete [] dataAoA;
+  delete d;
+  delete mat;
+}
+
+TEST(JDispatch, Test_DispatchToComplex16ArrayOfArrays_ctor_dtor)
+{
+  DispatchToComplex16ArrayOfArrays * d = new DispatchToComplex16ArrayOfArrays();
+  const int rows = 3;
+  const int cols = 2;
+  complex16 * data = new complex16[rows*cols]{{1,10},{3,30},{5,50},{2,20},{4,40},{6,60}};
+  complex16 ** dataAoA = new complex16 * [rows];
+  dataAoA[0] = new complex16[cols]{{1,10},{2,20}};
+  dataAoA[1] = new complex16[cols]{{3,30},{4,40}};
+  dataAoA[2] = new complex16[cols]{{5,50},{6,60}};
+  OGComplexMatrix * mat = new OGOwningComplexMatrix(data,rows,cols);
+  d->visit(mat);
+  ASSERT_TRUE(d->getRows()==rows);
+  ASSERT_TRUE(d->getCols()==cols);
+  for(int k = 0; k < rows; k++)
+  {
+    ASSERT_TRUE(ArrayFuzzyEquals(d->getData()[k],dataAoA[k],cols));
+    delete[] dataAoA[k];
+  }
+  delete [] dataAoA;
+  delete d;
+  delete mat;
+}

--- a/src/jshim/test/check_jdispatch.cc
+++ b/src/jshim/test/check_jdispatch.cc
@@ -77,7 +77,7 @@ private:
     jfieldID _someNonFieldID;
 };
 
-TEST(JDispatch, Test_DispatchToReal16ArrayOfArrays_ctor_dtor)
+TEST(JDispatch, Test_DispatchToReal16ArrayOfArrays_OGRealMatrix)
 {
   DispatchToReal16ArrayOfArrays * d = new DispatchToReal16ArrayOfArrays();
   const int rows = 3;
@@ -101,7 +101,7 @@ TEST(JDispatch, Test_DispatchToReal16ArrayOfArrays_ctor_dtor)
   delete mat;
 }
 
-TEST(JDispatch, Test_DispatchToComplex16ArrayOfArrays_ctor_dtor)
+TEST(JDispatch, Test_DispatchToComplex16ArrayOfArrays_OGComplexMatrix)
 {
   DispatchToComplex16ArrayOfArrays * d = new DispatchToComplex16ArrayOfArrays();
   const int rows = 3;
@@ -123,4 +123,27 @@ TEST(JDispatch, Test_DispatchToComplex16ArrayOfArrays_ctor_dtor)
   delete [] dataAoA;
   delete d;
   delete mat;
+}
+
+
+TEST(JDispatch, Test_DispatchToReal16ArrayOfArrays_OGRealScalar)
+{
+  DispatchToReal16ArrayOfArrays * d = new DispatchToReal16ArrayOfArrays();
+  real16 value = 1234;
+  OGRealScalar * scal = new OGRealScalar(value);
+  d->visit(scal);
+  ASSERT_TRUE(d->getRows()==1);
+  ASSERT_TRUE(d->getCols()==1);
+  ASSERT_TRUE(SingleValueFuzzyEquals(d->getData()[0][0],value));
+  delete d;
+  delete scal;
+}
+
+TEST(JDispatch, Test_DispatchToReal16ArrayOfArrays_OGComplexScalar)
+{
+  DispatchToReal16ArrayOfArrays * d = new DispatchToReal16ArrayOfArrays();
+  OGComplexScalar * scal = new OGComplexScalar({1,2});
+  ASSERT_ANY_THROW(d->visit(scal));
+  delete d;
+  delete scal;
 }

--- a/src/jshim/test/check_jterminals.cc
+++ b/src/jshim/test/check_jterminals.cc
@@ -128,7 +128,7 @@ template<typename T> class Fake_JNIEnv_for_binding: public Fake_JNIEnv
       _value = value;
     }
     // fake object call returns obj
-    virtual jobject CallObjectMethod(jobject SUPPRESS_UNUSED obj, jmethodID SUPPRESS_UNUSED methodID, ...) override
+    virtual jobject CallObjectMethod(jobject obj, jmethodID SUPPRESS_UNUSED methodID, ...) override
     {
         return obj;
     }
@@ -214,9 +214,9 @@ TEST(JTerminals, Test_binding_getArrayFromJava_bad_GetDoubleArrayElements)
     class Fake_JNIEnv_for_binding_bad: public Fake_JNIEnv_for_binding<real16>
     {
       using Fake_JNIEnv_for_binding<real16>::Fake_JNIEnv_for_binding;
-      virtual real16 * GetDoubleArrayElements(jdoubleArray SUPPRESS_UNUSED arr, bool  SUPPRESS_UNUSED *isCopy) override
+      virtual jboolean ExceptionCheck() override
       {
-        return nullptr;
+        return JNI_TRUE;
       }
     };
     Fake_JNIEnv * env  = new Fake_JNIEnv_for_binding_bad(value);
@@ -238,9 +238,9 @@ TEST(JTerminals, Test_binding_getArrayFromJava_bad_GetIntArrayElements)
     class Fake_JNIEnv_for_binding_bad: public Fake_JNIEnv_for_binding<real16>
     {
       using Fake_JNIEnv_for_binding<real16>::Fake_JNIEnv_for_binding;
-      virtual int * GetIntArrayElements(jintArray SUPPRESS_UNUSED arr, bool  SUPPRESS_UNUSED *isCopy) override
+      virtual jboolean ExceptionCheck() override
       {
-        return nullptr;
+        return JNI_TRUE;
       }
     };
     Fake_JNIEnv * env  = new Fake_JNIEnv_for_binding_bad(value);
@@ -266,7 +266,7 @@ template<typename T>class Fake_JNIEnv_for_OGMatrix_T: public Fake_JNIEnv
     virtual jint CallIntMethod(jobject SUPPRESS_UNUSED obj, jmethodID SUPPRESS_UNUSED methodID, ...) {
       return _rows;
     }
-    virtual jobject CallObjectMethod(jobject SUPPRESS_UNUSED obj, jmethodID SUPPRESS_UNUSED methodID, ...) override
+    virtual jobject CallObjectMethod(jobject obj, jmethodID SUPPRESS_UNUSED methodID, ...) override
     {
         return obj;
     }
@@ -415,7 +415,7 @@ template<typename T>class Fake_JNIEnv_for_OGSparseMatrix_T: public Fake_JNIEnv_f
     virtual jint CallIntMethod(jobject SUPPRESS_UNUSED obj, jmethodID SUPPRESS_UNUSED methodID, ...) {
       return this->_rows;
     }
-    virtual jobject CallObjectMethod(jobject SUPPRESS_UNUSED obj, jmethodID SUPPRESS_UNUSED methodID, ...) override
+    virtual jobject CallObjectMethod(jobject obj, jmethodID SUPPRESS_UNUSED methodID, ...) override
     {
         return obj;
     }

--- a/src/jshim/test/check_jterminals.cc
+++ b/src/jshim/test/check_jterminals.cc
@@ -1,0 +1,241 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+#include "terminal.hh"
+#include "jterminals.hh"
+#include "jbindings.hh"
+#include "gtest/gtest.h"
+#include <string>
+#include "warningmacros.h"
+#include <iostream>
+#include "jvmmanager.hh"
+#include "debug.h"
+
+using namespace std;
+using namespace convert;
+
+// mock JVM
+class Fake_JavaVM: public JavaVM
+{
+  public:
+    virtual ~Fake_JavaVM(){};
+    virtual int GetEnv(void ** env, int SUPPRESS_UNUSED version) override
+    {
+     *env = _env;
+     return JNI_OK;
+    }
+    void setEnv(JNIEnv * env)
+    {
+        this->_env = env;
+    }
+    JNIEnv * getEnv()
+    {
+        return this->_env;
+    }
+    virtual jint AttachCurrentThread(void SUPPRESS_UNUSED **penv, void SUPPRESS_UNUSED *args)
+    {
+      *penv = this->_env;
+      return JNI_OK;
+    }
+};
+
+// mock JNIEnv
+class Fake_JNIEnv: public JNIEnv
+{
+  public:
+    Fake_JNIEnv()
+    {
+      _someNonClass = new _jclass();
+      _someNonMethodID = new _jmethodID();
+      _someNonFieldID = new _jfieldID();
+    }
+    virtual ~Fake_JNIEnv()
+    {
+      delete _someNonMethodID;
+      delete _someNonFieldID;
+      delete _someNonClass;
+    }
+    virtual jclass FindClass(const char SUPPRESS_UNUSED * name)
+    {
+      return _someNonClass;
+    }
+    virtual jmethodID GetMethodID(jclass SUPPRESS_UNUSED clazz, const char SUPPRESS_UNUSED *name, const char SUPPRESS_UNUSED *sig) override
+    {
+      return _someNonMethodID;
+    }
+    virtual jfieldID GetFieldID(jclass SUPPRESS_UNUSED clazz, const char SUPPRESS_UNUSED *name, const char SUPPRESS_UNUSED *sig) override
+    {
+      return _someNonFieldID;
+    }
+    using JNIEnv::CallIntMethod;
+    virtual jobject CallObjectMethod(jobject SUPPRESS_UNUSED obj, jmethodID SUPPRESS_UNUSED methodID, ...) override
+    {
+      return nullptr;
+    }
+private:
+    jclass _someNonClass;
+    jmethodID _someNonMethodID;
+    jfieldID _someNonFieldID;
+};
+
+template<typename T> class Fake_JNIEnv_for_binding: public Fake_JNIEnv
+{
+  public:
+    Fake_JNIEnv_for_binding(T value):Fake_JNIEnv()
+    {
+      _value = value;
+    }
+    // fake object call returns obj
+    virtual jobject CallObjectMethod(jobject SUPPRESS_UNUSED obj, jmethodID SUPPRESS_UNUSED methodID, ...) override
+    {
+        return obj;
+    }
+    virtual real16 * GetDoubleArrayElements(jdoubleArray SUPPRESS_UNUSED arr, bool  SUPPRESS_UNUSED *isCopy) override
+    {
+      return reinterpret_cast<real16 *>(&_value);
+    }
+    virtual int * GetIntArrayElements(jintArray SUPPRESS_UNUSED arr, bool  SUPPRESS_UNUSED *isCopy) override
+    {
+      return reinterpret_cast<int *>(&_value);
+    }
+  private:
+    T _value;
+};
+
+TEST(JTerminals, Test_JOGRealScalar_ctor)
+{
+    real16 value = 1234;
+    Fake_JavaVM * jvm = new Fake_JavaVM();
+    Fake_JNIEnv * env  = new Fake_JNIEnv_for_binding<real16>(value);
+    jvm->setEnv(env);
+    JVMManager::initialize(jvm);
+
+    jobject obj =  new _jobject();
+    JOGRealScalar * scalar = new JOGRealScalar(obj);
+    ASSERT_TRUE(scalar->getValue()==value);
+
+    delete scalar;
+    delete obj;
+    delete env;
+    delete jvm;
+}
+
+TEST(JTerminals, Test_JOGComplexScalar_ctor)
+{
+    complex16 value = {1234,5678};
+    Fake_JavaVM * jvm = new Fake_JavaVM();
+    Fake_JNIEnv * env  = new Fake_JNIEnv_for_binding<complex16>(value);
+    jvm->setEnv(env);
+    JVMManager::initialize(jvm);
+
+    jobject obj =  new _jobject();
+    JOGComplexScalar * scalar = new JOGComplexScalar(obj);
+    ASSERT_TRUE(scalar->getValue()==value);
+
+    delete scalar;
+    delete obj;
+    delete env;
+    delete jvm;
+}
+
+TEST(JTerminals, Test_JOGIntegerScalar_ctor)
+{
+    int value = 1234;
+    Fake_JavaVM * jvm = new Fake_JavaVM();
+    Fake_JNIEnv * env  = new Fake_JNIEnv_for_binding<int>(value);
+    jvm->setEnv(env);
+    JVMManager::initialize(jvm);
+
+    jobject obj =  new _jobject();
+    JOGIntegerScalar * scalar = new JOGIntegerScalar(obj);
+    ASSERT_TRUE(scalar->getValue()==value);
+
+    delete scalar;
+    delete obj;
+    delete env;
+    delete jvm;
+}
+
+TEST(JTerminals, Test_binding_getArrayFromJava_bad_GetDoubleArrayElements)
+{
+    real16 value = 1234;
+    Fake_JavaVM * jvm = new Fake_JavaVM();
+    class Fake_JNIEnv_for_binding_bad: public Fake_JNIEnv_for_binding<real16>
+    {
+      using Fake_JNIEnv_for_binding<real16>::Fake_JNIEnv_for_binding;
+      virtual real16 * GetDoubleArrayElements(jdoubleArray SUPPRESS_UNUSED arr, bool  SUPPRESS_UNUSED *isCopy) override
+      {
+        return nullptr;
+      }
+    };
+    Fake_JNIEnv * env  = new Fake_JNIEnv_for_binding_bad(value);
+    jvm->setEnv(env);
+    JVMManager::initialize(jvm);
+
+    jobject obj =  new _jobject();
+    ASSERT_ANY_THROW(new JOGRealScalar(obj));
+
+    delete obj;
+    delete env;
+    delete jvm;
+}
+
+TEST(JTerminals, Test_binding_getArrayFromJava_bad_GetIntArrayElements)
+{
+    real16 value = 1234;
+    Fake_JavaVM * jvm = new Fake_JavaVM();
+    class Fake_JNIEnv_for_binding_bad: public Fake_JNIEnv_for_binding<real16>
+    {
+      using Fake_JNIEnv_for_binding<real16>::Fake_JNIEnv_for_binding;
+      virtual int * GetIntArrayElements(jintArray SUPPRESS_UNUSED arr, bool  SUPPRESS_UNUSED *isCopy) override
+      {
+        return nullptr;
+      }
+    };
+    Fake_JNIEnv * env  = new Fake_JNIEnv_for_binding_bad(value);
+    jvm->setEnv(env);
+    JVMManager::initialize(jvm);
+
+    jobject obj =  new _jobject();
+    ASSERT_ANY_THROW(new JOGIntegerScalar(obj));
+
+    delete obj;
+    delete env;
+    delete jvm;
+}
+
+TEST(JTerminals, Test_bindPrimitiveArrayData_bad_obj)
+{
+    real16 value = 1234;
+    Fake_JavaVM * jvm = new Fake_JavaVM();
+    Fake_JNIEnv * env  = new Fake_JNIEnv_for_binding<real16>(value);
+    jvm->setEnv(env);
+    JVMManager::initialize(jvm);
+
+    jobject obj =  nullptr;
+    ASSERT_ANY_THROW(new JOGRealScalar(obj));
+
+    delete obj;
+    delete env;
+    delete jvm;
+}
+
+TEST(JTerminals, Test_bindPrimitiveArrayData_bad_method)
+{
+    jobject obj = new _jobject();
+    class pointless
+    {
+      public:
+        void run(jobject obj)
+        {
+          bindPrimitiveArrayData<real16, jdoubleArray>(obj, nullptr);
+        }
+    };
+    pointless * clazz = new pointless();
+    ASSERT_ANY_THROW(clazz->run(obj));
+    delete obj;
+    delete clazz;
+}

--- a/src/jshim/test/check_jterminals.cc
+++ b/src/jshim/test/check_jterminals.cc
@@ -18,6 +18,7 @@
 using namespace std;
 using namespace convert;
 
+
 // mock JVM
 class Fake_JavaVM: public JavaVM
 {
@@ -80,6 +81,44 @@ private:
     jmethodID _someNonMethodID;
     jfieldID _someNonFieldID;
 };
+
+
+TEST(JTerminals, Test_getIntFromVoidJMethod_null_meth)
+{
+  jobject obj = new _jobject();
+  ASSERT_ANY_THROW(getIntFromVoidJMethod(nullptr,obj));
+  delete obj;
+}
+
+TEST(JTerminals, Test_getIntFromVoidJMethod_null_obj)
+{
+  jmethodID meth = new _jmethodID();
+  ASSERT_ANY_THROW(getIntFromVoidJMethod(meth,nullptr));
+  delete meth;
+}
+
+TEST(JTerminals, Test_getIntFromVoidJMethod_null_envptr)
+{
+  class Fake_JavaVM_bad_attach: public Fake_JavaVM
+  {
+    virtual jint AttachCurrentThread(void SUPPRESS_UNUSED **penv, void SUPPRESS_UNUSED *args) override
+    {
+      *penv = nullptr;
+      return JNI_OK;
+    }
+  };
+  Fake_JavaVM * jvm = new Fake_JavaVM_bad_attach();
+  Fake_JNIEnv * env  = new Fake_JNIEnv();
+  jvm->setEnv(env);
+  JVMManager::initialize(jvm);
+  jmethodID meth = new _jmethodID();
+  jobject obj = new _jobject();
+  ASSERT_ANY_THROW(getIntFromVoidJMethod(meth,obj));
+  delete env;
+  delete jvm;
+  delete meth;
+  delete obj;
+}
 
 template<typename T> class Fake_JNIEnv_for_binding: public Fake_JNIEnv
 {

--- a/src/jshim/test/check_jterminals.cc
+++ b/src/jshim/test/check_jterminals.cc
@@ -38,7 +38,7 @@ TEST(JTerminals, Test_getIntFromVoidJMethod_null_envptr)
 {
   class Fake_JavaVM_bad_attach: public Fake_JavaVM
   {
-    virtual jint AttachCurrentThread(void SUPPRESS_UNUSED **penv, void SUPPRESS_UNUSED *args) override
+    virtual jint AttachCurrentThread(void **penv, void SUPPRESS_UNUSED *args) override
     {
       *penv = nullptr;
       return JNI_OK;

--- a/src/jshim/test/check_jterminals.cc
+++ b/src/jshim/test/check_jterminals.cc
@@ -117,6 +117,9 @@ TEST(JTerminals, Test_JOGRealScalar_ctor)
     JOGRealScalar * scalar = new JOGRealScalar(obj);
     ASSERT_TRUE(scalar->getValue()==value);
 
+    // debug print for coverage purposes
+    scalar->debug_print();
+
     delete scalar;
     delete obj;
     delete env;
@@ -135,6 +138,9 @@ TEST(JTerminals, Test_JOGComplexScalar_ctor)
     JOGComplexScalar * scalar = new JOGComplexScalar(obj);
     ASSERT_TRUE(scalar->getValue()==value);
 
+    // debug print for coverage purposes
+    scalar->debug_print();
+
     delete scalar;
     delete obj;
     delete env;
@@ -152,6 +158,9 @@ TEST(JTerminals, Test_JOGIntegerScalar_ctor)
     jobject obj =  new _jobject();
     JOGIntegerScalar * scalar = new JOGIntegerScalar(obj);
     ASSERT_TRUE(scalar->getValue()==value);
+
+    // debug print for coverage purposes
+    scalar->debug_print();
 
     delete scalar;
     delete obj;

--- a/src/jshim/test/check_jterminals.cc
+++ b/src/jshim/test/check_jterminals.cc
@@ -14,73 +14,10 @@
 #include "jvmmanager.hh"
 #include "debug.h"
 #include "equals.hh"
+#include "test/fake_jvm.hh"
 
 using namespace std;
 using namespace convert;
-
-
-// mock JVM
-class Fake_JavaVM: public JavaVM
-{
-  public:
-    virtual ~Fake_JavaVM(){};
-    virtual int GetEnv(void ** env, int SUPPRESS_UNUSED version) override
-    {
-     *env = _env;
-     return JNI_OK;
-    }
-    void setEnv(JNIEnv * env)
-    {
-        this->_env = env;
-    }
-    JNIEnv * getEnv()
-    {
-        return this->_env;
-    }
-    virtual jint AttachCurrentThread(void SUPPRESS_UNUSED **penv, void SUPPRESS_UNUSED *args)
-    {
-      *penv = this->_env;
-      return JNI_OK;
-    }
-};
-
-// mock JNIEnv
-class Fake_JNIEnv: public JNIEnv
-{
-  public:
-    Fake_JNIEnv()
-    {
-      _someNonClass = new _jclass();
-      _someNonMethodID = new _jmethodID();
-      _someNonFieldID = new _jfieldID();
-    }
-    virtual ~Fake_JNIEnv()
-    {
-      delete _someNonMethodID;
-      delete _someNonFieldID;
-      delete _someNonClass;
-    }
-    virtual jclass FindClass(const char SUPPRESS_UNUSED * name)
-    {
-      return _someNonClass;
-    }
-    virtual jmethodID GetMethodID(jclass SUPPRESS_UNUSED clazz, const char SUPPRESS_UNUSED *name, const char SUPPRESS_UNUSED *sig) override
-    {
-      return _someNonMethodID;
-    }
-    virtual jfieldID GetFieldID(jclass SUPPRESS_UNUSED clazz, const char SUPPRESS_UNUSED *name, const char SUPPRESS_UNUSED *sig) override
-    {
-      return _someNonFieldID;
-    }
-    using JNIEnv::CallIntMethod;
-    using JNIEnv::CallObjectMethod;
-    using JNIEnv::GetIntArrayElements;
-    using JNIEnv::GetDoubleArrayElements;
-private:
-    jclass _someNonClass;
-    jmethodID _someNonMethodID;
-    jfieldID _someNonFieldID;
-};
 
 
 TEST(JTerminals, Test_getIntFromVoidJMethod_null_meth)

--- a/src/jshim/test/check_jterminals.cc
+++ b/src/jshim/test/check_jterminals.cc
@@ -206,36 +206,3 @@ TEST(JTerminals, Test_binding_getArrayFromJava_bad_GetIntArrayElements)
     delete env;
     delete jvm;
 }
-
-TEST(JTerminals, Test_bindPrimitiveArrayData_bad_obj)
-{
-    real16 value = 1234;
-    Fake_JavaVM * jvm = new Fake_JavaVM();
-    Fake_JNIEnv * env  = new Fake_JNIEnv_for_binding<real16>(value);
-    jvm->setEnv(env);
-    JVMManager::initialize(jvm);
-
-    jobject obj =  nullptr;
-    ASSERT_ANY_THROW(new JOGRealScalar(obj));
-
-    delete obj;
-    delete env;
-    delete jvm;
-}
-
-TEST(JTerminals, Test_bindPrimitiveArrayData_bad_method)
-{
-    jobject obj = new _jobject();
-    class pointless
-    {
-      public:
-        void run(jobject obj)
-        {
-          bindPrimitiveArrayData<real16, jdoubleArray>(obj, nullptr);
-        }
-    };
-    pointless * clazz = new pointless();
-    ASSERT_ANY_THROW(clazz->run(obj));
-    delete obj;
-    delete clazz;
-}

--- a/src/jshim/test/check_jterminals.cc
+++ b/src/jshim/test/check_jterminals.cc
@@ -353,3 +353,53 @@ TEST(JTerminals, Test_JOGComplexMatrix_ctor)
     delete env;
     delete jvm;
 }
+
+TEST(JTerminals, Test_JOGRealDiagonalMatrix_ctor)
+{
+    int rval = 2;
+    real16 * datav = new real16[2]{10,20};
+    Fake_JavaVM * jvm = new Fake_JavaVM();
+    Fake_JNIEnv * env  = new Fake_JNIEnv_for_OGMatrix_T<real16>(rval, datav);
+    jvm->setEnv(env);
+    JVMManager::initialize(jvm);
+
+    jobject obj =  new _jobject();
+    JOGRealDiagonalMatrix * mat = new JOGRealDiagonalMatrix(obj);
+    ASSERT_TRUE(mat->getRows()==rval);
+    ASSERT_TRUE(mat->getCols()==rval);
+    ASSERT_TRUE(ArrayFuzzyEquals(mat->getData(), datav, 2));
+
+    // debug print for coverage purposes
+    mat->debug_print();
+
+    delete[] datav;
+    delete mat;
+    delete obj;
+    delete env;
+    delete jvm;
+}
+
+TEST(JTerminals, Test_JOGComplexDiagonalMatrix_ctor)
+{
+    int rval = 2;
+    complex16 * datav = new complex16[2]{{1,10},{2,20}};
+    Fake_JavaVM * jvm = new Fake_JavaVM();
+    Fake_JNIEnv * env  = new Fake_JNIEnv_for_OGMatrix_T<complex16>(rval, datav);
+    jvm->setEnv(env);
+    JVMManager::initialize(jvm);
+
+    jobject obj =  new _jobject();
+    JOGComplexDiagonalMatrix * mat = new JOGComplexDiagonalMatrix(obj);
+    ASSERT_TRUE(mat->getRows()==rval);
+    ASSERT_TRUE(mat->getCols()==rval);
+    ASSERT_TRUE(ArrayFuzzyEquals(mat->getData(), datav, 2));
+
+    // debug print for coverage purposes
+    mat->debug_print();
+
+    delete[] datav;
+    delete mat;
+    delete obj;
+    delete env;
+    delete jvm;
+}

--- a/src/jshim/test/check_jterminals.cc
+++ b/src/jshim/test/check_jterminals.cc
@@ -453,7 +453,10 @@ TEST(JTerminals, Test_JOGRealSparseMatrix_ctor)
     ASSERT_TRUE(ArrayBitEquals(mat->getColPtr(), idx, 4));
     ASSERT_TRUE(ArrayBitEquals(mat->getRowIdx(), idx, 4));
 
-    // not debug printing as the data pattern is invalid
+    mat->debug_print();
+
+    ASSERT_ANY_THROW(mat->toReal16ArrayOfArrays());
+    ASSERT_ANY_THROW(mat->toComplex16ArrayOfArrays());
 
     delete[] datav;
     delete[] idx;
@@ -482,7 +485,10 @@ TEST(JTerminals, Test_JOGComplexSparseMatrix_ctor)
     ASSERT_TRUE(ArrayBitEquals(mat->getColPtr(), idx, 4));
     ASSERT_TRUE(ArrayBitEquals(mat->getRowIdx(), idx, 4));
 
-    // not debug printing as the data pattern is invalid
+    mat->debug_print();
+
+    ASSERT_ANY_THROW(mat->toReal16ArrayOfArrays());
+    ASSERT_ANY_THROW(mat->toComplex16ArrayOfArrays());
 
     delete[] datav;
     delete[] idx;

--- a/src/jshim/test/check_jvmmanager_fakejni.cc
+++ b/src/jshim/test/check_jvmmanager_fakejni.cc
@@ -647,9 +647,17 @@ TEST(JVMManagerFakeJNITest, Test_JVMManager_bad_JNI_OnLoad)
 
 TEST(JVMManagerFakeJNITest, Test_JVMManager_checkEx_exfound)
 {
+  class Fake_JNIEnv_will_throw: public Fake_JNIEnv_testRegister
+  {
+    public:
+      virtual jboolean ExceptionCheck() override
+      {
+        return JNI_TRUE;
+      }
+  };
   JVMManager * jvm_manager = new JVMManager();
   Fake_JavaVM * jvm = new Fake_JavaVM();
-  Fake_JNIEnv_testRegister * env  = new Fake_JNIEnv_testRegister();
+  Fake_JNIEnv_testRegister * env  = new Fake_JNIEnv_will_throw();
   jvm->setEnv(env);
   jvm_manager->initialize(jvm);
   ASSERT_ANY_THROW(checkEx(env));

--- a/src/jshim/test/check_jvmmanager_fakejni.cc
+++ b/src/jshim/test/check_jvmmanager_fakejni.cc
@@ -677,3 +677,78 @@ TEST(JVMManagerFakeJNITest, Test_JVMManager_checkEx_noexfound)
   delete jvm;
   delete env;
 }
+
+TEST(JVMManagerFakeJNITest, Test_JVMManager_checknewIntArray_fail)
+{
+  JVMManager * jvm_manager = new JVMManager();
+  Fake_JavaVM * jvm = new Fake_JavaVM();
+  Fake_JNIEnv_testRegister * env  = new Fake_JNIEnv_testRegister();
+  jvm->setEnv(env);
+  jvm_manager->initialize(jvm);
+  jsize sz = 10;
+  ASSERT_ANY_THROW(jvm_manager->newIntArray(env,sz));
+  delete jvm_manager;
+  delete jvm;
+  delete env;
+}
+
+TEST(JVMManagerFakeJNITest, Test_JVMManager_checknewIntArray_success)
+{
+  JVMManager * jvm_manager = new JVMManager();
+  Fake_JavaVM * jvm = new Fake_JavaVM();
+  class Fake_JNIEnv_testRegister_noex: public Fake_JNIEnv_testRegister
+  {
+    virtual jintArray NewIntArray(jsize SUPPRESS_UNUSED len)
+    {
+      return new _jintArray();
+    }
+  };
+  Fake_JNIEnv_testRegister * env  = new Fake_JNIEnv_testRegister_noex();
+  jvm->setEnv(env);
+  jvm_manager->initialize(jvm);
+  jsize sz = 10;
+  jobject ret = nullptr;
+  ASSERT_NO_THROW(ret = jvm_manager->newIntArray(env,sz));
+  delete ret;
+  delete jvm_manager;
+  delete jvm;
+  delete env;
+}
+
+
+TEST(JVMManagerFakeJNITest, Test_JVMManager_checknewDouble_fail)
+{
+  JVMManager * jvm_manager = new JVMManager();
+  Fake_JavaVM * jvm = new Fake_JavaVM();
+  Fake_JNIEnv_testRegister * env  = new Fake_JNIEnv_testRegister();
+  jvm->setEnv(env);
+  jvm_manager->initialize(jvm);
+  jdouble value = 10;
+  ASSERT_ANY_THROW(jvm_manager->newDouble(env,value));
+  delete jvm_manager;
+  delete jvm;
+  delete env;
+}
+
+TEST(JVMManagerFakeJNITest, Test_JVMManager_checknewnewDouble_success)
+{
+  JVMManager * jvm_manager = new JVMManager();
+  Fake_JavaVM * jvm = new Fake_JavaVM();
+  class Fake_JNIEnv_testRegister_noex: public Fake_JNIEnv_testRegister
+  {
+    virtual jobject NewObject(jclass SUPPRESS_UNUSED clazz, jmethodID SUPPRESS_UNUSED methodID, ...)
+    {
+      return new _jobject();
+    }
+  };
+  Fake_JNIEnv_testRegister * env  = new Fake_JNIEnv_testRegister_noex();
+  jvm->setEnv(env);
+  jvm_manager->initialize(jvm);
+  jdouble value = 10;
+  jobject ret = nullptr;
+  ASSERT_NO_THROW(ret = jvm_manager->newDouble(env,value));
+  delete ret;
+  delete jvm_manager;
+  delete jvm;
+  delete env;
+}

--- a/src/jshim/test/check_jvmmanager_fakejni.cc
+++ b/src/jshim/test/check_jvmmanager_fakejni.cc
@@ -133,7 +133,23 @@ TEST(JVMManagerFakeJNITest, Test_JVMManager_test_registerReferences)
     ASSERT_TRUE(jvm_manager->getOGSparseMatrixClazz_getRowIdx()!=nullptr);
     ASSERT_TRUE(jvm_manager->getComplexArrayContainerClazz_ctor_DAoA_DAoA()!=nullptr);
     ASSERT_TRUE(jvm_manager-> getOGExprTypeEnumClazz__hashdefined()!=nullptr);
-    
+    ASSERT_TRUE(jvm_manager->getOGRealScalarClazz()!=nullptr);
+    ASSERT_TRUE(jvm_manager->getOGComplexScalarClazz()!=nullptr);
+    ASSERT_TRUE(jvm_manager->getOGRealDenseMatrixClazz()!=nullptr);
+    ASSERT_TRUE(jvm_manager->getOGComplexDenseMatrixClazz()!=nullptr);
+    ASSERT_TRUE(jvm_manager->getOGRealDiagonalMatrixClazz()!=nullptr);
+    ASSERT_TRUE(jvm_manager->getOGComplexDiagonalMatrixClazz()!=nullptr);
+    ASSERT_TRUE(jvm_manager->getOGRealSparseMatrixClazz()!=nullptr);
+    ASSERT_TRUE(jvm_manager->getOGComplexSparseMatrixClazz()!=nullptr);
+    ASSERT_TRUE(jvm_manager->getOGRealScalarClazz_init()!=nullptr);
+    ASSERT_TRUE(jvm_manager->getOGComplexScalarClazz_init()!=nullptr);
+    ASSERT_TRUE(jvm_manager->getOGRealDenseMatrixClazz_init()!=nullptr);
+    ASSERT_TRUE(jvm_manager->getOGComplexDenseMatrixClazz_init()!=nullptr);
+    ASSERT_TRUE(jvm_manager->getOGRealDiagonalMatrixClazz_init()!=nullptr);
+    ASSERT_TRUE(jvm_manager->getOGComplexDiagonalMatrixClazz_init()!=nullptr);
+    ASSERT_TRUE(jvm_manager->getOGRealSparseMatrixClazz_init()!=nullptr);
+    ASSERT_TRUE(jvm_manager->getOGComplexSparseMatrixClazz_init()!=nullptr);
+
     delete env;
     delete jvm;
     delete jvm_manager;
@@ -627,4 +643,37 @@ TEST(JVMManagerFakeJNITest, Test_JVMManager_bad_JNI_OnLoad)
   ASSERT_TRUE(JNI_OnLoad(jvm, nullptr)==JNI_ERR);
   delete jvm;
   delete env;    
+}
+
+TEST(JVMManagerFakeJNITest, Test_JVMManager_checkEx_exfound)
+{
+  JVMManager * jvm_manager = new JVMManager();
+  Fake_JavaVM * jvm = new Fake_JavaVM();
+  Fake_JNIEnv_testRegister * env  = new Fake_JNIEnv_testRegister();
+  jvm->setEnv(env);
+  jvm_manager->initialize(jvm);
+  ASSERT_ANY_THROW(checkEx(env));
+  delete jvm_manager;
+  delete jvm;
+  delete env;
+}
+
+TEST(JVMManagerFakeJNITest, Test_JVMManager_checkEx_noexfound)
+{
+  JVMManager * jvm_manager = new JVMManager();
+  Fake_JavaVM * jvm = new Fake_JavaVM();
+  class Fake_JNIEnv_testRegister_noex: public Fake_JNIEnv_testRegister
+  {
+    virtual jthrowable ExceptionOccurred() override
+    {
+      return nullptr;
+    }
+  };
+  Fake_JNIEnv_testRegister * env  = new Fake_JNIEnv_testRegister_noex();
+  jvm->setEnv(env);
+  jvm_manager->initialize(jvm);
+  ASSERT_NO_THROW(checkEx(env));
+  delete jvm_manager;
+  delete jvm;
+  delete env;
 }

--- a/src/jshim/test/check_jvmmanager_fakejni.cc
+++ b/src/jshim/test/check_jvmmanager_fakejni.cc
@@ -12,30 +12,10 @@
 #include <iostream>
 #include "jvmmanager.hh"
 #include "debug.h"
+#include "test/fake_jvm.hh"
 
 using namespace std;
 using namespace convert;
-
-// Fake VM
-class Fake_JavaVM: public JavaVM
-{
-  public:   
-    virtual ~Fake_JavaVM(){};
-    virtual int GetEnv(void SUPPRESS_UNUSED ** env, int SUPPRESS_UNUSED version) override
-    {
-     *env = _env;
-     return JNI_OK;
-    }
-    void setEnv(JNIEnv * env)
-    {
-        this->_env = env;
-    }
-    JNIEnv * getEnv()
-    {
-        return this->_env;
-    }        
-    virtual jint AttachCurrentThread(void SUPPRESS_UNUSED **penv, void SUPPRESS_UNUSED *args) { return JNI_OK; }
-};
 
 // Test bad JVM (GetEnv() env ptr returns JNI_ERR)
 TEST(JVMManagerFakeJNITest, Test_JVMManager_initialize_badversion)


### PR DESCRIPTION
This PR is fairly heavy going I'm afraid. MAT-317 is to increase the coverage of the JNI layer, which as we know is horribly complicated to test. I feel the outcome of this code is that we now have a large number of tests covering a lot of behaviour, which is good, however it emphasises that perhaps the design of the JVMManager class is wrong. The static nature of the methods in the JVMManager (for sound design reasons at the time) make it very hard to test as the underlying JNI calls have to be mocked opposed to mocking the behaviour of the JVMManager methods via class extension and overriding virtuals.

This PR:
- Adds a load of unit tests for the JNI layer (largely terminals and data binding).
- Sorts out problems with windows symbol exports.
- Removes duplicated binding code.
- Fixes a number of erroneous `delete` calls.
- Makes methods that are not implemented throw opposed to just run debug statements (done with view that there's work waiting to make it to mainline that handles exceptions).
- Adds more aggressive checking of JNI calls and state.

I realise that the jshim test code is not that eloquent and has some duplication. However, as a redesign is on the books, I think the effort of neater testing with an mock JVMManager would be best done at that time.

BB Multi-Pass: [http://devmaths-lx-1:8011/builders/nyqwk2-testing/builds/662](http://devmaths-lx-1:8011/builders/nyqwk2-testing/builds/662)
Coverage: librdag 92.4%, jshim 71.0% (massive improvement in jshim)
Java coverage: 82% (unchanged)
