### PR TITLE
[MAT-296] Report coverage for generated code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,7 +175,7 @@ if (NOT WIN32)
 
   add_custom_target(coverageextract
                      DEPENDS coverageinfo
-                     COMMAND lcov -o coverage-extract.info --extract coverage.info "\"${CMAKE_SOURCE_DIR}/include/*\"" "\"${CMAKE_SOURCE_DIR}/src/*\""
+                     COMMAND lcov -o coverage-extract.info --extract coverage.info "\"${CMAKE_SOURCE_DIR}/include/*\"" "\"${CMAKE_SOURCE_DIR}/src/*\"" "\"${CMAKE_BINARY_DIR}/src/*\"" "\"${CMAKE_BINARY_DIR}/include/*\""
                      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
                      COMMENT "Removing external from coverage info")
 


### PR DESCRIPTION
Adds coverage reporting for `build/include` and `build/src`.

Buildbot pass: http://devmaths-lx-1:8011/builders/nyqwk2-testing/builds/763
Coverage:
build/src/jshim: 0.8%
build/src/librdag: 13.7%
src/jshim: 64.1%
src/librdag: 92.2%
src/librdag/runners: 94.7%
Java: 82%

All coverage figures unchanged - this is just extra reporting.
