### PR TITLE
[MAT-351] Drop longdog in version and match JAR name with DOGMA1.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,12 +58,12 @@ set(maven_VERSION
 # JAR VARIABLES
 set(JARDIR ${CMAKE_BINARY_DIR}/jars)
 
-set(JAR_VERSION "${PROJECT_NAME}-${maven_VERSION}-SNAPSHOT")
+set(JAR_VERSION "${maven_VERSION}-SNAPSHOT")
 
-set(JAR_NAME_NO_EXTN "${JAR_VERSION}" )
-set(JAR_SOURCES_NAME_NO_EXTN "${JAR_VERSION}-sources" )
-set(JAR_TEST_NAME_NO_EXTN "${JAR_VERSION}-tests" )
-set(JAR_JAVADOC_NAME_NO_EXTN "${JAR_VERSION}-javadoc" )
+set(JAR_NAME_NO_EXTN "og-maths-${JAR_VERSION}" )
+set(JAR_SOURCES_NAME_NO_EXTN "${JAR_NAME_NO_EXTN}-sources" )
+set(JAR_TEST_NAME_NO_EXTN "${JAR_NAME_NO_EXTN}-tests" )
+set(JAR_JAVADOC_NAME_NO_EXTN "${JAR_NAME_NO_EXTN}-javadoc" )
 
 set(JAR_EXT ".jar")
 
@@ -231,7 +231,7 @@ else()
                     COMMENT "Gathering Java test coverage information")
   add_custom_target(jacoco
                     COMMAND ${Java_JAVA_EXECUTABLE} com.opengamma.jacocoreporter.ReportGenerator jacoco.exec
-                            ${JARDIR}/CMakeFiles/${JAR_VERSION}.dir ${CMAKE_SOURCE_DIR}/src/java/src/main/java
+                            ${JARDIR}/CMakeFiles/${JAR_NAME_NO_EXTN}.dir ${CMAKE_SOURCE_DIR}/src/java/src/main/java
                             coveragereport
                     DEPENDS jacocorun
                     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
@@ -242,13 +242,13 @@ endif()
 # Installation to local maven repository
 add_custom_target(maven_install
                   COMMAND mvn install:install-file
-                          -Dfile=${JAR_VERSION}.jar
+                          -Dfile=${JAR_NAME}
                           -DgroupId=com.opengamma.maths
                           -DartifactId=og-maths
                           -Dversion=${JAR_VERSION}
                           -Dpackaging=jar
-                          -Djavadoc=${PATH_AND_JAR_JAVADOC_NAME}
-                          -Dsources=${PATH_AND_JAR_SOURCES_NAME}
+                          -Djavadoc=${JAR_JAVADOC_NAME}
+                          -Dsources=${JAR_SOURCES_NAME}
                   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/jars)
 
 message("Build type: " ${CMAKE_BUILD_TYPE})


### PR DESCRIPTION
The group ID, artifact ID, and version now match that discussed in MAT-351. I.e.:

Group ID: com.opengamma.maths
Artifact ID: og-maths
version: 0.1.0-SNAPSHOT

This is also reflected in the built jar file name: og-maths-0.1.0-SNAPSHOT.jar

I decided to PR this separately from a whole purge of the name "longdog" everywhere, because that purge will probably make a rebase difficult - I will leave that for some future time when there is no in-flight work on the Java side.

If this PR is merged, I will adjust the pom for OG-Analytics on the MAT-310 branch accordingly.

Buildbot pass: http://devmaths-lx-1:8011/builders/nyqwk2-testing/builds/768
Coverage: all unchanged.
