### PR TITLE
[MAT-334] Add constructors required for Windows implementation

### DIFF
--- a/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionNative.java
+++ b/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionNative.java
@@ -6,6 +6,14 @@ package com.opengamma.longdog.exceptions;
 public class MathsExceptionNative extends MathsException {
 
   /**
+   * This form of the constructor is used on Windows, where no native stack trace is provided.
+   * @param msg the error message
+   */
+  public MathsExceptionNative(String msg) {
+	super(msg);
+  }
+
+  /**
    * Serial ID
    */
   private static final long serialVersionUID = 2689725471014028060L;

--- a/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionNativeComputation.java
+++ b/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionNativeComputation.java
@@ -9,6 +9,15 @@ package com.opengamma.longdog.exceptions;
  * Provides a manner in which maths exceptions relating to execution in native code can be thrown.
  */
 public class MathsExceptionNativeComputation extends MathsExceptionNative {
+  
+  /**
+   * This form of the constructor is used on Windows, where no native stack trace is provided.
+   * @param msg the error message
+   */
+  public MathsExceptionNativeComputation(String msg) {
+	super(msg);
+  }
+
   /**
    * Serial ID
    */

--- a/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionNativeConversion.java
+++ b/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionNativeConversion.java
@@ -10,6 +10,14 @@ package com.opengamma.longdog.exceptions;
  */
 public class MathsExceptionNativeConversion extends MathsExceptionNative {
   /**
+   * This form of the constructor is used on Windows, where no native stack trace is provided.
+   * @param msg the error message
+   */
+  public MathsExceptionNativeConversion(String msg) {
+    super(msg);
+  }
+
+/**
    * Serial ID
    */
   private static final long serialVersionUID = -303234672217705296L;


### PR DESCRIPTION
Hopefully this should fix the missing constructor error on Windows.

Buildbot pass: http://devmaths-lx-1:8011/builders/nyqwk2-testing/builds/677
