### PR TITLE
Mat 341

### DIFF
--- a/include/convertto.hh
+++ b/include/convertto.hh
@@ -31,21 +31,21 @@ class ConvertTo
 {
   public:
     ConvertTo();
-    OGOwningRealMatrix * convertToOGRealMatrix(OGRealScalar const * thing) const;
-    OGOwningRealMatrix * convertToOGRealMatrix(OGIntegerScalar const * thing) const;
-    OGOwningRealMatrix * convertToOGRealMatrix(OGRealDiagonalMatrix const * thing) const;
-    OGOwningRealMatrix * convertToOGRealMatrix(OGLogicalMatrix const * thing) const;
-    OGOwningRealMatrix * convertToOGRealMatrix(OGRealSparseMatrix const * thing) const;
+    OGRealMatrix * convertToOGRealMatrix(OGRealScalar const * thing) const;
+    OGRealMatrix * convertToOGRealMatrix(OGIntegerScalar const * thing) const;
+    OGRealMatrix * convertToOGRealMatrix(OGRealDiagonalMatrix const * thing) const;
+    OGRealMatrix * convertToOGRealMatrix(OGLogicalMatrix const * thing) const;
+    OGRealMatrix * convertToOGRealMatrix(OGRealSparseMatrix const * thing) const;
 
-    OGOwningComplexMatrix * convertToOGComplexMatrix(OGRealScalar const * thing) const;
-    OGOwningComplexMatrix * convertToOGComplexMatrix(OGIntegerScalar const * thing) const;
-    OGOwningComplexMatrix * convertToOGComplexMatrix(OGComplexScalar const * thing) const;
-    OGOwningComplexMatrix * convertToOGComplexMatrix(OGRealDiagonalMatrix const * thing) const;
-    OGOwningComplexMatrix * convertToOGComplexMatrix(OGComplexDiagonalMatrix const * thing) const;
-    OGOwningComplexMatrix * convertToOGComplexMatrix(OGRealSparseMatrix const * thing) const;
-    OGOwningComplexMatrix * convertToOGComplexMatrix(OGComplexSparseMatrix const * thing) const;
-    OGOwningComplexMatrix * convertToOGComplexMatrix(OGRealMatrix const * thing) const;
-    OGOwningComplexMatrix * convertToOGComplexMatrix(OGLogicalMatrix const * thing) const;
+    OGComplexMatrix * convertToOGComplexMatrix(OGRealScalar const * thing) const;
+    OGComplexMatrix * convertToOGComplexMatrix(OGIntegerScalar const * thing) const;
+    OGComplexMatrix * convertToOGComplexMatrix(OGComplexScalar const * thing) const;
+    OGComplexMatrix * convertToOGComplexMatrix(OGRealDiagonalMatrix const * thing) const;
+    OGComplexMatrix * convertToOGComplexMatrix(OGComplexDiagonalMatrix const * thing) const;
+    OGComplexMatrix * convertToOGComplexMatrix(OGRealSparseMatrix const * thing) const;
+    OGComplexMatrix * convertToOGComplexMatrix(OGComplexSparseMatrix const * thing) const;
+    OGComplexMatrix * convertToOGComplexMatrix(OGRealMatrix const * thing) const;
+    OGComplexMatrix * convertToOGComplexMatrix(OGLogicalMatrix const * thing) const;
 };
 
 }

--- a/include/debug.h
+++ b/include/debug.h
@@ -12,6 +12,9 @@
 #define DEBUG_PRINT(...) do {} while(0)
 #endif
 
+// default precision used in debug output
+#define __DEBUG_PRECISION 10
+
 // Used by VAL64BIT_PRINT
 #define INT64HIGHLOW(val,high,low) \
     low = (long long unsigned int)val & 0x00000000FFFFFFFFULL; \

--- a/include/terminal.hh
+++ b/include/terminal.hh
@@ -215,10 +215,16 @@ template <typename T> class OGArray: public OGTerminal
     virtual DATA_ACCESS getDataAccess() const;
     virtual bool equals(const OGTerminal *)const override;
     virtual bool fuzzyequals(const OGTerminal * ) const override;
+    /*
+     * The following will throw.
+     */
     virtual OGRealMatrix * asFullOGRealMatrix() const override;
     virtual OGComplexMatrix * asFullOGComplexMatrix() const override;
     virtual OGTerminal * createOwningCopy() const override;
     virtual OGTerminal * createComplexOwningCopy() const override;
+    virtual void debug_print() const override;
+    virtual OGNumeric* copy() const override;
+    virtual void accept(Visitor &v) const override;
   protected:
     void setData(T * data);
     void setRows(int rows);

--- a/include/terminal.hh
+++ b/include/terminal.hh
@@ -149,6 +149,7 @@ class OGScalar: public OGTerminal
     T ** toArrayOfArrays() const;
     virtual bool equals(const OGTerminal * ) const override;
     virtual bool fuzzyequals(const OGTerminal * ) const override;
+    virtual void debug_print() const override;
     /*
      * The following will throw.
      */
@@ -156,7 +157,6 @@ class OGScalar: public OGTerminal
     virtual OGComplexMatrix * asFullOGComplexMatrix() const override;
     virtual OGTerminal * createOwningCopy() const override;
     virtual OGTerminal * createComplexOwningCopy() const override;
-    virtual void debug_print() const override;
     virtual OGNumeric* copy() const override;
   protected:
     T _value;

--- a/include/terminal.hh
+++ b/include/terminal.hh
@@ -149,6 +149,15 @@ class OGScalar: public OGTerminal
     T ** toArrayOfArrays() const;
     virtual bool equals(const OGTerminal * ) const override;
     virtual bool fuzzyequals(const OGTerminal * ) const override;
+    /*
+     * The following will throw.
+     */
+    virtual OGRealMatrix * asFullOGRealMatrix() const override;
+    virtual OGComplexMatrix * asFullOGComplexMatrix() const override;
+    virtual OGTerminal * createOwningCopy() const override;
+    virtual OGTerminal * createComplexOwningCopy() const override;
+    virtual void debug_print() const override;
+    virtual OGNumeric* copy() const override;
   protected:
     T _value;
 };

--- a/include/terminal.hh
+++ b/include/terminal.hh
@@ -215,6 +215,10 @@ template <typename T> class OGArray: public OGTerminal
     virtual DATA_ACCESS getDataAccess() const;
     virtual bool equals(const OGTerminal *)const override;
     virtual bool fuzzyequals(const OGTerminal * ) const override;
+    virtual OGRealMatrix * asFullOGRealMatrix() const override;
+    virtual OGComplexMatrix * asFullOGComplexMatrix() const override;
+    virtual OGTerminal * createOwningCopy() const override;
+    virtual OGTerminal * createComplexOwningCopy() const override;
   protected:
     void setData(T * data);
     void setRows(int rows);
@@ -241,6 +245,7 @@ template <typename T> class OGMatrix: public OGArray<T>
     OGMatrix(T * data, int rows, int cols, DATA_ACCESS access_spec);
     virtual ~OGMatrix();
     virtual void accept(Visitor &v) const override;
+    virtual void debug_print() const override;
     T** toArrayOfArrays() const;
 };
 
@@ -251,7 +256,6 @@ class OGRealMatrix: public OGMatrix<real16>
 {
   public:
     using OGMatrix::OGMatrix;
-    virtual void debug_print() const override;
     virtual real16 ** toReal16ArrayOfArrays() const override;
     virtual OGNumeric* copy() const override;
     virtual const OGRealMatrix* asOGRealMatrix() const override;
@@ -267,7 +271,6 @@ class OGComplexMatrix: public OGMatrix<complex16>
 {
   public:
     using OGMatrix::OGMatrix;
-    virtual void debug_print() const override;
     virtual complex16 ** toComplex16ArrayOfArrays() const override;
     virtual OGNumeric* copy() const override;
     virtual const OGComplexMatrix* asOGComplexMatrix() const override;

--- a/include/terminal.hh
+++ b/include/terminal.hh
@@ -206,6 +206,7 @@ class OGIntegerScalar: public OGScalar<int>
 template <typename T> class OGArray: public OGTerminal
 {
   public:
+    virtual ~OGArray() override;
     T * getData() const; // Returns a pointer to the underlying data
     T * toArray() const; // Returns a pointer to a copy of the underlying data
     virtual int getRows() const override;
@@ -293,6 +294,8 @@ template <typename T> class OGDiagonalMatrix: public OGArray<T>
 {
   public:
     OGDiagonalMatrix(T * data, int rows, int cols);
+    OGDiagonalMatrix(T * data, int rows, int cols, DATA_ACCESS access_spec);
+    virtual ~OGDiagonalMatrix() override;
     virtual void accept(Visitor &v) const override;
     T** toArrayOfArrays() const;
 };
@@ -316,12 +319,6 @@ class OGRealDiagonalMatrix: public OGDiagonalMatrix<real16>
     virtual OGTerminal * createComplexOwningCopy() const override;
 };
 
-class OGOwningRealDiagonalMatrix: public OGRealDiagonalMatrix
-{
-  public:
-    virtual ~OGOwningRealDiagonalMatrix() override;
-    using OGRealDiagonalMatrix::OGRealDiagonalMatrix;
-};
 
 class OGComplexDiagonalMatrix: public OGDiagonalMatrix<complex16>
 {
@@ -339,12 +336,6 @@ class OGComplexDiagonalMatrix: public OGDiagonalMatrix<complex16>
     virtual OGTerminal * createComplexOwningCopy() const override;
 };
 
-class OGOwningComplexDiagonalMatrix: public OGComplexDiagonalMatrix
-{
-  public:
-    virtual ~OGOwningComplexDiagonalMatrix() override;
-    using OGComplexDiagonalMatrix::OGComplexDiagonalMatrix;
-};
 
 /**
  * Things that extend OGSparseMatrix

--- a/include/terminal.hh
+++ b/include/terminal.hh
@@ -256,9 +256,7 @@ template <typename T> class OGArray: public OGTerminal
 template <typename T> class OGMatrix: public OGArray<T>
 {
   public:
-    OGMatrix(T * data, int rows, int cols);
-    OGMatrix(T * data, int rows, int cols, DATA_ACCESS access_spec);
-    virtual ~OGMatrix();
+    OGMatrix(T * data, int rows, int cols, DATA_ACCESS access_spec=VIEWER);
     virtual void accept(Visitor &v) const override;
     virtual void debug_print() const override;
     T** toArrayOfArrays() const;
@@ -311,9 +309,7 @@ class OGLogicalMatrix: public OGRealMatrix
 template <typename T> class OGDiagonalMatrix: public OGArray<T>
 {
   public:
-    OGDiagonalMatrix(T * data, int rows, int cols);
-    OGDiagonalMatrix(T * data, int rows, int cols, DATA_ACCESS access_spec);
-    virtual ~OGDiagonalMatrix() override;
+    OGDiagonalMatrix(T * data, int rows, int cols, DATA_ACCESS access_spec=VIEWER);
     virtual void accept(Visitor &v) const override;
     T** toArrayOfArrays() const;
 };
@@ -362,8 +358,7 @@ class OGComplexDiagonalMatrix: public OGDiagonalMatrix<complex16>
 template <typename T> class OGSparseMatrix: public OGArray<T>
 {
   public:
-    OGSparseMatrix(int * colPtr, int * rowIdx, T * data, int rows, int cols);
-    OGSparseMatrix(int * colPtr, int * rowIdx, T * data, int rows, int cols, DATA_ACCESS access_spec);
+    OGSparseMatrix(int * colPtr, int * rowIdx, T * data, int rows, int cols, DATA_ACCESS access_spec=VIEWER);
     virtual ~OGSparseMatrix();
     virtual void accept(Visitor &v) const override;
     int* getColPtr() const;

--- a/include/terminal.hh
+++ b/include/terminal.hh
@@ -345,6 +345,8 @@ template <typename T> class OGSparseMatrix: public OGArray<T>
 {
   public:
     OGSparseMatrix(int * colPtr, int * rowIdx, T * data, int rows, int cols);
+    OGSparseMatrix(int * colPtr, int * rowIdx, T * data, int rows, int cols, DATA_ACCESS access_spec);
+    virtual ~OGSparseMatrix();
     virtual void accept(Visitor &v) const override;
     int* getColPtr() const;
     int* getRowIdx() const;
@@ -378,12 +380,6 @@ class OGRealSparseMatrix: public OGSparseMatrix<real16>
     virtual OGTerminal * createComplexOwningCopy() const override;
 };
 
-class OGOwningRealSparseMatrix: public OGRealSparseMatrix
-{
-  public:
-    virtual ~OGOwningRealSparseMatrix() override;
-    using OGRealSparseMatrix::OGRealSparseMatrix;
-};
 
 class OGComplexSparseMatrix: public OGSparseMatrix<complex16>
 {
@@ -399,13 +395,6 @@ class OGComplexSparseMatrix: public OGSparseMatrix<complex16>
     virtual OGComplexMatrix * asFullOGComplexMatrix() const override;
     virtual OGTerminal * createOwningCopy() const override;
     virtual OGTerminal * createComplexOwningCopy() const override;
-};
-
-class OGOwningComplexSparseMatrix: public OGComplexSparseMatrix
-{
-  public:
-    virtual ~OGOwningComplexSparseMatrix() override;
-    using OGComplexSparseMatrix::OGComplexSparseMatrix;
 };
 
 } // end namespace librdag

--- a/src/generator/runners.py
+++ b/src/generator/runners.py
@@ -137,14 +137,14 @@ class PrefixOpRunner(UnaryExpressionRunner):
     def real_matrix_implementation(self):
         d = { 'symbol':     self.symbol,
               'datatype':   'real16',
-              'returntype': 'OGOwningRealMatrix' }
+              'returntype': 'OGRealMatrix' }
         return prefix_matrix_runner_implementation % d
 
     @property
     def complex_matrix_implementation(self):
         d = { 'symbol':     self.symbol,
               'datatype':   'complex16',
-              'returntype': 'OGOwningComplexMatrix' }
+              'returntype': 'OGComplexMatrix' }
         return prefix_matrix_runner_implementation % d
 
 class UnaryFunctionRunner(UnaryExpressionRunner):
@@ -169,14 +169,14 @@ class UnaryFunctionRunner(UnaryExpressionRunner):
     def real_matrix_implementation(self):
         d = { 'function':    self.function,
               'datatype':   'real16',
-              'returntype': 'OGOwningRealMatrix' }
+              'returntype': 'OGRealMatrix' }
         return unaryfunction_matrix_runner_implementation % d
 
     @property
     def complex_matrix_implementation(self):
         d = { 'function':   self.function,
               'datatype':   'complex16',
-              'returntype': 'OGOwningComplexMatrix' }
+              'returntype': 'OGComplexMatrix' }
         return unaryfunction_matrix_runner_implementation % d
 
 class UnimplementedUnary(UnaryExpressionRunner):

--- a/src/generator/runnertemplates.py
+++ b/src/generator/runnertemplates.py
@@ -120,7 +120,7 @@ prefix_matrix_runner_implementation = """\
   {
     newData[i] = %(symbol)sdata[i];
   }
-  ret = new %(returntype)s(newData, arg->getRows(), arg->getCols());
+  ret = new %(returntype)s(newData, arg->getRows(), arg->getCols(), OWNER);
 """
 
 # UnaryFunction runner
@@ -137,7 +137,7 @@ unaryfunction_matrix_runner_implementation = """\
   {
     newData[i] = %(function)s(data[i]);
   }
-  ret = new %(returntype)s(newData, arg->getRows(), arg->getCols());
+  ret = new %(returntype)s(newData, arg->getRows(), arg->getCols(), OWNER);
 """
 
 # Unimplemented runners

--- a/src/jshim/test/check_jdispatch.cc
+++ b/src/jshim/test/check_jdispatch.cc
@@ -75,7 +75,7 @@ TEST(JDispatch, Test_DispatchToReal16ArrayOfArrays_OGRealMatrix)
   dataAoA[0] = new real16[cols]{1,2};
   dataAoA[1] = new real16[cols]{3,4};
   dataAoA[2] = new real16[cols]{5,6};
-  OGRealMatrix * mat = new OGOwningRealMatrix(data,rows,cols);
+  OGRealMatrix * mat = new OGRealMatrix(data,rows,cols, OWNER);
   d->visit(mat);
   ASSERT_TRUE(d->getRows()==rows);
   ASSERT_TRUE(d->getCols()==cols);
@@ -92,7 +92,7 @@ TEST(JDispatch, Test_DispatchToReal16ArrayOfArrays_OGRealMatrix)
 TEST(JDispatch, Test_DispatchToReal16ArrayOfArrays_OGComplexMatrix)
 {
   DispatchToReal16ArrayOfArrays * d = new DispatchToReal16ArrayOfArrays();
-  OGOwningComplexMatrix * mat = new OGOwningComplexMatrix(new complex16[1]{12},1,1);
+  OGComplexMatrix * mat = new OGComplexMatrix(new complex16[1]{12},1,1, OWNER);
   ASSERT_ANY_THROW(d->visit(mat));
   delete d;
   delete mat;
@@ -242,7 +242,7 @@ TEST(JDispatch, Test_DispatchToComplex16ArrayOfArrays_OGComplexMatrix)
   dataAoA[0] = new complex16[cols]{{1,10},{2,20}};
   dataAoA[1] = new complex16[cols]{{3,30},{4,40}};
   dataAoA[2] = new complex16[cols]{{5,50},{6,60}};
-  OGComplexMatrix * mat = new OGOwningComplexMatrix(data,rows,cols);
+  OGComplexMatrix * mat = new OGComplexMatrix(data,rows,cols,OWNER);
   d->visit(mat);
   ASSERT_TRUE(d->getRows()==rows);
   ASSERT_TRUE(d->getCols()==cols);
@@ -259,7 +259,7 @@ TEST(JDispatch, Test_DispatchToComplex16ArrayOfArrays_OGComplexMatrix)
 TEST(JDispatch, Test_DispatchToComplex16ArrayOfArrays_OGRealMatrix)
 {
   DispatchToComplex16ArrayOfArrays * d = new DispatchToComplex16ArrayOfArrays();
-  OGRealMatrix * mat = new OGOwningRealMatrix(new real16[4]{1,2,3,4},2,2);
+  OGRealMatrix * mat = new OGRealMatrix(new real16[4]{1,2,3,4},2,2, OWNER);
   ASSERT_ANY_THROW(d->visit(mat));
   delete d;
   delete mat;

--- a/src/librdag/convertto.cc
+++ b/src/librdag/convertto.cc
@@ -19,29 +19,29 @@ ConvertTo::ConvertTo()
 {}
 
 // things that convert to OGRealMatrix
-OGOwningRealMatrix *
+OGRealMatrix *
 ConvertTo::convertToOGRealMatrix(OGRealScalar const * thing) const
 {
-  OGOwningRealMatrix * ret = new OGOwningRealMatrix(1,1);
+  OGRealMatrix * ret = new OGRealMatrix(new real16[1](),1,1, OWNER);
   ret->getData()[0]=thing->getValue();
   return ret;
 }
 
-OGOwningRealMatrix *
+OGRealMatrix *
 ConvertTo::convertToOGRealMatrix(OGIntegerScalar const * thing) const
 {
-  OGOwningRealMatrix * ret = new OGOwningRealMatrix(1,1);
+  OGRealMatrix * ret = new OGRealMatrix(new real16[1](),1,1, OWNER);
   ret->getData()[0]=thing->getValue();
   return ret;
 }
 
-OGOwningRealMatrix *
+OGRealMatrix *
 ConvertTo::convertToOGRealMatrix(OGRealDiagonalMatrix const * thing) const
 {
   int rows = thing->getRows();
   int cols = thing->getCols();
   int wlen = thing->getDatalen();
-  OGOwningRealMatrix * ret = new OGOwningRealMatrix(rows,cols);
+  OGRealMatrix * ret = new OGRealMatrix(new real16[rows*cols](),rows,cols, OWNER);
   real16 * diagdata = thing->getData();
   real16 * data = ret->getData();
   for(int i=0;i<wlen;i++)
@@ -51,13 +51,13 @@ ConvertTo::convertToOGRealMatrix(OGRealDiagonalMatrix const * thing) const
   return ret;
 }
 
-OGOwningRealMatrix *
+OGRealMatrix *
 ConvertTo::convertToOGRealMatrix(OGLogicalMatrix const * thing) const
 {
   int rows = thing->getRows();
   int cols = thing->getCols();
   int wlen = thing->getDatalen();
-  OGOwningRealMatrix * ret = new OGOwningRealMatrix(rows,cols);
+  OGRealMatrix * ret = new OGRealMatrix(new real16[wlen](),rows,cols, OWNER);
   real16 * thedata = thing->getData();
   real16 * data = ret->getData();
   memcpy(data,thedata,sizeof(real16)*wlen);
@@ -65,7 +65,7 @@ ConvertTo::convertToOGRealMatrix(OGLogicalMatrix const * thing) const
 }
 
 
-OGOwningRealMatrix *
+OGRealMatrix *
 ConvertTo::convertToOGRealMatrix(OGRealSparseMatrix const * thing) const
 {
 
@@ -75,7 +75,7 @@ ConvertTo::convertToOGRealMatrix(OGRealSparseMatrix const * thing) const
   int * rowIdx = thing->getRowIdx();
   real16 * sparsedata = thing->getData();
 
-  OGOwningRealMatrix * ret = new OGOwningRealMatrix(rows,cols);
+  OGRealMatrix * ret = new OGRealMatrix(new real16[rows*cols](),rows,cols, OWNER);
   real16 * data = ret->getData();
   for (int ir = 0; ir < cols; ir++)
   {
@@ -90,37 +90,37 @@ ConvertTo::convertToOGRealMatrix(OGRealSparseMatrix const * thing) const
 
 // things that convert to OGComplexMatrix
 
-OGOwningComplexMatrix *
+OGComplexMatrix *
 ConvertTo::convertToOGComplexMatrix(OGRealScalar const * thing) const
 {
-  OGOwningComplexMatrix * ret = new OGOwningComplexMatrix(1,1);
+  OGComplexMatrix * ret = new OGComplexMatrix(new complex16[1](),1,1, OWNER);
   ret->getData()[0]=thing->getValue();
   return ret;
 }
 
-OGOwningComplexMatrix *
+OGComplexMatrix *
 ConvertTo::convertToOGComplexMatrix(OGIntegerScalar const * thing) const
 {
-  OGOwningComplexMatrix * ret = new OGOwningComplexMatrix(1,1);
+  OGComplexMatrix * ret = new OGComplexMatrix(new complex16[1](),1,1, OWNER);
   ret->getData()[0]=thing->getValue();
   return ret;
 }
 
-OGOwningComplexMatrix *
+OGComplexMatrix *
 ConvertTo::convertToOGComplexMatrix(OGComplexScalar const * thing) const
 {
-  OGOwningComplexMatrix * ret = new OGOwningComplexMatrix(1,1);
+  OGComplexMatrix * ret = new OGComplexMatrix(new complex16[1](),1,1, OWNER);
   ret->getData()[0]=thing->getValue();
   return ret;
 }
 
-OGOwningComplexMatrix *
+OGComplexMatrix *
 ConvertTo::convertToOGComplexMatrix(OGRealDiagonalMatrix const * thing) const
 {
   int rows = thing->getRows();
   int cols = thing->getCols();
   int wlen = thing->getDatalen();
-  OGOwningComplexMatrix * ret = new OGOwningComplexMatrix(rows,cols);
+  OGComplexMatrix * ret = new OGComplexMatrix(new complex16[rows*cols](),rows,cols, OWNER);
   real16 * diagdata = thing->getData();
   complex16 * data = ret->getData();
   for(int i=0;i<wlen;i++)
@@ -130,13 +130,13 @@ ConvertTo::convertToOGComplexMatrix(OGRealDiagonalMatrix const * thing) const
   return ret;
 }
 
-OGOwningComplexMatrix *
+OGComplexMatrix *
 ConvertTo::convertToOGComplexMatrix(OGComplexDiagonalMatrix const * thing) const
 {
   int rows = thing->getRows();
   int cols = thing->getCols();
   int wlen = thing->getDatalen();
-  OGOwningComplexMatrix * ret = new OGOwningComplexMatrix(rows,cols);
+  OGComplexMatrix * ret = new OGComplexMatrix(new complex16[rows*cols](),rows,cols, OWNER);
   complex16 * diagdata = thing->getData();
   complex16 * data = ret->getData();
   for(int i=0;i<wlen;i++)
@@ -146,7 +146,7 @@ ConvertTo::convertToOGComplexMatrix(OGComplexDiagonalMatrix const * thing) const
   return ret;
 }
 
-OGOwningComplexMatrix *
+OGComplexMatrix *
 ConvertTo::convertToOGComplexMatrix(OGRealSparseMatrix const * thing) const
 {
   int rows = thing->getRows();
@@ -154,7 +154,7 @@ ConvertTo::convertToOGComplexMatrix(OGRealSparseMatrix const * thing) const
   int * colPtr = thing->getColPtr();
   int * rowIdx = thing->getRowIdx();
   real16 * sparsedata = thing->getData();
-  OGOwningComplexMatrix * ret = new OGOwningComplexMatrix(rows,cols);
+  OGComplexMatrix * ret = new OGComplexMatrix(new complex16[rows*cols](),rows,cols, OWNER);
   complex16 * data = ret->getData();
   for (int ir = 0; ir < cols; ir++)
   {
@@ -166,7 +166,7 @@ ConvertTo::convertToOGComplexMatrix(OGRealSparseMatrix const * thing) const
   return ret;
 }
 
-OGOwningComplexMatrix *
+OGComplexMatrix *
 ConvertTo::convertToOGComplexMatrix(OGComplexSparseMatrix const * thing) const
 {
   int rows = thing->getRows();
@@ -174,7 +174,7 @@ ConvertTo::convertToOGComplexMatrix(OGComplexSparseMatrix const * thing) const
   int * colPtr = thing->getColPtr();
   int * rowIdx = thing->getRowIdx();
   complex16 * sparsedata = thing->getData();
-  OGOwningComplexMatrix * ret = new OGOwningComplexMatrix(rows,cols);
+  OGComplexMatrix * ret = new OGComplexMatrix(new complex16[rows*cols](),rows,cols, OWNER);
   complex16 * data = ret->getData();
   for (int ir = 0; ir < cols; ir++)
   {
@@ -186,13 +186,13 @@ ConvertTo::convertToOGComplexMatrix(OGComplexSparseMatrix const * thing) const
   return ret;
 }
 
-OGOwningComplexMatrix *
+OGComplexMatrix *
 ConvertTo::convertToOGComplexMatrix(OGRealMatrix const * thing) const
 {
   int rows = thing->getRows();
   int cols = thing->getCols();
   int wlen = thing->getDatalen();
-  OGOwningComplexMatrix * ret = new OGOwningComplexMatrix(rows,cols);
+  OGComplexMatrix * ret = new OGComplexMatrix(new complex16[wlen](),rows,cols, OWNER);
   real16 * densedata = thing->getData();
   complex16 * data = ret->getData();
   for(int i=0;i<wlen;i++)
@@ -202,13 +202,13 @@ ConvertTo::convertToOGComplexMatrix(OGRealMatrix const * thing) const
   return ret;
 }
 
-OGOwningComplexMatrix *
+OGComplexMatrix *
 ConvertTo::convertToOGComplexMatrix(OGLogicalMatrix const * thing) const
 {
   int rows = thing->getRows();
   int cols = thing->getCols();
   int wlen = thing->getDatalen();
-  OGOwningComplexMatrix * ret = new OGOwningComplexMatrix(rows,cols);
+  OGComplexMatrix * ret = new OGComplexMatrix(new complex16[wlen](),rows,cols, OWNER);
   real16 * densedata = thing->getData();
   complex16 * data = ret->getData();
   for(int i=0;i<wlen;i++)

--- a/src/librdag/terminal.cc
+++ b/src/librdag/terminal.cc
@@ -243,6 +243,48 @@ OGScalar<T>::fuzzyequals(const OGTerminal * other) const
   return true;
 }
 
+template<typename T>
+OGRealMatrix *
+OGScalar<T>::asFullOGRealMatrix() const
+{
+  throw rdag_error("Cannot asFullOGRealMatrix() template OGScalar<T> class.");
+}
+
+template<typename T>
+OGComplexMatrix  *
+OGScalar<T>::asFullOGComplexMatrix() const
+{
+  throw rdag_error("Cannot asFullOGComplexMatrix() template OGScalar<T> class.");
+}
+
+template<typename T>
+OGTerminal *
+OGScalar<T>::createOwningCopy() const
+{
+  throw rdag_error("Cannot createOwningCopy() template OGScalar<T> class.");
+}
+
+template<typename T>
+OGTerminal *
+OGScalar<T>::createComplexOwningCopy() const
+{
+  throw rdag_error("Cannot createComplexOwningCopy() template OGScalar<T> class.");
+}
+
+template<typename T>
+void
+OGScalar<T>::debug_print() const
+{
+  cout << "OGScalar<T>: " << setprecision(__DEBUG_PRECISION) << this->getValue() << endl;
+}
+
+template<typename T>
+OGNumeric *
+OGScalar<T>::copy() const
+{
+  throw rdag_error("Cannot copy() template OGScalar<T> class.");
+}
+
 
 template class OGScalar<real16>;
 template class OGScalar<complex16>;

--- a/src/librdag/terminal.cc
+++ b/src/librdag/terminal.cc
@@ -1021,7 +1021,7 @@ OGRealDiagonalMatrix::asFullOGComplexMatrix() const
 OGTerminal *
 OGRealDiagonalMatrix::createOwningCopy() const
 {
-  real16 * newdata =  new real16[this->getDatalen()]();
+  real16 * newdata =  new real16[this->getDatalen()];
   std::copy(this->getData(), this->getData()+this->getDatalen(), newdata);
   return new OGRealDiagonalMatrix(newdata, this->getRows(), this->getCols(), OWNER);
 }
@@ -1029,7 +1029,7 @@ OGRealDiagonalMatrix::createOwningCopy() const
 OGTerminal *
 OGRealDiagonalMatrix::createComplexOwningCopy() const
 {
-  complex16 * newdata =  new complex16[this->getDatalen()]();
+  complex16 * newdata =  new complex16[this->getDatalen()];
   std::copy(this->getData(), this->getData()+this->getDatalen(), newdata);
   return new OGComplexDiagonalMatrix(newdata, this->getRows(), this->getCols(), OWNER);
 }

--- a/src/librdag/terminal.cc
+++ b/src/librdag/terminal.cc
@@ -684,7 +684,7 @@ template class OGArray<complex16>;
  */
 
 template<typename T>
-OGMatrix<T>::OGMatrix(T* data, int rows, int cols)
+OGMatrix<T>::OGMatrix(T* data, int rows, int cols, DATA_ACCESS access_spec)
 {
   if (data == nullptr)
   {
@@ -694,11 +694,6 @@ OGMatrix<T>::OGMatrix(T* data, int rows, int cols)
   this->setRows(rows);
   this->setCols(cols);
   this->setDatalen(rows*cols);
-}
-
-template<typename T>
-OGMatrix<T>::OGMatrix(T* data, int rows, int cols, DATA_ACCESS access_spec):OGMatrix(data,rows,cols)
-{
   this->setDataAccess(access_spec);
 }
 
@@ -727,9 +722,6 @@ OGMatrix<T>::toArrayOfArrays() const
   }
   return tmp;
 }
-
-template<typename T>
-OGMatrix<T>::~OGMatrix(){}
 
 template class OGMatrix<real16>;
 template class OGMatrix<complex16>;
@@ -882,9 +874,8 @@ OGComplexMatrix::createComplexOwningCopy() const
  * OGDiagonalMatrix
  */
 
-
 template<typename T>
-OGDiagonalMatrix<T>::OGDiagonalMatrix(T* data, int rows, int cols)
+OGDiagonalMatrix<T>::OGDiagonalMatrix(T* data, int rows, int cols, DATA_ACCESS access_spec)
 {
   if (data == nullptr)
   {
@@ -894,17 +885,8 @@ OGDiagonalMatrix<T>::OGDiagonalMatrix(T* data, int rows, int cols)
   this->setRows(rows);
   this->setCols(cols);
   this->setDatalen(rows>cols?cols:rows);
-}
-
-template<typename T>
-OGDiagonalMatrix<T>::OGDiagonalMatrix(T* data, int rows, int cols, DATA_ACCESS access_spec):OGDiagonalMatrix(data,rows,cols)
-{
   this->setDataAccess(access_spec);
 }
-
-template<typename T>
-OGDiagonalMatrix<T>::~OGDiagonalMatrix()
-{}
 
 template<typename T>
 void
@@ -1117,7 +1099,7 @@ OGComplexDiagonalMatrix::asFullOGComplexMatrix() const
 OGTerminal *
 OGComplexDiagonalMatrix::createOwningCopy() const
 {
-  complex16 * newdata =  new complex16[this->getDatalen()]();
+  complex16 * newdata =  new complex16[this->getDatalen()];
   std::copy(this->getData(), this->getData()+this->getDatalen(), newdata);
   return new OGComplexDiagonalMatrix(newdata, this->getRows(), this->getCols(), OWNER);
 }
@@ -1135,7 +1117,7 @@ OGComplexDiagonalMatrix::createComplexOwningCopy() const
  */
 
 template<typename T>
-OGSparseMatrix<T>::OGSparseMatrix(int * colPtr, int * rowIdx, T* data, int rows, int cols)
+OGSparseMatrix<T>::OGSparseMatrix(int * colPtr, int * rowIdx, T* data, int rows, int cols, DATA_ACCESS access_spec)
 {
   if (data == nullptr)
   {
@@ -1146,12 +1128,7 @@ OGSparseMatrix<T>::OGSparseMatrix(int * colPtr, int * rowIdx, T* data, int rows,
   this->setCols(cols);
   this->setColPtr(colPtr);
   this->setRowIdx(rowIdx);
-  this->setDatalen(colPtr[cols]); // must go last to catch null on colptr happens  
-}
-
-template<typename T>
-OGSparseMatrix<T>::OGSparseMatrix(int * colPtr, int * rowIdx, T* data, int rows, int cols, DATA_ACCESS access_spec):OGSparseMatrix(colPtr, rowIdx, data, rows, cols)
-{
+  this->setDatalen(colPtr[cols]); // must go last to catch null on colptr happens
   this->setDataAccess(access_spec);
 }
 

--- a/src/librdag/terminal.cc
+++ b/src/librdag/terminal.cc
@@ -11,8 +11,11 @@
 #include "warningmacros.h"
 #include "equals.hh"
 #include "iss.hh"
+#include "debug.h"
 #include "convertto.hh"
 #include <iostream>
+#include <iostream>
+#include <iomanip>
 
 namespace librdag {
 
@@ -571,6 +574,41 @@ OGArray<T>::setDataAccess(DATA_ACCESS access_spec)
   _data_access = access_spec;
 }
 
+template<typename T>
+OGRealMatrix *
+OGArray<T>::
+asFullOGRealMatrix() const
+{
+  // this is a default backstop impl whilst waiting for a traited version
+  throw rdag_error("Cannot convert asFullOGRealMatrix(), concrete implementation class required for operation.");
+}
+
+template<typename T>
+OGComplexMatrix *
+OGArray<T>::
+asFullOGComplexMatrix() const
+{
+  // this is a default backstop impl whilst waiting for a traited version
+  throw rdag_error("Cannot convert asFullOGComplexMatrix(), concrete implementation class required for operation.");
+}
+
+template<typename T>
+OGTerminal *
+OGArray<T>::
+createOwningCopy() const
+{
+  // this is a default backstop impl whilst waiting for a traited version
+  throw rdag_error("Cannot createOwningCopy(), concrete implementation class required for operation.");
+}
+
+template<typename T>
+OGTerminal *
+OGArray<T>::
+createComplexOwningCopy() const
+{
+  // this is a default backstop impl whilst waiting for a traited version
+  throw rdag_error("Cannot createComplexOwningCopy(), concrete implementation class required for operation.");
+}
 
 template class OGArray<real16>;
 template class OGArray<complex16>;
@@ -630,25 +668,27 @@ OGMatrix<T>::~OGMatrix(){}
 template class OGMatrix<real16>;
 template class OGMatrix<complex16>;
 
-/**
- * OGRealMatrix
- */
-
+template<typename T>
 void
-OGRealMatrix::debug_print() const
+OGMatrix<T>::debug_print() const
 {
-  printf("\n");
+  cout << std::endl;
   int lim = (this->getCols()-1);
   int rows = this->getRows();
   for(int i = 0 ; i < rows; i++)
   {
-    for(int j = 0 ; j < lim; j++)
+    for(int j = 0 ; j < lim-1; j++)
     {
-      printf("%6.4f, ",this->getData()[j*rows+i]);
+      cout << setprecision(__DEBUG_PRECISION) << this->getData()[j*rows+i] << ", ";
     }
-    printf("%6.4f\n",this->getData()[lim*rows+i]);
+    cout << this->getData()[lim*rows+i] << std::endl;
   }
 }
+
+
+/**
+ * OGRealMatrix
+ */
 
 real16**
 OGRealMatrix::toReal16ArrayOfArrays() const
@@ -717,23 +757,6 @@ OGLogicalMatrix::asOGLogicalMatrix() const
 /**
  * OGComplexMatrix
  */
-
-void
-OGComplexMatrix::debug_print() const
-{
-  printf("\n");
-  int lim = (this->getCols()-1);
-  int rows = this->getRows();
-  for(int i = 0 ; i < rows; i++)
-  {
-    for(int j = 0 ; j < lim; j++)
-    {
-      printf("%6.4f + %6.4fi, ",this->getData()[j*rows+i].real(),this->getData()[j*rows+i].imag());
-    }
-      printf("%6.4f + %6.4fi, ",this->getData()[lim*rows+i].real(),this->getData()[lim*rows+i].imag());
-  }
-
-}
 
 complex16**
 OGComplexMatrix::toComplex16ArrayOfArrays() const

--- a/src/librdag/terminal.cc
+++ b/src/librdag/terminal.cc
@@ -575,6 +575,30 @@ OGArray<T>::setDataAccess(DATA_ACCESS access_spec)
 }
 
 template<typename T>
+void
+OGArray<T>::
+debug_print() const
+{
+  throw rdag_error("Cannot debug_print abstract OGArray<T> class.");
+}
+
+template<typename T>
+OGNumeric *
+OGArray<T>::
+copy() const
+{
+  throw rdag_error("Cannot copy abstract OGArray<T> class.");
+}
+
+template<typename T>
+void
+OGArray<T>::
+accept(Visitor SUPPRESS_UNUSED &v) const
+{
+  throw rdag_error("Cannot visit abstract OGArray<T> class.");
+}
+
+template<typename T>
 OGRealMatrix *
 OGArray<T>::
 asFullOGRealMatrix() const

--- a/src/librdag/terminal.cc
+++ b/src/librdag/terminal.cc
@@ -1061,6 +1061,22 @@ OGSparseMatrix<T>::OGSparseMatrix(int * colPtr, int * rowIdx, T* data, int rows,
 }
 
 template<typename T>
+OGSparseMatrix<T>::OGSparseMatrix(int * colPtr, int * rowIdx, T* data, int rows, int cols, DATA_ACCESS access_spec):OGSparseMatrix(colPtr, rowIdx, data, rows, cols)
+{
+  this->setDataAccess(access_spec);
+}
+
+template<typename T>
+OGSparseMatrix<T>::~OGSparseMatrix()
+{
+  if(this->getDataAccess() == OWNER)
+  {
+    delete[] this->getColPtr();
+    delete[] this->getRowIdx();
+  }
+}
+
+template<typename T>
 void
 OGSparseMatrix<T>::accept(Visitor &v) const
 {
@@ -1242,7 +1258,7 @@ OGRealSparseMatrix::createOwningCopy() const
   std::copy(this->getColPtr(), this->getColPtr()+this->getCols()+1, newColPtr);
   int * newRowIdx = new int[this->getDatalen()];
   std::copy(this->getRowIdx(), this->getRowIdx()+this->getDatalen(), newRowIdx);
-  return new OGOwningRealSparseMatrix(newColPtr, newRowIdx, newdata, this->getRows(), this->getCols());
+  return new OGRealSparseMatrix(newColPtr, newRowIdx, newdata, this->getRows(), this->getCols(), OWNER);
 }
 
 OGTerminal *
@@ -1254,19 +1270,8 @@ OGRealSparseMatrix::createComplexOwningCopy() const
   std::copy(this->getColPtr(), this->getColPtr()+this->getCols()+1, newColPtr);
   int * newRowIdx = new int[this->getDatalen()];
   std::copy(this->getRowIdx(), this->getRowIdx()+this->getDatalen(), newRowIdx);
-  return new OGOwningComplexSparseMatrix(newColPtr, newRowIdx, newdata, this->getRows(), this->getCols());
+  return new OGComplexSparseMatrix(newColPtr, newRowIdx, newdata, this->getRows(), this->getCols(), OWNER);
 }
-
-/**
- * OGOwningRealSparseMatrix
- */
-OGOwningRealSparseMatrix::~OGOwningRealSparseMatrix()
-{
-  delete [] this->getColPtr();
-  delete [] this->getRowIdx();
-  delete [] this->getData();
-}
-
 
 /**
  * OGComplexSparseMatrix
@@ -1340,25 +1345,13 @@ OGComplexSparseMatrix::createOwningCopy() const
   std::copy(this->getColPtr(), this->getColPtr()+this->getCols()+1, newColPtr);
   int * newRowIdx = new int[this->getDatalen()];
   std::copy(this->getRowIdx(), this->getRowIdx()+this->getDatalen(), newRowIdx);
-  return new OGOwningComplexSparseMatrix(newColPtr, newRowIdx, newdata, this->getRows(), this->getCols());
+  return new OGComplexSparseMatrix(newColPtr, newRowIdx, newdata, this->getRows(), this->getCols(), OWNER);
 }
 
 OGTerminal *
 OGComplexSparseMatrix::createComplexOwningCopy() const
 {
   return this->createOwningCopy();
-}
-
-
-
-/**
- * OGOwningComplexSparseMatrix
- */
-OGOwningComplexSparseMatrix::~OGOwningComplexSparseMatrix()
-{
-  delete [] this->getColPtr();
-  delete [] this->getRowIdx();
-  delete [] this->getData();
 }
 
 } // namespace librdag

--- a/src/librdag/terminal.cc
+++ b/src/librdag/terminal.cc
@@ -426,6 +426,15 @@ OGIntegerScalar::createComplexOwningCopy() const
  */
 
 template<typename T>
+OGArray<T>::~OGArray()
+{
+  if(this->getDataAccess() == OWNER)
+  {
+    delete [] this->getData();
+  }
+}
+
+template<typename T>
 T*
 OGArray<T>::getData() const
 {
@@ -616,13 +625,7 @@ OGMatrix<T>::toArrayOfArrays() const
 }
 
 template<typename T>
-OGMatrix<T>::~OGMatrix()
-{
-  if(this->getDataAccess() == OWNER)
-  {
-    delete [] this->getData();
-  }
-}
+OGMatrix<T>::~OGMatrix(){}
 
 template class OGMatrix<real16>;
 template class OGMatrix<complex16>;
@@ -805,6 +808,16 @@ OGDiagonalMatrix<T>::OGDiagonalMatrix(T* data, int rows, int cols)
 }
 
 template<typename T>
+OGDiagonalMatrix<T>::OGDiagonalMatrix(T* data, int rows, int cols, DATA_ACCESS access_spec):OGDiagonalMatrix(data,rows,cols)
+{
+  this->setDataAccess(access_spec);
+}
+
+template<typename T>
+OGDiagonalMatrix<T>::~OGDiagonalMatrix()
+{}
+
+template<typename T>
 void
 OGDiagonalMatrix<T>::accept(Visitor &v) const
 {
@@ -919,25 +932,17 @@ OGRealDiagonalMatrix::asFullOGComplexMatrix() const
 OGTerminal *
 OGRealDiagonalMatrix::createOwningCopy() const
 {
-  real16 * newdata =  new real16[this->getDatalen()];
+  real16 * newdata =  new real16[this->getDatalen()]();
   std::copy(this->getData(), this->getData()+this->getDatalen(), newdata);
-  return new OGOwningRealDiagonalMatrix(newdata, this->getRows(), this->getCols());
+  return new OGRealDiagonalMatrix(newdata, this->getRows(), this->getCols(), OWNER);
 }
 
 OGTerminal *
 OGRealDiagonalMatrix::createComplexOwningCopy() const
 {
-  complex16 * newdata =  new complex16[this->getDatalen()];
+  complex16 * newdata =  new complex16[this->getDatalen()]();
   std::copy(this->getData(), this->getData()+this->getDatalen(), newdata);
-  return new OGOwningComplexDiagonalMatrix(newdata, this->getRows(), this->getCols());
-}
-
-/**
- * OGOwningRealDiagonalMatrix
- */
-OGOwningRealDiagonalMatrix::~OGOwningRealDiagonalMatrix()
-{
-  delete [] this->getData();
+  return new OGComplexDiagonalMatrix(newdata, this->getRows(), this->getCols(), OWNER);
 }
 
 
@@ -1023,9 +1028,9 @@ OGComplexDiagonalMatrix::asFullOGComplexMatrix() const
 OGTerminal *
 OGComplexDiagonalMatrix::createOwningCopy() const
 {
-  complex16 * newdata =  new complex16[this->getDatalen()];
+  complex16 * newdata =  new complex16[this->getDatalen()]();
   std::copy(this->getData(), this->getData()+this->getDatalen(), newdata);
-  return new OGOwningComplexDiagonalMatrix(newdata, this->getRows(), this->getCols());
+  return new OGComplexDiagonalMatrix(newdata, this->getRows(), this->getCols(), OWNER);
 }
 
 OGTerminal *
@@ -1035,13 +1040,6 @@ OGComplexDiagonalMatrix::createComplexOwningCopy() const
 }
 
 
-/**
- * OGOwningComplexDiagonalMatrix
- */
-OGOwningComplexDiagonalMatrix::~OGOwningComplexDiagonalMatrix()
-{
-  delete [] this->getData();
-}
 
 /**
  * OGSparseMatrix

--- a/src/librdag/test/CMakeLists.txt
+++ b/src/librdag/test/CMakeLists.txt
@@ -9,7 +9,20 @@ SET(CMAKE_FC_FLAGS  "${CMAKE_FC_FLAGS} ${GCC_COVERAGE_COMPILE_FLAGS} -cpp" )
 
 link_directories(${longdog_BINARY_DIR}/src/librdag)
 
-set(TESTS check_expressions check_containers check_execution check_rtti check_terminals check_entrypt check_dispatch check_equals check_numerictypes check_convertto check_iss)
+set(TESTS
+  check_containers
+  check_convertto
+  check_dispatch
+  check_entrypt
+  check_equals
+  check_execution
+  check_expressions
+  check_iss
+  check_numerictypes
+  check_rtti
+  check_terminals
+  check_terminals_abstract_regression
+  )
 
 if(NOT WIN32)
   set(TESTS ${TESTS} check_exceptions)

--- a/src/librdag/test/check_convertto.cc
+++ b/src/librdag/test/check_convertto.cc
@@ -22,7 +22,7 @@ TEST(ConvertToTest, OGRealScalarConvertToOGRealMatrix) {
   data[0]=value;
   OGRealMatrix * expected = new OGRealMatrix(data,1,1);
   ConvertTo * c = new ConvertTo();
-  OGOwningRealMatrix * answer = c->convertToOGRealMatrix(scalar);
+  OGRealMatrix * answer = c->convertToOGRealMatrix(scalar);
   ASSERT_TRUE(*expected==~*answer);
 
 
@@ -42,7 +42,7 @@ TEST(ConvertToTest, OGIntegerScalarConvertToOGRealMatrix) {
   data[0]=value;
   OGRealMatrix * expected = new OGRealMatrix(data,1,1);
   ConvertTo * c = new ConvertTo();
-  OGOwningRealMatrix * answer = c->convertToOGRealMatrix(scalar);
+  OGRealMatrix * answer = c->convertToOGRealMatrix(scalar);
   ASSERT_TRUE(*expected==~*answer);
 
   delete c;
@@ -60,7 +60,7 @@ TEST(ConvertToTest, OGLogicalMatrixConvertToOGRealMatrix) {
   real16 * expected_values = new real16[12]{1,0,1,0,1,0,1,0,1,0,1,0};
   OGRealMatrix * expected = new OGRealMatrix(expected_values,3,4);
   ConvertTo * c = new ConvertTo();
-  OGOwningRealMatrix * answer = c->convertToOGRealMatrix(input);
+  OGRealMatrix * answer = c->convertToOGRealMatrix(input);
   ASSERT_TRUE(*expected==~*answer);
 
   delete c;
@@ -79,7 +79,7 @@ TEST(ConvertToTest, OGRealDiagonalMatrixConvertToOGRealMatrix) {
   OGRealDiagonalMatrix * input = new OGRealDiagonalMatrix(input_values,4,6);
   OGRealMatrix * expected = new OGRealMatrix(expected_values,4,6);
   ConvertTo * c = new ConvertTo();
-  OGOwningRealMatrix * answer = c->convertToOGRealMatrix(input);
+  OGRealMatrix * answer = c->convertToOGRealMatrix(input);
   ASSERT_TRUE(*expected==~*answer);
 
 
@@ -101,7 +101,7 @@ TEST(ConvertToTest, OGRealSparseMatrixConvertToOGRealMatrix) {
   OGRealSparseMatrix * input = new OGRealSparseMatrix(input_colPtr, input_rowIdx, input_values,4,3);
   OGRealMatrix * expected = new OGRealMatrix(expected_values,4,3);
   ConvertTo * c = new ConvertTo();
-  OGOwningRealMatrix * answer = c->convertToOGRealMatrix(input);
+  OGRealMatrix * answer = c->convertToOGRealMatrix(input);
   ASSERT_TRUE(*expected==~*answer);
 
 
@@ -125,7 +125,7 @@ TEST(ConvertToTest, OGRealScalarConvertToOGComplexMatrix) {
   data[0]=value;
   OGComplexMatrix * expected = new OGComplexMatrix(data,1,1);
   ConvertTo * c = new ConvertTo();
-  OGOwningComplexMatrix * answer = c->convertToOGComplexMatrix(scalar);
+  OGComplexMatrix * answer = c->convertToOGComplexMatrix(scalar);
   ASSERT_TRUE(*expected==~*answer);
 
   delete c;
@@ -144,7 +144,7 @@ TEST(ConvertToTest, OGIntegerScalarConvertToOGComplexMatrix) {
   data[0]=value;
   OGComplexMatrix * expected = new OGComplexMatrix(data,1,1);
   ConvertTo * c = new ConvertTo();
-  OGOwningComplexMatrix * answer = c->convertToOGComplexMatrix(scalar);
+  OGComplexMatrix * answer = c->convertToOGComplexMatrix(scalar);
   ASSERT_TRUE(*expected==~*answer);
 
   delete c;
@@ -163,7 +163,7 @@ TEST(ConvertToTest, OGComplexScalarConvertToOGComplexMatrix) {
   data[0]=value;
   OGComplexMatrix * expected = new OGComplexMatrix(data,1,1);
   ConvertTo * c = new ConvertTo();
-  OGOwningComplexMatrix * answer = c->convertToOGComplexMatrix(scalar);
+  OGComplexMatrix * answer = c->convertToOGComplexMatrix(scalar);
   ASSERT_TRUE(*expected==~*answer);
 
 
@@ -183,7 +183,7 @@ TEST(ConvertToTest, OGRealDiagonalMatrixConvertToOGComplexMatrix) {
   OGRealDiagonalMatrix * input = new OGRealDiagonalMatrix(input_values,4,6);
   OGComplexMatrix * expected = new OGComplexMatrix(expected_values,4,6);
   ConvertTo * c = new ConvertTo();
-  OGOwningComplexMatrix * answer = c->convertToOGComplexMatrix(input);
+  OGComplexMatrix * answer = c->convertToOGComplexMatrix(input);
   ASSERT_TRUE(*expected==~*answer);
 
 
@@ -204,7 +204,7 @@ TEST(ConvertToTest, OGComplexDiagonalMatrixConvertToOGComplexMatrix) {
   OGComplexDiagonalMatrix * input = new OGComplexDiagonalMatrix(input_values,4,6);
   OGComplexMatrix * expected = new OGComplexMatrix(expected_values,4,6);
   ConvertTo * c = new ConvertTo();
-  OGOwningComplexMatrix * answer = c->convertToOGComplexMatrix(input);
+  OGComplexMatrix * answer = c->convertToOGComplexMatrix(input);
   ASSERT_TRUE(*expected==~*answer);
 
 
@@ -226,7 +226,7 @@ TEST(ConvertToTest, OGRealSparseMatrixConvertToOGComplexMatrix) {
   OGRealSparseMatrix * input = new OGRealSparseMatrix(input_colPtr, input_rowIdx, input_values,4,3);
   OGComplexMatrix * expected = new OGComplexMatrix(expected_values,4,3);
   ConvertTo * c = new ConvertTo();
-  OGOwningComplexMatrix * answer = c->convertToOGComplexMatrix(input);
+  OGComplexMatrix * answer = c->convertToOGComplexMatrix(input);
   ASSERT_TRUE(*expected==~*answer);
 
 
@@ -251,7 +251,7 @@ TEST(ConvertToTest, OGComplexSparseMatrixConvertToOGComplexMatrix) {
   OGComplexSparseMatrix * input = new OGComplexSparseMatrix(input_colPtr, input_rowIdx, input_values,4,3);
   OGComplexMatrix * expected = new OGComplexMatrix(expected_values,4,3);
   ConvertTo * c = new ConvertTo();
-  OGOwningComplexMatrix * answer = c->convertToOGComplexMatrix(input);
+  OGComplexMatrix * answer = c->convertToOGComplexMatrix(input);
   ASSERT_TRUE(*expected==~*answer);
 
 
@@ -274,7 +274,7 @@ TEST(ConvertToTest, OGRealMatrixConvertToOGComplexMatrix) {
   OGRealMatrix * input = new OGRealMatrix(input_values,4,3);
   OGComplexMatrix * expected = new OGComplexMatrix(expected_values,4,3);
   ConvertTo * c = new ConvertTo();
-  OGOwningComplexMatrix * answer = c->convertToOGComplexMatrix(input);
+  OGComplexMatrix * answer = c->convertToOGComplexMatrix(input);
   ASSERT_TRUE(*expected==~*answer);
 
 
@@ -295,7 +295,7 @@ TEST(ConvertToTest, OGRealMatrixConvertToOGLogicalMatrix) {
   OGLogicalMatrix * input = new OGLogicalMatrix(input_values,4,3);
   OGComplexMatrix * expected = new OGComplexMatrix(expected_values,4,3);
   ConvertTo * c = new ConvertTo();
-  OGOwningComplexMatrix * answer = c->convertToOGComplexMatrix(input);
+  OGComplexMatrix * answer = c->convertToOGComplexMatrix(input);
   ASSERT_TRUE(*expected==~*answer);
 
   delete c;

--- a/src/librdag/test/check_equals.cc
+++ b/src/librdag/test/check_equals.cc
@@ -420,9 +420,9 @@ TEST(EqualsTest, OGRealSparseMatrix) {
   OGRealSparseMatrix * badcolptr = new OGRealSparseMatrix(colPtr2, rowIdx, r_data1, rows, cols);
   OGRealSparseMatrix * badrowidx = new OGRealSparseMatrix(colPtr, rowIdx2, r_data1, rows, cols);
   OGRealScalar * badtype = new OGRealScalar(1.0e0);
-  OGRealSparseMatrix * r_comparable_sparse = new OGOwningRealSparseMatrix(new int[6] {0, 2, 4, 7, 7, 7}, new int[7] {0, 1, 0, 2, 1, 2, 3 }, new real16[7] {1.0e0, 3.0e0, 2.0e0, 5.0e0, 4.0e0, 6.0e0, 7.0e0 }, 5, 4);
+  OGRealSparseMatrix * r_comparable_sparse = new OGRealSparseMatrix(new int[6] {0, 2, 4, 7, 7, 7}, new int[7] {0, 1, 0, 2, 1, 2, 3 }, new real16[7] {1.0e0, 3.0e0, 2.0e0, 5.0e0, 4.0e0, 6.0e0, 7.0e0 }, 5, 4, OWNER);
   OGRealMatrix * r_notcomparable = new OGRealMatrix(new real16[4]{1.e0,2.e0,3.e0,5.e0},2,2,OWNER);
-  OGComplexSparseMatrix * c_comparable_sparse = new OGOwningComplexSparseMatrix(new int[6] {0, 2, 4, 7, 7, 7}, new int[7] {0, 1, 0, 2, 1, 2, 3 }, new complex16[7] {{1.0e0,0.e0}, {3.0e0,0.e0}, {2.0e0,0.e0}, {5.0e0,0.e0}, {4.0e0,0.e0}, {6.0e0,0.e0}, {7.0e0,0.e0}}, 5, 4);
+  OGComplexSparseMatrix * c_comparable_sparse = new OGComplexSparseMatrix(new int[6] {0, 2, 4, 7, 7, 7}, new int[7] {0, 1, 0, 2, 1, 2, 3 }, new complex16[7] {{1.0e0,0.e0}, {3.0e0,0.e0}, {2.0e0,0.e0}, {5.0e0,0.e0}, {4.0e0,0.e0}, {6.0e0,0.e0}, {7.0e0,0.e0}}, 5, 4, OWNER);
   OGComplexDiagonalMatrix * c_notcomparable = new OGComplexDiagonalMatrix(new complex16[4]{1.e0,2.e0,3.e0,5.e0},5,4, OWNER);
 
   ASSERT_TRUE(matrix->equals(same));
@@ -504,7 +504,7 @@ TEST(EqualsTest, OGComplexSparseMatrix) {
   OGComplexSparseMatrix * badrowidx = new OGComplexSparseMatrix(colPtr, rowIdx2, c_data1, rows, cols);
   OGRealScalar * badtype = new OGRealScalar(1.0e0);
   OGRealMatrix * r_notcomparable = new OGRealMatrix(new real16[4]{1.e0,2.e0,3.e0,5.e0},2,2,OWNER);
-  OGComplexSparseMatrix * c_comparable_sparse = new OGOwningComplexSparseMatrix(new int[6] {0, 2, 4, 7, 7, 7}, new int[7] {0, 1, 0, 2, 1, 2, 3 }, new complex16[7] {{1.0e0,10.0e0}, {3.0e0,30.0e0}, {2.0e0,20.0e0}, {5.0e0,50.0e0}, {4.0e0,40.0e0}, {6.0e0,60.0e0}, {7.0e0,70.0e0} }, 5, 4);
+  OGComplexSparseMatrix * c_comparable_sparse = new OGComplexSparseMatrix(new int[6] {0, 2, 4, 7, 7, 7}, new int[7] {0, 1, 0, 2, 1, 2, 3 }, new complex16[7] {{1.0e0,10.0e0}, {3.0e0,30.0e0}, {2.0e0,20.0e0}, {5.0e0,50.0e0}, {4.0e0,40.0e0}, {6.0e0,60.0e0}, {7.0e0,70.0e0} }, 5, 4, OWNER);
   OGComplexDiagonalMatrix * c_notcomparable = new OGComplexDiagonalMatrix(new complex16[4]{1.e0,2.e0,3.e0,5.e0},5,4, OWNER);
 
 
@@ -578,7 +578,7 @@ TEST(EqualsTest, OGRealDiagonalMatrix) {
   OGRealDiagonalMatrix * baddata = new OGRealDiagonalMatrix(r_data2,4,4);
   OGRealMatrix * comparable = new OGRealMatrix(r_fullmatrix,4,4);
   OGComplexMatrix * badtype = new OGComplexMatrix(c_data1,2,2);
-  OGRealSparseMatrix * r_comparable_sparse = new OGOwningRealSparseMatrix(new int[5] {0, 1, 2, 3, 4}, new int[4] {0, 1, 2, 3}, new real16[7] {1.0e0, 2.0e0, 3.0e0, 4.0e0}, 4, 4);
+  OGRealSparseMatrix * r_comparable_sparse = new OGRealSparseMatrix(new int[5] {0, 1, 2, 3, 4}, new int[4] {0, 1, 2, 3}, new real16[7] {1.0e0, 2.0e0, 3.0e0, 4.0e0}, 4, 4, OWNER);
   OGRealMatrix * r_notcomparable = new OGRealMatrix(new real16[4]{1.e0,2.e0,3.e0,5.e0},2,2,OWNER);
   OGComplexDiagonalMatrix * c_comparable_diag = new OGComplexDiagonalMatrix(new complex16[4] {{1.0e0,0.e0}, {2.0e0,0.e0}, {3.0e0,0.e0}, {4.0e0,0.e0}},4, 4, OWNER);
   OGComplexDiagonalMatrix * c_notcomparable = new OGComplexDiagonalMatrix(new complex16[4]{1.e0,2.e0,3.e0,5.e0},4,4, OWNER);

--- a/src/librdag/test/check_equals.cc
+++ b/src/librdag/test/check_equals.cc
@@ -152,10 +152,10 @@ TEST(EqualsTest, OGRealScalar) {
   OGRealScalar * same = new OGRealScalar(1.0e0);
   OGRealScalar * baddata = new OGRealScalar(2.0e0);
   OGComplexScalar * badtype = new OGComplexScalar({1.0e0,2.0e0});
-  OGRealMatrix * r_comparable = new OGOwningRealMatrix(new real16[1]{1.e0},1,1);
-  OGRealMatrix * r_notcomparable = new OGOwningRealMatrix(new real16[2]{1.e0,2.e0},1,2);
-  OGComplexMatrix * c_comparable = new OGOwningComplexMatrix(new complex16[1]{{1.e0,0.e0}},1,1);
-  OGComplexMatrix * c_notcomparable = new OGOwningComplexMatrix(new complex16[1]{{1.e0,2.e0}},1,1);
+  OGRealMatrix * r_comparable = new OGRealMatrix(new real16[1]{1.e0},1,1,OWNER);
+  OGRealMatrix * r_notcomparable = new OGRealMatrix(new real16[2]{1.e0,2.e0},1,2,OWNER);
+  OGComplexMatrix * c_comparable = new OGComplexMatrix(new complex16[1]{{1.e0,0.e0}},1,1, OWNER);
+  OGComplexMatrix * c_notcomparable = new OGComplexMatrix(new complex16[1]{{1.e0,2.e0}},1,1, OWNER);
 
   ASSERT_TRUE(scalar->equals(same));
   ASSERT_TRUE(*scalar==*same);
@@ -199,9 +199,9 @@ TEST(EqualsTest, OGComplexScalar) {
   OGComplexScalar * same = new OGComplexScalar({1.0e0,2.0e0});
   OGComplexScalar * baddata = new OGComplexScalar({-1.0e0,2.0e0});
   OGRealScalar * badtype = new OGRealScalar(1.0e0);
-  OGRealMatrix * r_notcomparable = new OGOwningRealMatrix(new real16[2]{1.e0,2.e0},1,2);
-  OGComplexMatrix * c_comparable = new OGOwningComplexMatrix(new complex16[1]{{1.e0,2.e0}},1,1);
-  OGComplexMatrix * c_notcomparable = new OGOwningComplexMatrix(new complex16[2]{{1.e0,2.e0},{3.e0,4.e0}},2,1);
+  OGRealMatrix * r_notcomparable = new OGRealMatrix(new real16[2]{1.e0,2.e0},1,2,OWNER);
+  OGComplexMatrix * c_comparable = new OGComplexMatrix(new complex16[1]{{1.e0,2.e0}},1,1, OWNER);
+  OGComplexMatrix * c_notcomparable = new OGComplexMatrix(new complex16[2]{{1.e0,2.e0},{3.e0,4.e0}},2,1, OWNER);
 
 
   ASSERT_TRUE(scalar->equals(same));
@@ -241,10 +241,10 @@ TEST(EqualsTest, OGIntegerScalar) {
   OGIntegerScalar * same = new OGIntegerScalar(1);
   OGIntegerScalar * baddata = new OGIntegerScalar(2);
   OGRealScalar * badtype = new OGRealScalar(1);
-  OGRealMatrix * r_comparable = new OGOwningRealMatrix(new real16[1]{1.e0},1,1);
-  OGRealMatrix * r_notcomparable = new OGOwningRealMatrix(new real16[2]{1.e0,2.e0},1,2);
-  OGComplexMatrix * c_comparable = new OGOwningComplexMatrix(new complex16[1]{{1.e0,0.e0}},1,1);
-  OGComplexMatrix * c_notcomparable = new OGOwningComplexMatrix(new complex16[1]{{1.e0,2.e0}},1,1);
+  OGRealMatrix * r_comparable = new OGRealMatrix(new real16[1]{1.e0},1,1,OWNER);
+  OGRealMatrix * r_notcomparable = new OGRealMatrix(new real16[2]{1.e0,2.e0},1,2,OWNER);
+  OGComplexMatrix * c_comparable = new OGComplexMatrix(new complex16[1]{{1.e0,0.e0}},1,1, OWNER);
+  OGComplexMatrix * c_notcomparable = new OGComplexMatrix(new complex16[1]{{1.e0,2.e0}},1,1, OWNER);
 
   ASSERT_TRUE(scalar->equals(same));
   ASSERT_TRUE(*scalar==*same);
@@ -291,10 +291,10 @@ TEST(EqualsTest, OGRealMatrix) {
   OGRealMatrix * baddata = new OGRealMatrix(r_data2,2,2);
   OGComplexMatrix * badtype = new OGComplexMatrix(c_data1,2,2);
 
-  OGRealMatrix * r_comparable = new OGOwningRealMatrix(new real16[4]{1.e0,2.e0,3.e0,4.e0},2,2);
-  OGRealMatrix * r_notcomparable = new OGOwningRealMatrix(new real16[4]{1.e0,2.e0,3.e0,5.e0},2,2);
-  OGComplexMatrix * c_comparable = new OGOwningComplexMatrix(new complex16[4]{{1.e0,0.e0},{2.e0,0.e0},{3.e0,0.e0},{4.e0,0.e0}},2,2);
-  OGComplexMatrix * c_notcomparable = new OGOwningComplexMatrix(new complex16[1]{{1.e0,2.e0}},1,1);
+  OGRealMatrix * r_comparable = new OGRealMatrix(new real16[4]{1.e0,2.e0,3.e0,4.e0},2,2,OWNER);
+  OGRealMatrix * r_notcomparable = new OGRealMatrix(new real16[4]{1.e0,2.e0,3.e0,5.e0},2,2,OWNER);
+  OGComplexMatrix * c_comparable = new OGComplexMatrix(new complex16[4]{{1.e0,0.e0},{2.e0,0.e0},{3.e0,0.e0},{4.e0,0.e0}},2,2, OWNER);
+  OGComplexMatrix * c_notcomparable = new OGComplexMatrix(new complex16[1]{{1.e0,2.e0}},1,1, OWNER);
 
   ASSERT_TRUE(matrix->equals(same));
   ASSERT_TRUE(*matrix==*same);
@@ -354,9 +354,9 @@ TEST(EqualsTest, OGComplexMatrix) {
   OGComplexMatrix * badcols = new OGComplexMatrix(c_data1,2,4);
   OGComplexMatrix * baddata = new OGComplexMatrix(c_data2,2,2);
   OGRealMatrix * badtype = new OGRealMatrix(r_data1,2,2);
-  OGRealMatrix * r_notcomparable = new OGOwningRealMatrix(new real16[4]{1.e0,2.e0,3.e0,5.e0},2,2);
-  OGComplexMatrix * c_comparable = new OGOwningComplexMatrix(new complex16[4]{{1.0e0,10.0e0},{2.0e0,20.0e0},{3.0e0,30.0e0},{4.0e0,40.0e0}},2,2);
-  OGComplexMatrix * c_notcomparable = new OGOwningComplexMatrix(new complex16[4]{{1.0e0,10.0e0},{2.0e0,20.0e0},{3.0e0,30.0e0},{5.0e0,50.0e0}},2,2);
+  OGRealMatrix * r_notcomparable = new OGRealMatrix(new real16[4]{1.e0,2.e0,3.e0,5.e0},2,2,OWNER);
+  OGComplexMatrix * c_comparable = new OGComplexMatrix(new complex16[4]{{1.0e0,10.0e0},{2.0e0,20.0e0},{3.0e0,30.0e0},{4.0e0,40.0e0}},2,2, OWNER);
+  OGComplexMatrix * c_notcomparable = new OGComplexMatrix(new complex16[4]{{1.0e0,10.0e0},{2.0e0,20.0e0},{3.0e0,30.0e0},{5.0e0,50.0e0}},2,2, OWNER);
 
   ASSERT_TRUE(matrix->equals(same));
   ASSERT_TRUE(*matrix==*same);
@@ -421,7 +421,7 @@ TEST(EqualsTest, OGRealSparseMatrix) {
   OGRealSparseMatrix * badrowidx = new OGRealSparseMatrix(colPtr, rowIdx2, r_data1, rows, cols);
   OGRealScalar * badtype = new OGRealScalar(1.0e0);
   OGRealSparseMatrix * r_comparable_sparse = new OGOwningRealSparseMatrix(new int[6] {0, 2, 4, 7, 7, 7}, new int[7] {0, 1, 0, 2, 1, 2, 3 }, new real16[7] {1.0e0, 3.0e0, 2.0e0, 5.0e0, 4.0e0, 6.0e0, 7.0e0 }, 5, 4);
-  OGRealMatrix * r_notcomparable = new OGOwningRealMatrix(new real16[4]{1.e0,2.e0,3.e0,5.e0},2,2);
+  OGRealMatrix * r_notcomparable = new OGRealMatrix(new real16[4]{1.e0,2.e0,3.e0,5.e0},2,2,OWNER);
   OGComplexSparseMatrix * c_comparable_sparse = new OGOwningComplexSparseMatrix(new int[6] {0, 2, 4, 7, 7, 7}, new int[7] {0, 1, 0, 2, 1, 2, 3 }, new complex16[7] {{1.0e0,0.e0}, {3.0e0,0.e0}, {2.0e0,0.e0}, {5.0e0,0.e0}, {4.0e0,0.e0}, {6.0e0,0.e0}, {7.0e0,0.e0}}, 5, 4);
   OGComplexDiagonalMatrix * c_notcomparable = new OGOwningComplexDiagonalMatrix(new complex16[4]{1.e0,2.e0,3.e0,5.e0},5,4);
 
@@ -503,7 +503,7 @@ TEST(EqualsTest, OGComplexSparseMatrix) {
   OGComplexSparseMatrix * badcolptr = new OGComplexSparseMatrix(colPtr2, rowIdx, c_data1, rows, cols);
   OGComplexSparseMatrix * badrowidx = new OGComplexSparseMatrix(colPtr, rowIdx2, c_data1, rows, cols);
   OGRealScalar * badtype = new OGRealScalar(1.0e0);
-  OGRealMatrix * r_notcomparable = new OGOwningRealMatrix(new real16[4]{1.e0,2.e0,3.e0,5.e0},2,2);
+  OGRealMatrix * r_notcomparable = new OGRealMatrix(new real16[4]{1.e0,2.e0,3.e0,5.e0},2,2,OWNER);
   OGComplexSparseMatrix * c_comparable_sparse = new OGOwningComplexSparseMatrix(new int[6] {0, 2, 4, 7, 7, 7}, new int[7] {0, 1, 0, 2, 1, 2, 3 }, new complex16[7] {{1.0e0,10.0e0}, {3.0e0,30.0e0}, {2.0e0,20.0e0}, {5.0e0,50.0e0}, {4.0e0,40.0e0}, {6.0e0,60.0e0}, {7.0e0,70.0e0} }, 5, 4);
   OGComplexDiagonalMatrix * c_notcomparable = new OGOwningComplexDiagonalMatrix(new complex16[4]{1.e0,2.e0,3.e0,5.e0},5,4);
 
@@ -579,7 +579,7 @@ TEST(EqualsTest, OGRealDiagonalMatrix) {
   OGRealMatrix * comparable = new OGRealMatrix(r_fullmatrix,4,4);
   OGComplexMatrix * badtype = new OGComplexMatrix(c_data1,2,2);
   OGRealSparseMatrix * r_comparable_sparse = new OGOwningRealSparseMatrix(new int[5] {0, 1, 2, 3, 4}, new int[4] {0, 1, 2, 3}, new real16[7] {1.0e0, 2.0e0, 3.0e0, 4.0e0}, 4, 4);
-  OGRealMatrix * r_notcomparable = new OGOwningRealMatrix(new real16[4]{1.e0,2.e0,3.e0,5.e0},2,2);
+  OGRealMatrix * r_notcomparable = new OGRealMatrix(new real16[4]{1.e0,2.e0,3.e0,5.e0},2,2,OWNER);
   OGComplexDiagonalMatrix * c_comparable_diag = new OGOwningComplexDiagonalMatrix(new complex16[4] {{1.0e0,0.e0}, {2.0e0,0.e0}, {3.0e0,0.e0}, {4.0e0,0.e0}},4, 4);
   OGComplexDiagonalMatrix * c_notcomparable = new OGOwningComplexDiagonalMatrix(new complex16[4]{1.e0,2.e0,3.e0,5.e0},4,4);
 
@@ -648,7 +648,7 @@ TEST(EqualsTest, OGComplexDiagonalMatrix) {
   OGComplexDiagonalMatrix * badcols = new OGComplexDiagonalMatrix(c_data1,4,12);
   OGComplexDiagonalMatrix * baddata = new OGComplexDiagonalMatrix(c_data2,4,4);
   OGRealMatrix * badtype = new OGRealMatrix(r_data1,2,2);
-  OGRealMatrix * r_notcomparable = new OGOwningRealMatrix(new real16[4]{1.e0,2.e0,3.e0,5.e0},2,2);
+  OGRealMatrix * r_notcomparable = new OGRealMatrix(new real16[4]{1.e0,2.e0,3.e0,5.e0},2,2,OWNER);
   OGComplexDiagonalMatrix * c_comparable_diag = new OGOwningComplexDiagonalMatrix(new complex16[4] {{1.0e0,10.e0}, {2.0e0,20.e0}, {3.0e0,30.e0}, {4.0e0,40.e0}},4, 4);
   OGComplexDiagonalMatrix * c_notcomparable = new OGOwningComplexDiagonalMatrix(new complex16[4]{1.e0,2.e0,3.e0,5.e0},4,4);
 

--- a/src/librdag/test/check_equals.cc
+++ b/src/librdag/test/check_equals.cc
@@ -423,7 +423,7 @@ TEST(EqualsTest, OGRealSparseMatrix) {
   OGRealSparseMatrix * r_comparable_sparse = new OGOwningRealSparseMatrix(new int[6] {0, 2, 4, 7, 7, 7}, new int[7] {0, 1, 0, 2, 1, 2, 3 }, new real16[7] {1.0e0, 3.0e0, 2.0e0, 5.0e0, 4.0e0, 6.0e0, 7.0e0 }, 5, 4);
   OGRealMatrix * r_notcomparable = new OGRealMatrix(new real16[4]{1.e0,2.e0,3.e0,5.e0},2,2,OWNER);
   OGComplexSparseMatrix * c_comparable_sparse = new OGOwningComplexSparseMatrix(new int[6] {0, 2, 4, 7, 7, 7}, new int[7] {0, 1, 0, 2, 1, 2, 3 }, new complex16[7] {{1.0e0,0.e0}, {3.0e0,0.e0}, {2.0e0,0.e0}, {5.0e0,0.e0}, {4.0e0,0.e0}, {6.0e0,0.e0}, {7.0e0,0.e0}}, 5, 4);
-  OGComplexDiagonalMatrix * c_notcomparable = new OGOwningComplexDiagonalMatrix(new complex16[4]{1.e0,2.e0,3.e0,5.e0},5,4);
+  OGComplexDiagonalMatrix * c_notcomparable = new OGComplexDiagonalMatrix(new complex16[4]{1.e0,2.e0,3.e0,5.e0},5,4, OWNER);
 
   ASSERT_TRUE(matrix->equals(same));
   ASSERT_TRUE(*matrix==*same);
@@ -505,7 +505,7 @@ TEST(EqualsTest, OGComplexSparseMatrix) {
   OGRealScalar * badtype = new OGRealScalar(1.0e0);
   OGRealMatrix * r_notcomparable = new OGRealMatrix(new real16[4]{1.e0,2.e0,3.e0,5.e0},2,2,OWNER);
   OGComplexSparseMatrix * c_comparable_sparse = new OGOwningComplexSparseMatrix(new int[6] {0, 2, 4, 7, 7, 7}, new int[7] {0, 1, 0, 2, 1, 2, 3 }, new complex16[7] {{1.0e0,10.0e0}, {3.0e0,30.0e0}, {2.0e0,20.0e0}, {5.0e0,50.0e0}, {4.0e0,40.0e0}, {6.0e0,60.0e0}, {7.0e0,70.0e0} }, 5, 4);
-  OGComplexDiagonalMatrix * c_notcomparable = new OGOwningComplexDiagonalMatrix(new complex16[4]{1.e0,2.e0,3.e0,5.e0},5,4);
+  OGComplexDiagonalMatrix * c_notcomparable = new OGComplexDiagonalMatrix(new complex16[4]{1.e0,2.e0,3.e0,5.e0},5,4, OWNER);
 
 
   ASSERT_TRUE(matrix->equals(same));
@@ -580,8 +580,8 @@ TEST(EqualsTest, OGRealDiagonalMatrix) {
   OGComplexMatrix * badtype = new OGComplexMatrix(c_data1,2,2);
   OGRealSparseMatrix * r_comparable_sparse = new OGOwningRealSparseMatrix(new int[5] {0, 1, 2, 3, 4}, new int[4] {0, 1, 2, 3}, new real16[7] {1.0e0, 2.0e0, 3.0e0, 4.0e0}, 4, 4);
   OGRealMatrix * r_notcomparable = new OGRealMatrix(new real16[4]{1.e0,2.e0,3.e0,5.e0},2,2,OWNER);
-  OGComplexDiagonalMatrix * c_comparable_diag = new OGOwningComplexDiagonalMatrix(new complex16[4] {{1.0e0,0.e0}, {2.0e0,0.e0}, {3.0e0,0.e0}, {4.0e0,0.e0}},4, 4);
-  OGComplexDiagonalMatrix * c_notcomparable = new OGOwningComplexDiagonalMatrix(new complex16[4]{1.e0,2.e0,3.e0,5.e0},4,4);
+  OGComplexDiagonalMatrix * c_comparable_diag = new OGComplexDiagonalMatrix(new complex16[4] {{1.0e0,0.e0}, {2.0e0,0.e0}, {3.0e0,0.e0}, {4.0e0,0.e0}},4, 4, OWNER);
+  OGComplexDiagonalMatrix * c_notcomparable = new OGComplexDiagonalMatrix(new complex16[4]{1.e0,2.e0,3.e0,5.e0},4,4, OWNER);
 
 
   ASSERT_TRUE(matrix->equals(same));
@@ -649,8 +649,8 @@ TEST(EqualsTest, OGComplexDiagonalMatrix) {
   OGComplexDiagonalMatrix * baddata = new OGComplexDiagonalMatrix(c_data2,4,4);
   OGRealMatrix * badtype = new OGRealMatrix(r_data1,2,2);
   OGRealMatrix * r_notcomparable = new OGRealMatrix(new real16[4]{1.e0,2.e0,3.e0,5.e0},2,2,OWNER);
-  OGComplexDiagonalMatrix * c_comparable_diag = new OGOwningComplexDiagonalMatrix(new complex16[4] {{1.0e0,10.e0}, {2.0e0,20.e0}, {3.0e0,30.e0}, {4.0e0,40.e0}},4, 4);
-  OGComplexDiagonalMatrix * c_notcomparable = new OGOwningComplexDiagonalMatrix(new complex16[4]{1.e0,2.e0,3.e0,5.e0},4,4);
+  OGComplexDiagonalMatrix * c_comparable_diag = new OGComplexDiagonalMatrix(new complex16[4] {{1.0e0,10.e0}, {2.0e0,20.e0}, {3.0e0,30.e0}, {4.0e0,40.e0}},4, 4, OWNER);
+  OGComplexDiagonalMatrix * c_notcomparable = new OGComplexDiagonalMatrix(new complex16[4]{1.e0,2.e0,3.e0,5.e0},4,4, OWNER);
 
   ASSERT_TRUE(matrix->equals(same));
   ASSERT_TRUE(*matrix==*same);

--- a/src/librdag/test/check_iss.cc
+++ b/src/librdag/test/check_iss.cc
@@ -28,12 +28,12 @@ class issTest : public ::testing::Test
     OGComplexDiagonalMatrix * _ogcomplexdiagonalmatrix = nullptr;
     OGRealSparseMatrix * _ogrealsparsematrix = nullptr;
     OGComplexSparseMatrix * _ogcomplexsparsematrix = nullptr;
-    OGOwningRealMatrix * _ogowningrealmatrix = nullptr;
-    OGOwningComplexMatrix * _ogowningcomplexmatrix = nullptr;
-    OGOwningRealMatrix * _ogrealvector1 = nullptr;
-    OGOwningRealMatrix * _ogrealvector2 = nullptr;
-    OGOwningComplexMatrix * _ogcomplexvector1 = nullptr;
-    OGOwningComplexMatrix * _ogcomplexvector2 = nullptr;
+    OGRealMatrix * _ogowningrealmatrix = nullptr;
+    OGComplexMatrix * _ogowningcomplexmatrix = nullptr;
+    OGRealMatrix * _ogrealvector1 = nullptr;
+    OGRealMatrix * _ogrealvector2 = nullptr;
+    OGComplexMatrix * _ogcomplexvector1 = nullptr;
+    OGComplexMatrix * _ogcomplexvector2 = nullptr;
     real16 * r_data;
     complex16 * c_data;
     int * colPtr;
@@ -54,12 +54,12 @@ class issTest : public ::testing::Test
     _ogcomplexdiagonalmatrix = new OGComplexDiagonalMatrix(c_data,1,1);
     _ogrealsparsematrix = new OGRealSparseMatrix(colPtr,rowIdx,r_data,1,1);
     _ogcomplexsparsematrix = new OGComplexSparseMatrix(colPtr,rowIdx,c_data,1,1);
-    _ogowningrealmatrix = new OGOwningRealMatrix(new real16[1]{1},1,1);
-    _ogowningcomplexmatrix = new OGOwningComplexMatrix(new complex16[1]{{1,2}},1,1);
-    _ogrealvector1 = new OGOwningRealMatrix(new real16[3]{1,2,3},1,3);
-    _ogrealvector2 = new OGOwningRealMatrix(new real16[3]{1,2,3},3,1);
-    _ogcomplexvector1 = new OGOwningComplexMatrix(new complex16[3]{{1,10},{2,20},{3,30}},1,3);
-    _ogcomplexvector2 = new OGOwningComplexMatrix(new complex16[3]{{1,10},{2,20},{3,30}},3,1);
+    _ogowningrealmatrix = new OGRealMatrix(new real16[1]{1},1,1, OWNER);
+    _ogowningcomplexmatrix = new OGComplexMatrix(new complex16[1]{{1,2}},1,1, OWNER);
+    _ogrealvector1 = new OGRealMatrix(new real16[3]{1,2,3},1,3, OWNER);
+    _ogrealvector2 = new OGRealMatrix(new real16[3]{1,2,3},3,1, OWNER);
+    _ogcomplexvector1 = new OGComplexMatrix(new complex16[3]{{1,10},{2,20},{3,30}},1,3, OWNER);
+    _ogcomplexvector2 = new OGComplexMatrix(new complex16[3]{{1,10},{2,20},{3,30}},3,1, OWNER);
   }
 
   virtual void TearDown()

--- a/src/librdag/test/check_terminals.cc
+++ b/src/librdag/test/check_terminals.cc
@@ -671,7 +671,7 @@ TEST(TerminalsTest, OGRealDiagonalMatrix) {
   OGTerminal * owningComplexCopy = tmp->createComplexOwningCopy();
   complex16 * cmplx_data = new complex16[tmp->getDatalen()];
   std::copy(data, data+tmp->getDatalen(), cmplx_data);
-  OGComplexDiagonalMatrix * cmplx_tmp = new OGOwningComplexDiagonalMatrix(cmplx_data, rows, cols);
+  OGComplexDiagonalMatrix * cmplx_tmp = new OGComplexDiagonalMatrix(cmplx_data, rows, cols, OWNER);
   ASSERT_TRUE(*cmplx_tmp->asOGTerminal()==~*owningComplexCopy);
   ASSERT_FALSE(tmp->getData()==reinterpret_cast<double *>(owningComplexCopy->asOGComplexDiagonalMatrix()->getData())); // make sure the data is unique
   delete cmplx_tmp;
@@ -686,45 +686,6 @@ TEST(TerminalsTest, OGRealDiagonalMatrix) {
 
   // clean up
   delete copy;
-  delete tmp;
-}
-
-/*
- * Test OGOwningRealDiagonalMatrix
- */
-TEST(TerminalsTest, OGOwningRealDiagonalMatrix) {
-  // data
-  real16 data [3] = {1e0,2e0,3e0};
-  int rows = 3;
-  int cols = 4;
-
-  // attempt construct from ok values
-  real16 * owned_data = new real16[3];
-  memcpy(owned_data,data, 3 * sizeof(real16));
-  OGOwningRealDiagonalMatrix * tmp = new OGOwningRealDiagonalMatrix(owned_data,rows, cols);
-
-  // check ctor worked
-  ASSERT_NE(tmp, nullptr);
-
-  // check getRows
-  ASSERT_EQ(tmp->getRows(), rows);
-
-  // check getCols
-  ASSERT_EQ(tmp->getCols(), cols);
-
-  // check getDatalen
-  ASSERT_EQ(tmp->getDatalen(), rows>cols?cols:rows);
-
-  // check getData
-  ASSERT_TRUE(ArrayEquals(tmp->getData(),data,tmp->getDatalen()));
-
-  // check getType() is ok
-  ASSERT_EQ(tmp->getType(), REAL_DIAGONAL_MATRIX_ENUM);
-
-  // check data
-  ASSERT_TRUE(ArrayEquals(tmp->getData(),data,tmp->getDatalen()));
-
-  // delete should free, valgrind should be happy
   delete tmp;
 }
 
@@ -853,45 +814,6 @@ TEST(TerminalsTest, OGComplexDiagonalMatrix) {
   delete tmp;
 }
 
-
-/*
- * Test OGOwningComplexDiagonalMatrix
- */
-TEST(TerminalsTest, OGOwningComplexDiagonalMatrix) {
-  // data
-  complex16 data [3] = {{1e0,10e0},{2e0,20e0},{3e0,30e0}};
-  int rows = 3;
-  int cols = 4;
-
-  // attempt construct from ok values
-  complex16 * owned_data = new complex16[3];
-  memcpy(owned_data,data, 3 * sizeof(complex16));
-  OGOwningComplexDiagonalMatrix * tmp = new OGOwningComplexDiagonalMatrix(owned_data,rows, cols);
-
-  // check ctor worked
-  ASSERT_NE(tmp, nullptr);
-
-  // check getRows
-  ASSERT_EQ(tmp->getRows(), rows);
-
-  // check getCols
-  ASSERT_EQ(tmp->getCols(), cols);
-
-  // check getDatalen
-  ASSERT_EQ(tmp->getDatalen(), rows>cols?cols:rows);
-
-  // check getData
-  ASSERT_TRUE(ArrayEquals(tmp->getData(),data,tmp->getDatalen()));
-
-  // check getType() is ok
-  ASSERT_EQ(tmp->getType(), COMPLEX_DIAGONAL_MATRIX_ENUM);
-
-  // check data
-  ASSERT_TRUE(ArrayEquals(tmp->getData(),data,tmp->getDatalen()));
-
-  // delete should free, valgrind should be happy
-  delete tmp;
-}
 
 /*
  * Test OGRealSparseMatrix

--- a/src/librdag/test/check_terminals.cc
+++ b/src/librdag/test/check_terminals.cc
@@ -130,6 +130,21 @@ TEST(TerminalsTest, OGTerminalTest) {
 }
 
 /*
+ * Test OGScalar<T>
+ */
+TEST(TerminalsTest, OGScalarTest) {
+
+  OGScalar<real16> * tmp = new OGScalar<real16>(10);
+
+  ASSERT_ANY_THROW(tmp->copy());
+  ASSERT_ANY_THROW(tmp->asFullOGRealMatrix());
+  ASSERT_ANY_THROW(tmp->asFullOGComplexMatrix());
+  ASSERT_ANY_THROW(tmp->createOwningCopy());
+  ASSERT_ANY_THROW(tmp->createComplexOwningCopy());
+  delete tmp;
+}
+
+/*
  * Test OGRealScalar
  */
 TEST(TerminalsTest, OGRealScalarTest) {

--- a/src/librdag/test/check_terminals.cc
+++ b/src/librdag/test/check_terminals.cc
@@ -348,6 +348,23 @@ TEST(TerminalsTest, OGIntegerScalarTest) {
 }
 
 /*
+ * Test OGArray
+ */
+TEST(TerminalsTest, OGArrayTest) {
+
+  OGArray<real16> * tmp = new OGArray<real16>();
+
+  ASSERT_ANY_THROW(tmp->copy());
+  ASSERT_ANY_THROW(tmp->debug_print());
+  ASSERT_ANY_THROW(tmp->asFullOGRealMatrix());
+  ASSERT_ANY_THROW(tmp->asFullOGComplexMatrix());
+  ASSERT_ANY_THROW(tmp->createOwningCopy());
+  ASSERT_ANY_THROW(tmp->createComplexOwningCopy());
+
+  delete tmp;
+}
+
+/*
  * Test OGRealMatrix
  */
 TEST(TerminalsTest, OGRealMatrixTest) {

--- a/src/librdag/test/check_terminals.cc
+++ b/src/librdag/test/check_terminals.cc
@@ -136,11 +136,11 @@ TEST(TerminalsTest, OGScalarTest) {
 
   OGScalar<real16> * tmp = new OGScalar<real16>(10);
 
-  ASSERT_ANY_THROW(tmp->copy());
-  ASSERT_ANY_THROW(tmp->asFullOGRealMatrix());
-  ASSERT_ANY_THROW(tmp->asFullOGComplexMatrix());
-  ASSERT_ANY_THROW(tmp->createOwningCopy());
-  ASSERT_ANY_THROW(tmp->createComplexOwningCopy());
+  ASSERT_THROW(tmp->copy(), rdag_error);
+  ASSERT_THROW((tmp->asFullOGRealMatrix()), rdag_error);
+  ASSERT_THROW((tmp->asFullOGComplexMatrix()), rdag_error);
+  ASSERT_THROW((tmp->createOwningCopy()), rdag_error);
+  ASSERT_THROW((tmp->createComplexOwningCopy()), rdag_error);
 
   // print for test completeness
   tmp->debug_print();
@@ -192,7 +192,7 @@ TEST(TerminalsTest, OGRealScalarTest) {
   delete [] computed;
 
   // check toComplex16ArrayOfArrays, should throw
-  ASSERT_ANY_THROW(tmp->toComplex16ArrayOfArrays());
+  ASSERT_THROW((tmp->toComplex16ArrayOfArrays()), rdag_error);
 
   // check visitor
   FakeVisitor * v = new FakeVisitor();
@@ -256,7 +256,7 @@ TEST(TerminalsTest, OGComplexScalarTest) {
   ASSERT_EQ(tmp->getType(), COMPLEX_SCALAR_ENUM);
 
   // check can't promote as real
-  ASSERT_ANY_THROW(tmp->asFullOGRealMatrix());
+  ASSERT_THROW((tmp->asFullOGRealMatrix()), rdag_error);
 
   // wire up array for ArrOfArr test
   complex16 expectedtmp[1] = {{3.14e0, 0.00159e0}};
@@ -276,7 +276,7 @@ TEST(TerminalsTest, OGComplexScalarTest) {
   delete [] computed;
 
   // check toReal16ArrayOfArrays, should throw
-  ASSERT_ANY_THROW(tmp->toReal16ArrayOfArrays());
+  ASSERT_THROW((tmp->toReal16ArrayOfArrays()), rdag_error);
 
   // check visitor
   FakeVisitor * v = new FakeVisitor();
@@ -336,10 +336,10 @@ TEST(TerminalsTest, OGIntegerScalarTest) {
   ASSERT_EQ(tmp->getType(), INTEGER_SCALAR_ENUM);  
 
   // check toReal16ArrayOfArrays, should throw
-  ASSERT_ANY_THROW(tmp->toReal16ArrayOfArrays());
+  ASSERT_THROW((tmp->toReal16ArrayOfArrays()), rdag_error);
 
   // check toComplex16ArrayOfArrays, should throw
-  ASSERT_ANY_THROW(tmp->toComplex16ArrayOfArrays());
+  ASSERT_THROW((tmp->toComplex16ArrayOfArrays()), rdag_error);
 
   // check copy and asOGIntegerScalar
   OGNumeric * copy = tmp->copy();
@@ -373,14 +373,14 @@ TEST(TerminalsTest, OGArrayTest) {
 
   OGArray<real16> * tmp = new OGArray<real16>();
 
-  ASSERT_ANY_THROW(tmp->copy());
-  ASSERT_ANY_THROW(tmp->debug_print());
-  ASSERT_ANY_THROW(tmp->asFullOGRealMatrix());
-  ASSERT_ANY_THROW(tmp->asFullOGComplexMatrix());
-  ASSERT_ANY_THROW(tmp->createOwningCopy());
-  ASSERT_ANY_THROW(tmp->createComplexOwningCopy());
+  ASSERT_THROW((tmp->copy()), rdag_error);
+  ASSERT_THROW((tmp->debug_print()), rdag_error);
+  ASSERT_THROW((tmp->asFullOGRealMatrix()), rdag_error);
+  ASSERT_THROW((tmp->asFullOGComplexMatrix()), rdag_error);
+  ASSERT_THROW((tmp->createOwningCopy()), rdag_error);
+  ASSERT_THROW((tmp->createComplexOwningCopy()), rdag_error);
   Visitor * v = new FakeVisitor();
-  ASSERT_ANY_THROW(tmp->accept(*v));
+  ASSERT_THROW((tmp->accept(*v)), rdag_error);
   delete tmp;
   delete v;
 }
@@ -397,15 +397,15 @@ TEST(TerminalsTest, OGRealMatrixTest) {
   // attempt construct from nullptr, should throw
   real16 * null = nullptr;
   OGRealMatrix * tmp;
-  ASSERT_ANY_THROW(tmp = new OGRealMatrix(null,rows,cols));
+  ASSERT_THROW((tmp = new OGRealMatrix(null,rows,cols)), rdag_error);
 
   // attempt construct from bad rows
   tmp = nullptr;
-  ASSERT_ANY_THROW(tmp = new OGRealMatrix(data,-1,cols));
+  ASSERT_THROW((tmp = new OGRealMatrix(data,-1,cols)), rdag_error);
 
   // attempt construct from bad cols
   tmp = nullptr;
-  ASSERT_ANY_THROW(tmp = new OGRealMatrix(data,rows,-1));
+  ASSERT_THROW((tmp = new OGRealMatrix(data,rows,-1)), rdag_error);
 
   // attempt construct from ok data, own the data and delete it
   tmp = nullptr;
@@ -464,7 +464,7 @@ TEST(TerminalsTest, OGRealMatrixTest) {
   delete [] expected;  
 
   // check toComplex16ArrayOfArrays, expect throw
-  ASSERT_ANY_THROW(tmp->toComplex16ArrayOfArrays());
+  ASSERT_THROW((tmp->toComplex16ArrayOfArrays()), rdag_error);
 
   // check visitor
   FakeVisitor * v = new FakeVisitor();
@@ -517,15 +517,15 @@ TEST(TerminalsTest, OGComplexMatrixTest) {
   // attempt construct from nullptr, should throw
   complex16 * null = nullptr;
   OGComplexMatrix * tmp;
-  ASSERT_ANY_THROW(tmp = new OGComplexMatrix(null,rows,cols));
+  ASSERT_THROW((tmp = new OGComplexMatrix(null,rows,cols)), rdag_error);
 
   // attempt construct from bad rows
   tmp = nullptr;
-  ASSERT_ANY_THROW(tmp = new OGComplexMatrix(data,-1,cols));
+  ASSERT_THROW((tmp = new OGComplexMatrix(data,-1,cols)), rdag_error);
 
   // attempt construct from bad cols
   tmp = nullptr;
-  ASSERT_ANY_THROW(tmp = new OGComplexMatrix(data,rows,-1));
+  ASSERT_THROW((tmp = new OGComplexMatrix(data,rows,-1)), rdag_error);
 
   // attempt construct from ok data, own the data and delete it
   tmp = nullptr;
@@ -559,7 +559,7 @@ TEST(TerminalsTest, OGComplexMatrixTest) {
   ASSERT_EQ(tmp->getType(), COMPLEX_MATRIX_ENUM);    
 
   // check can't promote as real
-  ASSERT_ANY_THROW(tmp->asFullOGRealMatrix());
+  ASSERT_THROW((tmp->asFullOGRealMatrix()), rdag_error);
 
   // wire up array for ArrOfArr test
   complex16 expectedtmp[12] = {{1e0,10e0},{4e0,40e0},{7e0,70e0},{10e0,100e0},{2e0,20e0},{5e0,50e0},{8e0,80e0},{11e0,110e0},{3e0,30e0},{6e0,60e0},{9e0,90e0},{12e0,120e0}};
@@ -586,7 +586,7 @@ TEST(TerminalsTest, OGComplexMatrixTest) {
   delete [] expected;  
 
   // check toReal16ArrayOfArrays, expect throw
-  ASSERT_ANY_THROW(tmp->toReal16ArrayOfArrays());
+  ASSERT_THROW((tmp->toReal16ArrayOfArrays()), rdag_error);
 
   // check visitor
   FakeVisitor * v = new FakeVisitor();
@@ -635,15 +635,15 @@ TEST(TerminalsTest, OGRealDiagonalMatrix) {
   // attempt construct from nullptr, should throw
   real16 * null = nullptr;
   OGRealDiagonalMatrix * tmp;
-  ASSERT_ANY_THROW(tmp = new OGRealDiagonalMatrix(null,rows,cols));
+  ASSERT_THROW((tmp = new OGRealDiagonalMatrix(null,rows,cols)), rdag_error);
 
   // attempt construct from bad rows
   tmp = nullptr;
-  ASSERT_ANY_THROW(tmp = new OGRealDiagonalMatrix(data,-1,cols));
+  ASSERT_THROW((tmp = new OGRealDiagonalMatrix(data,-1,cols)), rdag_error);
 
   // attempt construct from bad cols
   tmp = nullptr;
-  ASSERT_ANY_THROW(tmp = new OGRealDiagonalMatrix(data,rows,-1));
+  ASSERT_THROW((tmp = new OGRealDiagonalMatrix(data,rows,-1)), rdag_error);
 
   // attempt construct from ok data, own the data and delete it
   tmp = nullptr;
@@ -715,7 +715,7 @@ TEST(TerminalsTest, OGRealDiagonalMatrix) {
   delete [] expected;  
 
   // check toComplex16ArrayOfArrays, expect throw
-  ASSERT_ANY_THROW(tmp->toComplex16ArrayOfArrays());
+  ASSERT_THROW((tmp->toComplex16ArrayOfArrays()), rdag_error);
 
   // check visitor
   FakeVisitor * v = new FakeVisitor();
@@ -772,15 +772,15 @@ TEST(TerminalsTest, OGComplexDiagonalMatrix) {
   // attempt construct from nullptr, should throw
   complex16 * null = nullptr;
   OGComplexDiagonalMatrix * tmp;
-  ASSERT_ANY_THROW(tmp = new OGComplexDiagonalMatrix(null,rows,cols));
+  ASSERT_THROW((tmp = new OGComplexDiagonalMatrix(null,rows,cols)), rdag_error);
 
   // attempt construct from bad rows
   tmp = nullptr;
-  ASSERT_ANY_THROW(tmp = new OGComplexDiagonalMatrix(data,-1,cols));
+  ASSERT_THROW((tmp = new OGComplexDiagonalMatrix(data,-1,cols)), rdag_error);
 
   // attempt construct from bad cols
   tmp = nullptr;
-  ASSERT_ANY_THROW(tmp = new OGComplexDiagonalMatrix(data,rows,-1));
+  ASSERT_THROW((tmp = new OGComplexDiagonalMatrix(data,rows,-1)), rdag_error);
 
   // attempt construct from ok data, own the data and delete it
   tmp = nullptr;
@@ -815,7 +815,7 @@ TEST(TerminalsTest, OGComplexDiagonalMatrix) {
   ASSERT_EQ(tmp->getType(), COMPLEX_DIAGONAL_MATRIX_ENUM);  
 
   // check can't promote as real
-  ASSERT_ANY_THROW(tmp->asFullOGRealMatrix());
+  ASSERT_THROW((tmp->asFullOGRealMatrix()), rdag_error);
 
   // wire up array for ArrOfArr test
   complex16 expectedtmp[12] = {{1e0,10e0},{0e0,0e0},{0e0,0e0},{0e0,0e0},{0e0,0e0},{2e0,20e0},{0e0,0e0},{0e0,0e0},{0e0,0e0},{0e0,0e0},{3e0,30e0},{0e0,0e0}};
@@ -855,7 +855,7 @@ TEST(TerminalsTest, OGComplexDiagonalMatrix) {
   delete [] expected;  
 
   // check toReal16ArrayOfArrays, expect throw
-  ASSERT_ANY_THROW(tmp->toReal16ArrayOfArrays());
+  ASSERT_THROW((tmp->toReal16ArrayOfArrays()), rdag_error);
 
   // check visitor
   FakeVisitor * v = new FakeVisitor();
@@ -913,24 +913,24 @@ TEST(TerminalsTest, OGRealSparseMatrix) {
 
   // attempt construct from colptr as null, should throw
   tmp = nullptr;
-  ASSERT_ANY_THROW(tmp = new OGRealSparseMatrix(nullintptr,rowIdx,data,rows,cols));
+  ASSERT_THROW((tmp = new OGRealSparseMatrix(nullintptr,rowIdx,data,rows,cols)), rdag_error);
 
   // attempt construct from rowidx as null, should throw
   tmp = nullptr;
-  ASSERT_ANY_THROW(tmp = new OGRealSparseMatrix(colPtr,nullintptr,data,rows,cols));
+  ASSERT_THROW((tmp = new OGRealSparseMatrix(colPtr,nullintptr,data,rows,cols)), rdag_error);
 
   // attempt construct from data nullptr, should throw
   real16 * nulldata = nullptr;
   tmp = nullptr;
-  ASSERT_ANY_THROW(tmp = new OGRealSparseMatrix(colPtr,rowIdx,nulldata,rows,cols));
+  ASSERT_THROW((tmp = new OGRealSparseMatrix(colPtr,rowIdx,nulldata,rows,cols)), rdag_error);
 
   // attempt construct from bad rows
   tmp = nullptr;
-  ASSERT_ANY_THROW(tmp = new OGRealSparseMatrix(colPtr,rowIdx,data,-1,cols));
+  ASSERT_THROW((tmp = new OGRealSparseMatrix(colPtr,rowIdx,data,-1,cols)), rdag_error);
 
   // attempt construct from bad cols
   tmp = nullptr;
-  ASSERT_ANY_THROW(tmp = new OGRealSparseMatrix(colPtr,rowIdx,data,rows,-1));
+  ASSERT_THROW((tmp = new OGRealSparseMatrix(colPtr,rowIdx,data,rows,-1)), rdag_error);
 
     // attempt construct from ok data, own the data and delete it
   tmp = nullptr;
@@ -1007,7 +1007,7 @@ TEST(TerminalsTest, OGRealSparseMatrix) {
   delete [] expected;
 
   // check toComplex16ArrayOfArrays, expect throw
-  ASSERT_ANY_THROW(tmp->toComplex16ArrayOfArrays());
+  ASSERT_THROW((tmp->toComplex16ArrayOfArrays()), rdag_error);
 
   // check visitor
   FakeVisitor * v = new FakeVisitor();
@@ -1069,24 +1069,24 @@ TEST(TerminalsTest, OGComplexSparseMatrix) {
 
   // attempt construct from colptr as null, should throw
   tmp = nullptr;
-  ASSERT_ANY_THROW(tmp = new OGComplexSparseMatrix(nullintptr,rowIdx,data,rows,cols));
+  ASSERT_THROW((tmp = new OGComplexSparseMatrix(nullintptr,rowIdx,data,rows,cols)), rdag_error);
 
   // attempt construct from rowidx as null, should throw
   tmp = nullptr;
-  ASSERT_ANY_THROW(tmp = new OGComplexSparseMatrix(colPtr,nullintptr,data,rows,cols));
+  ASSERT_THROW((tmp = new OGComplexSparseMatrix(colPtr,nullintptr,data,rows,cols)), rdag_error);
 
   // attempt construct from data nullptr, should throw
   complex16 * nulldata = nullptr;
   tmp = nullptr;
-  ASSERT_ANY_THROW(tmp = new OGComplexSparseMatrix(colPtr,rowIdx,nulldata,rows,cols));
+  ASSERT_THROW((tmp = new OGComplexSparseMatrix(colPtr,rowIdx,nulldata,rows,cols)), rdag_error);
 
   // attempt construct from bad rows
   tmp = nullptr;
-  ASSERT_ANY_THROW(tmp = new OGComplexSparseMatrix(colPtr,rowIdx,data,-1,cols));
+  ASSERT_THROW((tmp = new OGComplexSparseMatrix(colPtr,rowIdx,data,-1,cols)), rdag_error);
 
   // attempt construct from bad cols
   tmp = nullptr;
-  ASSERT_ANY_THROW(tmp = new OGComplexSparseMatrix(colPtr,rowIdx,data,rows,-1));
+  ASSERT_THROW((tmp = new OGComplexSparseMatrix(colPtr,rowIdx,data,rows,-1)), rdag_error);
 
   // attempt construct from ok data, own the data and delete it
   tmp = nullptr;
@@ -1127,7 +1127,7 @@ TEST(TerminalsTest, OGComplexSparseMatrix) {
   ASSERT_EQ(tmp->getType(), COMPLEX_SPARSE_MATRIX_ENUM);  
 
   // check can't promote as real
-  ASSERT_ANY_THROW(tmp->asFullOGRealMatrix());
+  ASSERT_THROW((tmp->asFullOGRealMatrix()), rdag_error);
 
   // wire up array for ArrOfArr test
   complex16 expectedtmp[20] = {
@@ -1172,7 +1172,7 @@ TEST(TerminalsTest, OGComplexSparseMatrix) {
   delete [] expected;
 
   // check toReal16ArrayOfArrays, expect throw
-  ASSERT_ANY_THROW(tmp->toReal16ArrayOfArrays());
+  ASSERT_THROW((tmp->toReal16ArrayOfArrays()), rdag_error);
 
   // check visitor
   FakeVisitor * v = new FakeVisitor();

--- a/src/librdag/test/check_terminals.cc
+++ b/src/librdag/test/check_terminals.cc
@@ -439,7 +439,9 @@ TEST(TerminalsTest, OGRealMatrixTest) {
 
   // check createComplexOwningCopy
   OGTerminal * owningComplexCopy = tmp->createComplexOwningCopy();
-  OGComplexMatrix * cmplx_tmp = new OGOwningComplexMatrix(data, rows, cols);
+  complex16 * cdata = new complex16[rows*cols]();
+  std::copy(data,data+(rows*cols),cdata);
+  OGComplexMatrix * cmplx_tmp = new OGComplexMatrix(cdata, rows, cols, OWNER);
   ASSERT_TRUE(*cmplx_tmp->asOGTerminal()==~*owningComplexCopy);
   ASSERT_FALSE(tmp->getData()==reinterpret_cast<double *>(owningComplexCopy->asOGComplexMatrix()->getData())); // make sure the data is unique
   delete cmplx_tmp;
@@ -453,45 +455,6 @@ TEST(TerminalsTest, OGRealMatrixTest) {
   delete tmp;
 }
 
-
-/*
- * Test OGOwningRealMatrix
- */
-TEST(TerminalsTest, OGOwningRealMatrix) {
-  // data
-  real16 data [12] = {1e0,2e0,3e0,4e0,5e0,6e0,7e0,8e0,9e0,10e0,11e0,12e0};
-  real16 zeros [12] = {0e0,0e0,0e0,0e0,0e0,0e0,0e0,0e0,0e0,0e0,0e0,0e0};
-  int rows = 3;
-  int cols = 4;
-
-  // attempt construct from ok values
-  OGOwningRealMatrix * tmp = new OGOwningRealMatrix(rows, cols);
-
-  // check ctor worked
-  ASSERT_NE(tmp, nullptr);
-
-  // check getRows
-  ASSERT_EQ(tmp->getRows(), rows);
-
-  // check getCols
-  ASSERT_EQ(tmp->getCols(), cols);
-
-  // check getDatalen
-  ASSERT_EQ(tmp->getDatalen(), rows*cols);
-
-  // check data is zerod
-  ASSERT_TRUE(ArrayEquals(tmp->getData(),zeros,tmp->getDatalen()));
-
-  // set data then check
-  memcpy(data,tmp->getData(),tmp->getDatalen()*sizeof(real16));
-  ASSERT_TRUE(ArrayEquals(tmp->getData(),data,tmp->getDatalen()));
-
-  // check getType() is ok
-  ASSERT_EQ(tmp->getType(), REAL_MATRIX_ENUM);
-
-  // delete should free, valgrind should be happy
-  delete tmp;
-}
 
 /*
  * Test OGComplexMatrix
@@ -597,46 +560,6 @@ TEST(TerminalsTest, OGComplexMatrixTest) {
 
   // clean up
   delete copy;
-  delete tmp;
-}
-
-
-/*
- * Test OGOwningComplexMatrix
- */
-TEST(TerminalsTest, OGOwningComplexMatrix) {
-  // data
-  complex16 data [12] = {{1e0,10e0},{2e0,20e0},{3e0,30e0},{4e0,40e0},{5e0,50e0},{6e0,60e0},{7e0,70e0},{8e0,80e0},{9e0,90e0},{10e0,100e0},{11e0,110e0},{12e0,120e0}};
-  complex16 zeros [12] = {{0e0,0e0},{0e0,0e0},{0e0,0e0},{0e0,0e0},{0e0,0e0},{0e0,0e0},{0e0,0e0},{0e0,0e0},{0e0,0e0},{0e0,0e0},{0e0,0e0},{0e0,0e0}};
-  int rows = 3;
-  int cols = 4;
-
-  // attempt construct from ok values
-  OGOwningComplexMatrix * tmp = new OGOwningComplexMatrix(rows, cols);
-
-  // check ctor worked
-  ASSERT_NE(tmp, nullptr);
-
-  // check getRows
-  ASSERT_EQ(tmp->getRows(), rows);
-
-  // check getCols
-  ASSERT_EQ(tmp->getCols(), cols);
-
-  // check getDatalen
-  ASSERT_EQ(tmp->getDatalen(), rows*cols);
-
-  // check data is zerod
-  ASSERT_TRUE(ArrayEquals(tmp->getData(),zeros,tmp->getDatalen()));
-
-  // set data then check
-  memcpy(tmp->getData(),data,tmp->getDatalen()*sizeof(complex16));
-  ASSERT_TRUE(ArrayEquals(tmp->getData(),data,tmp->getDatalen()));
-
-  // check getType() is ok
-  ASSERT_EQ(tmp->getType(), COMPLEX_MATRIX_ENUM);
-
-  // delete should free, valgrind should be happy
   delete tmp;
 }
 
@@ -1388,8 +1311,8 @@ public:
     virtual void debug_print() const override {}
     virtual void accept(Visitor SUPPRESS_UNUSED &v) const override {}
     virtual OGNumeric* copy() const override { return nullptr; }
-    virtual OGOwningRealMatrix * asFullOGRealMatrix() const override { return nullptr; }
-    virtual OGOwningComplexMatrix * asFullOGComplexMatrix() const override { return nullptr; }
+    virtual OGRealMatrix * asFullOGRealMatrix() const override { return nullptr; }
+    virtual OGComplexMatrix * asFullOGComplexMatrix() const override { return nullptr; }
     virtual OGTerminal * createOwningCopy() const override { return nullptr; }
     virtual OGTerminal * createComplexOwningCopy() const override { return nullptr;}
 };

--- a/src/librdag/test/check_terminals.cc
+++ b/src/librdag/test/check_terminals.cc
@@ -962,57 +962,6 @@ TEST(TerminalsTest, OGRealSparseMatrix) {
 
 
 /*
- * Test OGOwningRealSparseMatrix
- */
-TEST(TerminalsTest, OGOwningRealSparseMatrix) {
-  // data
-  real16 data [7] = { 1.0e0, 3.0e0, 2.0e0, 5.0e0, 4.0e0, 6.0e0, 7.0e0 };
-  int colPtr [6] = { 0, 2, 4, 7, 7, 7 };
-  int rowIdx [7] = { 0, 1, 0, 2, 1, 2, 3 };
-  int rows = 5;
-  int cols = 4;
-
-  // attempt construct from ok values
-  real16 * owned_data = new real16[7];
-  memcpy(owned_data,data, 7 * sizeof(real16));
-  int * owned_colPtr = new int[6];
-  memcpy(owned_colPtr,colPtr, 6 * sizeof(int));
-  int * owned_rowIdx = new int[7];
-  memcpy(owned_rowIdx,rowIdx, 7 * sizeof(int));
-
-
-  OGOwningRealSparseMatrix * tmp = new OGOwningRealSparseMatrix(owned_colPtr, owned_rowIdx,owned_data,rows, cols);
-
-  // check ctor worked
-  ASSERT_NE(tmp, nullptr);
-
-  // check getRows
-  ASSERT_EQ(tmp->getRows(), rows);
-
-  // check getCols
-  ASSERT_EQ(tmp->getCols(), cols);
-
-  // check getDatalen
-  ASSERT_EQ(tmp->getDatalen(), colPtr[cols]);
-
-  // check getData
-  ASSERT_TRUE(ArrayEquals(tmp->getData(),data,tmp->getDatalen()));
-
-  // check getColPtr
-  ASSERT_TRUE(ArrayEquals(tmp->getColPtr(),colPtr,6));
-
-  // check getRowIdx
-  ASSERT_TRUE(ArrayEquals(tmp->getRowIdx(),rowIdx,7));
-
-  // check getType() is ok
-  ASSERT_EQ(tmp->getType(), REAL_SPARSE_MATRIX_ENUM);
-
-  // delete should free, valgrind should be happy
-  delete tmp;
-}
-
-
-/*
  * Test OGComplexSparseMatrix
  */
 TEST(TerminalsTest, OGComplexSparseMatrix) {
@@ -1162,56 +1111,6 @@ TEST(TerminalsTest, OGComplexSparseMatrix) {
 
   // clean up
   delete copy;
-  delete tmp;
-}
-
-/*
- * Test OGOwningComplexSparseMatrix
- */
-TEST(TerminalsTest, OGOwningComplexSparseMatrix) {
-  // data
-  complex16 data [12] = { {1, 10}, {5, 0}, {0, 90}, {2, 20}, {0, 60}, {10, 100}, {0, 30}, {7, 70}, {11, 0}, {15, 0}, {0, 120}, {0, 160} };
-  int colPtr [6] = { 0, 3, 6, 10, 12, 12 };
-  int rowIdx [12] = { 0, 1, 2, 0, 1, 2, 0, 1, 2, 3, 2, 3 };
-  int rows = 5;
-  int cols = 4;
-
-  // attempt construct from ok values
-  complex16 * owned_data = new complex16[12];
-  memcpy(owned_data,data, 12 * sizeof(complex16));
-  int * owned_colPtr = new int[6];
-  memcpy(owned_colPtr,colPtr, 6 * sizeof(int));
-  int * owned_rowIdx = new int[12];
-  memcpy(owned_rowIdx,rowIdx, 12 * sizeof(int));
-
-
-  OGOwningComplexSparseMatrix * tmp = new OGOwningComplexSparseMatrix(owned_colPtr, owned_rowIdx,owned_data,rows, cols);
-
-  // check ctor worked
-  ASSERT_NE(tmp, nullptr);
-
-  // check getRows
-  ASSERT_EQ(tmp->getRows(), rows);
-
-  // check getCols
-  ASSERT_EQ(tmp->getCols(), cols);
-
-  // check getDatalen
-  ASSERT_EQ(tmp->getDatalen(), colPtr[cols]);
-
-  // check getData
-  ASSERT_TRUE(ArrayEquals(tmp->getData(),data,tmp->getDatalen()));
-
-  // check getColPtr
-  ASSERT_TRUE(ArrayEquals(tmp->getColPtr(),colPtr,6));
-
-  // check getRowIdx
-  ASSERT_TRUE(ArrayEquals(tmp->getRowIdx(),rowIdx,7));
-
-  // check getType() is ok
-  ASSERT_EQ(tmp->getType(), COMPLEX_SPARSE_MATRIX_ENUM);
-
-  // delete should free, valgrind should be happy
   delete tmp;
 }
 

--- a/src/librdag/test/check_terminals.cc
+++ b/src/librdag/test/check_terminals.cc
@@ -407,11 +407,22 @@ TEST(TerminalsTest, OGRealMatrixTest) {
   tmp = nullptr;
   ASSERT_ANY_THROW(tmp = new OGRealMatrix(data,rows,-1));
 
+  // attempt construct from ok data, own the data and delete it
+  tmp = nullptr;
+  tmp = new OGRealMatrix(new real16[2]{10,20},1,2, OWNER);
+  ASSERT_NE(tmp, nullptr);
+  ASSERT_TRUE(tmp->getDataAccess()==OWNER);
+  delete tmp;
+
   // attempt construct from ok data
   tmp = nullptr;
   tmp = new OGRealMatrix(data,rows,cols);
+
   // check ctor worked
   ASSERT_NE(tmp, nullptr);
+
+  // check it's a view context
+  ASSERT_TRUE(tmp->getDataAccess()==VIEWER);
 
   // check getRows
   ASSERT_EQ(tmp->getRows(), rows);
@@ -516,11 +527,21 @@ TEST(TerminalsTest, OGComplexMatrixTest) {
   tmp = nullptr;
   ASSERT_ANY_THROW(tmp = new OGComplexMatrix(data,rows,-1));
 
+  // attempt construct from ok data, own the data and delete it
+  tmp = nullptr;
+  tmp = new OGComplexMatrix(new complex16[2]{{10,20},{30,40}},1,2, OWNER);
+  ASSERT_NE(tmp, nullptr);
+  ASSERT_TRUE(tmp->getDataAccess()==OWNER);
+  delete tmp;
+
   // attempt construct from ok data
   tmp = nullptr;
   tmp = new OGComplexMatrix(data,rows,cols);
   // check ctor worked
   ASSERT_NE(tmp, nullptr);
+
+  // check it's a view context
+  ASSERT_TRUE(tmp->getDataAccess()==VIEWER);
 
   // check getRows
   ASSERT_EQ(tmp->getRows(), rows);
@@ -624,11 +645,22 @@ TEST(TerminalsTest, OGRealDiagonalMatrix) {
   tmp = nullptr;
   ASSERT_ANY_THROW(tmp = new OGRealDiagonalMatrix(data,rows,-1));
 
+  // attempt construct from ok data, own the data and delete it
+  tmp = nullptr;
+  tmp = new OGRealDiagonalMatrix(new real16[2]{10,20},2,2, OWNER);
+  ASSERT_NE(tmp, nullptr);
+  ASSERT_TRUE(tmp->getDataAccess()==OWNER);
+  delete tmp;
+
   // attempt construct from ok data
   tmp = nullptr;
   tmp = new OGRealDiagonalMatrix(data,rows,cols);
+
   // check ctor worked
   ASSERT_NE(tmp, nullptr);
+
+  // check it's a view context
+  ASSERT_TRUE(tmp->getDataAccess()==VIEWER);
 
   // check getRows
   ASSERT_EQ(tmp->getRows(), rows);
@@ -750,11 +782,22 @@ TEST(TerminalsTest, OGComplexDiagonalMatrix) {
   tmp = nullptr;
   ASSERT_ANY_THROW(tmp = new OGComplexDiagonalMatrix(data,rows,-1));
 
+  // attempt construct from ok data, own the data and delete it
+  tmp = nullptr;
+  tmp = new OGComplexDiagonalMatrix(new complex16[2]{{10,20},{30,40}},2,2, OWNER);
+  ASSERT_NE(tmp, nullptr);
+  ASSERT_TRUE(tmp->getDataAccess()==OWNER);
+  delete tmp;
+
   // attempt construct from ok data
   tmp = nullptr;
   tmp = new OGComplexDiagonalMatrix(data,rows,cols);
+
   // check ctor worked
   ASSERT_NE(tmp, nullptr);
+
+  // check it's a view context
+  ASSERT_TRUE(tmp->getDataAccess()==VIEWER);
 
   // check getRows
   ASSERT_EQ(tmp->getRows(), rows);
@@ -889,11 +932,22 @@ TEST(TerminalsTest, OGRealSparseMatrix) {
   tmp = nullptr;
   ASSERT_ANY_THROW(tmp = new OGRealSparseMatrix(colPtr,rowIdx,data,rows,-1));
 
+    // attempt construct from ok data, own the data and delete it
+  tmp = nullptr;
+  tmp = new OGRealSparseMatrix(new int[3]{0,2,2}, new int[2]{0,1},new real16[2]{10,20},2,2, OWNER);
+  ASSERT_NE(tmp, nullptr);
+  ASSERT_TRUE(tmp->getDataAccess()==OWNER);
+  delete tmp;
+
   // attempt construct from ok data
   tmp = nullptr;
   tmp = new OGRealSparseMatrix(colPtr,rowIdx,data,rows,cols);
+
   // check ctor worked
   ASSERT_NE(tmp, nullptr);
+
+  // check it's a view context
+  ASSERT_TRUE(tmp->getDataAccess()==VIEWER);
 
   // check getRows
   ASSERT_EQ(tmp->getRows(), rows);
@@ -1034,11 +1088,22 @@ TEST(TerminalsTest, OGComplexSparseMatrix) {
   tmp = nullptr;
   ASSERT_ANY_THROW(tmp = new OGComplexSparseMatrix(colPtr,rowIdx,data,rows,-1));
 
+  // attempt construct from ok data, own the data and delete it
+  tmp = nullptr;
+  tmp = new OGComplexSparseMatrix(new int[3]{0,2,2}, new int[2]{0,1},new complex16[2]{{10,20},{30,40}},2,2, OWNER);
+  ASSERT_NE(tmp, nullptr);
+  ASSERT_TRUE(tmp->getDataAccess()==OWNER);
+  delete tmp;
+
   // attempt construct from ok data
   tmp = nullptr;
   tmp = new OGComplexSparseMatrix(colPtr,rowIdx,data,rows,cols);
+
   // check ctor worked
   ASSERT_NE(tmp, nullptr);
+
+  // check it's a view context
+  ASSERT_TRUE(tmp->getDataAccess()==VIEWER);
 
   // check getRows
   ASSERT_EQ(tmp->getRows(), rows);

--- a/src/librdag/test/check_terminals.cc
+++ b/src/librdag/test/check_terminals.cc
@@ -360,8 +360,10 @@ TEST(TerminalsTest, OGArrayTest) {
   ASSERT_ANY_THROW(tmp->asFullOGComplexMatrix());
   ASSERT_ANY_THROW(tmp->createOwningCopy());
   ASSERT_ANY_THROW(tmp->createComplexOwningCopy());
-
+  Visitor * v = new FakeVisitor();
+  ASSERT_ANY_THROW(tmp->accept(*v));
   delete tmp;
+  delete v;
 }
 
 /*

--- a/src/librdag/test/check_terminals.cc
+++ b/src/librdag/test/check_terminals.cc
@@ -141,6 +141,10 @@ TEST(TerminalsTest, OGScalarTest) {
   ASSERT_ANY_THROW(tmp->asFullOGComplexMatrix());
   ASSERT_ANY_THROW(tmp->createOwningCopy());
   ASSERT_ANY_THROW(tmp->createComplexOwningCopy());
+
+  // print for test completeness
+  tmp->debug_print();
+
   delete tmp;
 }
 

--- a/src/librdag/test/check_terminals_abstract_regression.cc
+++ b/src/librdag/test/check_terminals_abstract_regression.cc
@@ -1,0 +1,152 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+#include "terminal.hh"
+#include "expression.hh"
+#include "visitor.hh"
+#include "exceptions.hh"
+#include "gtest/gtest.h"
+#include "warningmacros.h"
+#include "exprtypeenum.h"
+
+using namespace std;
+using namespace librdag;
+/**
+ * These tests are here to make sure that the templated types can always be used
+ * in their templated form.
+ */
+
+// Adds the first data element of one ogmatrix to another
+template <typename T> T ogmatrix_t_add_1x1(OGMatrix<T> * arr0, OGMatrix<T> * arr1)
+{
+  T ret = arr0->getData()[0] + arr1->getData()[0];
+  return ret;
+}
+
+// Adds the first data element of one ogdiagonalmatrix to another
+template <typename T> T ogdiagonalmatrix_t_add_1x1(OGDiagonalMatrix<T> * arr0, OGDiagonalMatrix<T> * arr1)
+{
+  T ret = arr0->getData()[0] + arr1->getData()[0];
+  return ret;
+}
+
+// Adds the first data element of one ogdiagonalmatrix to another
+template <typename T> T ogsparsematrix_t_add_1x1(OGSparseMatrix<T> * arr0, OGSparseMatrix<T> * arr1)
+{
+  T ret = arr0->getData()[0] + arr1->getData()[0];
+  return ret;
+}
+
+// Adds the first data element of one ogscalar to another
+template <typename T> T ogscalar_t_add(OGScalar<T> * arr0, OGScalar<T> * arr1)
+{
+  T ret = arr0->getValue() + arr1->getValue();
+  return ret;
+}
+
+/**
+ * Enforcing check that OGMatrix<T> can be used in a templated function.
+ */
+TEST(AbstractTerminalsRegressionTest, OGMatrix_T) {
+  OGMatrix<real16>  * r16_0 = new OGMatrix<real16>(new real16[1]{10},1,1,OWNER);
+  OGMatrix<real16>  * r16_1 = new OGMatrix<real16>(new real16[1]{20},1,1,OWNER);
+  real16 ranswer = ogmatrix_t_add_1x1(r16_0, r16_1);
+  real16 rexpected = 30;
+  ASSERT_TRUE(ranswer==rexpected);
+
+  delete r16_0;
+  delete r16_1;
+
+  OGMatrix<complex16>  * c16_0 = new OGMatrix<complex16>(new complex16[1]{{10,7}},1,1,OWNER);
+  OGMatrix<complex16>  * c16_1 = new OGMatrix<complex16>(new complex16[1]{{20,14}},1,1,OWNER);
+  complex16 canswer = ogmatrix_t_add_1x1(c16_0, c16_1);
+  complex16 cexpected = {30,21};
+  ASSERT_TRUE(canswer==cexpected);
+
+  delete c16_0;
+  delete c16_1;
+}
+
+
+/**
+ * Enforcing check that OGDiagonalMatrix<T> can be used in a templated function.
+ */
+TEST(AbstractTerminalsRegressionTest, OGDiagonalMatrix_T) {
+  OGDiagonalMatrix<real16>  * r16_0 = new OGDiagonalMatrix<real16>(new real16[1]{10},1,1,OWNER);
+  OGDiagonalMatrix<real16>  * r16_1 = new OGDiagonalMatrix<real16>(new real16[1]{20},1,1,OWNER);
+  real16 ranswer = ogdiagonalmatrix_t_add_1x1(r16_0, r16_1);
+  real16 rexpected = 30;
+  ASSERT_TRUE(ranswer==rexpected);
+
+  delete r16_0;
+  delete r16_1;
+
+  OGDiagonalMatrix<complex16>  * c16_0 = new OGDiagonalMatrix<complex16>(new complex16[1]{{10,7}},1,1,OWNER);
+  OGDiagonalMatrix<complex16>  * c16_1 = new OGDiagonalMatrix<complex16>(new complex16[1]{{20,14}},1,1,OWNER);
+  complex16 canswer = ogdiagonalmatrix_t_add_1x1(c16_0, c16_1);
+  complex16 cexpected = {30,21};
+  ASSERT_TRUE(canswer==cexpected);
+
+  delete c16_0;
+  delete c16_1;
+}
+
+
+/**
+ * Enforcing check that OGSparseMatrix<T> can be used in a templated function.
+ */
+TEST(AbstractTerminalsRegressionTest, OGSparseMatrix_T) {
+  OGSparseMatrix<real16>  * r16_0 = new OGSparseMatrix<real16>(new int[2]{0,1}, new int[1]{0},new real16[1]{10},1,1,OWNER);
+  OGSparseMatrix<real16>  * r16_1 = new OGSparseMatrix<real16>(new int[2]{0,1}, new int[1]{0},new real16[1]{20},1,1,OWNER);
+  real16 ranswer = ogsparsematrix_t_add_1x1(r16_0, r16_1);
+  real16 rexpected = 30;
+  ASSERT_TRUE(ranswer==rexpected);
+
+  delete r16_0;
+  delete r16_1;
+
+  OGSparseMatrix<complex16>  * c16_0 = new OGSparseMatrix<complex16>(new int[2]{0,1}, new int[1]{0},new complex16[1]{{10,7}},1,1,OWNER);
+  OGSparseMatrix<complex16>  * c16_1 = new OGSparseMatrix<complex16>(new int[2]{0,1}, new int[1]{0},new complex16[1]{{20,14}},1,1,OWNER);
+  complex16 canswer = ogsparsematrix_t_add_1x1(c16_0, c16_1);
+  complex16 cexpected = {30,21};
+  ASSERT_TRUE(canswer==cexpected);
+
+  delete c16_0;
+  delete c16_1;
+}
+
+
+/**
+ * Enforcing check that OGScalar<T> can be used in a templated function.
+ */
+TEST(AbstractTerminalsRegressionTest, OGScalar_T) {
+  OGScalar<real16>  * r16_0 = new OGScalar<real16>(10);
+  OGScalar<real16>  * r16_1 = new OGScalar<real16>(20);
+  real16 ranswer = ogscalar_t_add(r16_0, r16_1);
+  real16 rexpected = 30;
+  ASSERT_TRUE(ranswer==rexpected);
+
+  delete r16_0;
+  delete r16_1;
+
+  OGScalar<complex16>  * c16_0 = new OGScalar<complex16>({10,7});
+  OGScalar<complex16>  * c16_1 = new OGScalar<complex16>({20,14});
+  complex16 canswer = ogscalar_t_add(c16_0, c16_1);
+  complex16 cexpected = {30,21};
+  ASSERT_TRUE(canswer==cexpected);
+
+  delete c16_0;
+  delete c16_1;
+
+  OGScalar<int>  * i16_0 = new OGScalar<int>(10);
+  OGScalar<int>  * i16_1 = new OGScalar<int>(20);
+  int ianswer = ogscalar_t_add(i16_0, i16_1);
+  int iexpected = 30;
+  ASSERT_TRUE(ianswer==iexpected);
+
+  delete i16_0;
+  delete i16_1;
+}

--- a/src/librdag/test/nodes/check_norm2.cc
+++ b/src/librdag/test/nodes/check_norm2.cc
@@ -29,16 +29,16 @@ INSTANTIATE_NODE_TEST_CASE_P(NORM2Tests,NORM2,
   new CheckUnary<NORM2>( new OGRealScalar(1.0), new OGRealScalar(1.0), MATHSEQUAL),
   new CheckUnary<NORM2>( new OGRealScalar(-1.0), new OGRealScalar(1.0), MATHSEQUAL),
   new CheckUnary<NORM2>( new OGRealScalar(0.0), new OGRealScalar(0.0), MATHSEQUAL),
-  new CheckUnary<NORM2>( new OGOwningRealMatrix(new real16[1]{-1},1,1), new OGRealScalar(1.0), MATHSEQUAL),
-  new CheckUnary<NORM2>( new OGOwningRealMatrix(new real16[3]{1,2,3},1,3), new OGRealScalar(3.74165738677394), MATHSEQUAL),
-  new CheckUnary<NORM2>( new OGOwningRealMatrix(new real16[12]{1,4,7,10,2,5,8,11,3,6,9,12},4,3), new OGRealScalar(25.4624074360364), MATHSEQUAL),
+  new CheckUnary<NORM2>( new OGRealMatrix(new real16[1]{-1},1,1, OWNER), new OGRealScalar(1.0), MATHSEQUAL),
+  new CheckUnary<NORM2>( new OGRealMatrix(new real16[3]{1,2,3},1,3, OWNER), new OGRealScalar(3.74165738677394), MATHSEQUAL),
+  new CheckUnary<NORM2>( new OGRealMatrix(new real16[12]{1,4,7,10,2,5,8,11,3,6,9,12},4,3, OWNER), new OGRealScalar(25.4624074360364), MATHSEQUAL),
   // test complex
   new CheckUnary<NORM2>( new OGComplexScalar({1.0,0}), new OGRealScalar(1.0), MATHSEQUAL),
   new CheckUnary<NORM2>( new OGComplexScalar({0,1.0}), new OGRealScalar(1.0), MATHSEQUAL),
   new CheckUnary<NORM2>( new OGComplexScalar({1.0,1.0}), new OGRealScalar(std::sqrt(2)), MATHSEQUAL),
 new CheckUnary<NORM2>( new OGComplexScalar({-1.0,1.0}), new OGRealScalar(std::sqrt(2)), MATHSEQUAL),
   new CheckUnary<NORM2>( new OGComplexScalar({0,0}), new OGRealScalar(0.0), MATHSEQUAL),
-  new CheckUnary<NORM2>( new OGOwningComplexMatrix(new complex16[3]{{1,10},{2,20},{3,30}},1,3), new OGRealScalar(37.6031913539263), MATHSEQUAL),
-  new CheckUnary<NORM2>( new OGOwningComplexMatrix(new complex16[12]{{1,10},{4,40},{7,70},{10,100},{2,20},{5,50},{8,80},{11,110},{3,30},{6,60},{9,90},{12,120}},4,3), new OGRealScalar(255.894027746469), MATHSEQUAL)
+  new CheckUnary<NORM2>( new OGComplexMatrix(new complex16[3]{{1,10},{2,20},{3,30}},1,3, OWNER), new OGRealScalar(37.6031913539263), MATHSEQUAL),
+  new CheckUnary<NORM2>( new OGComplexMatrix(new complex16[12]{{1,10},{4,40},{7,70},{10,100},{2,20},{5,50},{8,80},{11,110},{3,30},{6,60},{9,90},{12,120}},4,3, OWNER), new OGRealScalar(255.894027746469), MATHSEQUAL)
   )
 );


### PR DESCRIPTION
This ticket was about making it possible to instantiate the templated terminal types and removing the `*Owning*` classes in favour of just having data ownership as a property of the class.
The PR:
- Removes all the `*Owning*` classes.
- Adds the enum `DATA_ACCESS` with members `OWNER` and `VIEWER`, to reflect ownership of underlying POD or viewing of underlying POD respectively.
- Adds ctors that take a `DATA_ACCESS` parameter to all classes that extend `OGArray<T>`.
- Updates the unit tests to reflect the above.
- Adds in a load of default methods that throw as implementations for currently abstract templates, like `OGMatrix<T>`, such that they aren't abstract and can be instantiated.
- Adds tests and regression tests such that the above mention templates cannot accidentally become abstract again!

BB Multi-Pass: [http://devmaths-lx-1:8011/builders/nyqwk2-testing/builds/713](http://devmaths-lx-1:8011/builders/nyqwk2-testing/builds/713)
Coverage: librdag 92.4%, jshim 63.9% (jshim decrease due to merge of untested exception handling code from https://github.com/OpenGamma/nyqwk2/pull/66)
Java coverage: 81% (1% decrease, reason as for jshim)
