### PR TITLE
Implement infix runners for matrices

### DIFF
--- a/src/generator/runners.py
+++ b/src/generator/runners.py
@@ -1,5 +1,6 @@
 from runnertemplates import runners_header, runners_cc, binary_runner_class_definition, \
                             binary_runner_function, infix_scalar_runner_implementation, \
+                            infix_matrix_runner_implementation,                         \
                             unary_runner_class_definition, unary_runner_function,       \
                             prefix_scalar_runner_implementation, \
                             prefix_matrix_runner_implementation, \
@@ -154,18 +155,22 @@ class InfixOpRunner(BinaryExpressionRunner):
     @property
     def scalar_implementation(self):
         d = { 'symbol':     self.symbol,
-              'arg0type':   'OGRealScalar',
-              'arg1type':   'OGRealScalar',
               'returntype': 'OGRealScalar' }
         return infix_scalar_runner_implementation % d
 
     @property
     def real_matrix_implementation(self):
-        return "  arg0->debug_print(); arg1->debug_print(); ret = arg0; // TBC"
+        d = { 'symbol':     self.symbol,
+              'datatype':   'real16',
+              'returntype': 'OGRealMatrix' }
+        return infix_matrix_runner_implementation % d
 
     @property
     def complex_matrix_implementation(self):
-        return "  arg0->debug_print(); arg1->debug_print(); ret = arg0; // TBC"
+        d = { 'symbol':     self.symbol,
+              'datatype':   'complex16',
+              'returntype': 'OGComplexMatrix' }
+        return infix_matrix_runner_implementation % d
 
 class PrefixOpRunner(UnaryExpressionRunner):
     """A PrefixOp is a UnaryFunction whose symbol is placed just before its

--- a/src/generator/runnertemplates.py
+++ b/src/generator/runnertemplates.py
@@ -99,7 +99,33 @@ infix_matrix_runner_implementation = """\
   int r1 = arg1->getRows();
   int c0 = arg0->getCols();
   int c1 = arg1->getCols();
-  if ((r0 != r1) || (c0 != c1))
+  
+  bool arg0scalar = false, arg1scalar = false;
+  %(datatype)s arg0value = 0.0, arg1value = 0.0;
+
+  int newRows, newCols;
+  
+  if ((r0 == 1) && (c0 == 1))
+  {
+    arg0scalar = true;
+    arg0value = arg0->getData()[0];
+    newRows = arg1->getRows();
+    newCols = arg1->getCols();
+  }
+  else if ((r1 == 1) && (c1 == 1))
+  {
+    arg1scalar = true;
+    arg1value = arg1->getData()[0];
+    newRows = arg0->getRows();
+    newCols = arg0->getCols();
+  }
+  else
+  {
+    newRows = arg0->getRows();
+    newCols = arg0->getCols();
+  }
+  
+  if (((r0 != r1) || (c0 != c1)) && !arg0scalar && !arg1scalar)
   {
     stringstream s;
     s << "Matrix dimensions ";
@@ -110,18 +136,44 @@ infix_matrix_runner_implementation = """\
     throw rdag_error(s.str());
   }
 
-  int datalen = arg0->getDatalen();
-  %(datatype)s* newData = new %(datatype)s[datalen];
+  %(datatype)s* newData;
 
-  %(datatype)s* data0 = arg0->getData();
-  %(datatype)s* data1 = arg1->getData();
-
-  for (int i = 0; i < datalen; i++)
+  if (arg0scalar)
   {
-    newData[i] = data0[i] %(symbol)s data1[i];
+    int datalen = arg1->getDatalen();
+    %(datatype)s* data1 = arg1->getData();
+    newData = new %(datatype)s[datalen];
+    
+    for (int i = 0; i < datalen; i++)
+    {
+      newData[i] = data1[i] %(symbol)s arg0value;
+    }
+  }
+  else if (arg1scalar)
+  {
+    int datalen = arg0->getDatalen();
+    %(datatype)s* data0 = arg0->getData();
+    newData = new %(datatype)s[datalen];
+    
+    for (int i = 0; i < datalen; i++)
+    {
+      newData[i] = data0[i] %(symbol)s arg1value;
+    }
+  }
+  else
+  {
+    int datalen = arg0->getDatalen();
+    %(datatype)s* data0 = arg0->getData();
+    %(datatype)s* data1 = arg1->getData();
+    newData = new %(datatype)s[datalen];
+    
+    for (int i = 0; i < datalen; i++)
+    {
+      newData[i] = data0[i] %(symbol)s data1[i];
+    }
   }
 
-  ret = new %(returntype)s(newData, arg0->getRows(), arg0->getCols(), OWNER);
+  ret = new %(returntype)s(newData, newRows, newCols, OWNER);
 """
 
 # Unary runner

--- a/src/generator/runnertemplates.py
+++ b/src/generator/runnertemplates.py
@@ -94,6 +94,36 @@ infix_scalar_runner_implementation = """\
   ret = new %(returntype)s(arg0->getValue() %(symbol)s arg1->getValue());\
 """
 
+infix_matrix_runner_implementation = """\
+  int r0 = arg0->getRows();
+  int r1 = arg1->getRows();
+  int c0 = arg0->getCols();
+  int c1 = arg1->getCols();
+  if ((r0 != r1) || (c0 != c1))
+  {
+    stringstream s;
+    s << "Matrix dimensions ";
+    s << "(" << r0 << "," << c0 << ")";
+    s << " and ";
+    s << "(" << r1 << "," << c1 << ")";
+    s << " mismatch for operation: %(symbol)s";
+    throw rdag_error(s.str());
+  }
+
+  int datalen = arg0->getDatalen();
+  %(datatype)s* newData = new %(datatype)s[datalen];
+
+  %(datatype)s* data0 = arg0->getData();
+  %(datatype)s* data1 = arg1->getData();
+
+  for (int i = 0; i < datalen; i++)
+  {
+    newData[i] = data0[i] %(symbol)s data1[i];
+  }
+
+  ret = new %(returntype)s(newData, arg0->getRows(), arg0->getCols(), OWNER);
+"""
+
 # Unary runner
 
 unary_runner_class_definition = """\

--- a/src/java/src/test/CMakeLists.txt
+++ b/src/java/src/test/CMakeLists.txt
@@ -13,6 +13,7 @@ fqn_to_dir(JPACKAGEDIR ${JPACKAGEFQN})
 set(JAVA_FILES
     testnodes/TestNorm2Materialise.java
     testnodes/TestPlusMaterialise.java
+    testnodes/TestPlusMaterialiseToComplex.java
     testnodes/TestNegateMaterialise.java
     testnodes/TestSVDMaterialise.java
     testnodes/TestMtimesMaterialise.java

--- a/src/java/src/test/java/com/opengamma/longdog/testnodes/TestPlusMaterialise.java
+++ b/src/java/src/test/java/com/opengamma/longdog/testnodes/TestPlusMaterialise.java
@@ -24,7 +24,7 @@ public class TestPlusMaterialise {
 
   @DataProvider
   public Object[][] dataContainer() {
-    Object[][] obj = new Object[6][2];
+    Object[][] obj = new Object[10][2];
 
 
     obj[0][0] = new PLUS(new OGRealScalar(2.0), new OGRealScalar(3.0));
@@ -79,6 +79,25 @@ public class TestPlusMaterialise {
     }
     obj[5][0] = bigRealMatrixTree;
     obj[5][1] = new OGRealDenseMatrix(realMatrixSum);
+
+    obj[6][0] = new PLUS(m1, new OGRealScalar(1.0));
+    obj[6][1] = new OGRealDenseMatrix(new double[][] { { 2.0, 3.0 }, { 4.0, 5.0 } });
+
+    OGNumeric m6 = new OGRealDenseMatrix(new double[][] { { 2.0, 3.0 }, { 4.0, 5.0 } });
+
+    obj[6][0] = new PLUS(m1, new OGRealScalar(1.0));
+    obj[6][1] = m6;
+
+    obj[7][0] = new PLUS(new OGRealScalar(1.0), m1);
+    obj[7][1] = m6;
+
+    OGNumeric m7 = new OGRealDenseMatrix(new double[][] { { 1.0 } });
+
+    obj[8][0] = new PLUS(m1, m7);
+    obj[8][1] = m6;
+
+    obj[9][0] = new PLUS(m7, m1);
+    obj[9][1] = m6;
 
     return obj;
   };

--- a/src/java/src/test/java/com/opengamma/longdog/testnodes/TestPlusMaterialise.java
+++ b/src/java/src/test/java/com/opengamma/longdog/testnodes/TestPlusMaterialise.java
@@ -10,19 +10,21 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import com.opengamma.longdog.datacontainers.OGNumeric;
+import com.opengamma.longdog.datacontainers.OGTerminal;
 import com.opengamma.longdog.datacontainers.lazy.OGExpr;
+import com.opengamma.longdog.datacontainers.matrix.OGRealDenseMatrix;
 import com.opengamma.longdog.datacontainers.scalar.OGRealScalar;
 import com.opengamma.longdog.exceptions.MathsException;
 import com.opengamma.longdog.exceptions.MathsExceptionIllegalArgument;
+import com.opengamma.longdog.helpers.FuzzyEquals;
 import com.opengamma.longdog.materialisers.Materialisers;
 import com.opengamma.longdog.nodes.PLUS;
-import com.opengamma.longdog.testhelpers.ArraysHelpers;
 
 public class TestPlusMaterialise {
 
   @DataProvider
   public Object[][] dataContainer() {
-    Object[][] obj = new Object[3][2];
+    Object[][] obj = new Object[6][2];
 
 
     obj[0][0] = new PLUS(new OGRealScalar(2.0), new OGRealScalar(3.0));
@@ -31,42 +33,76 @@ public class TestPlusMaterialise {
     obj[1][0] = new PLUS(new PLUS(new OGRealScalar(1.0), new OGRealScalar(2.0)), new OGRealScalar(3.0));
     obj[1][1] = new OGRealScalar(1.0 + 2.0 + 3.0);
 
-    OGNumeric bigtree = new OGRealScalar(0.0);
+    OGNumeric bigScalarTree = new OGRealScalar(0.0);
     double sum = 0.0;
     for (int i = 1; i < 500; i++) {
       if (i%2 == 0) {
-        bigtree = new PLUS(new OGRealScalar(i), bigtree);
+        bigScalarTree = new PLUS(new OGRealScalar(i), bigScalarTree);
       }
       else {
-        bigtree = new PLUS(bigtree, new OGRealScalar(i));
+        bigScalarTree = new PLUS(bigScalarTree, new OGRealScalar(i));
       }
       sum += i;
     }
 
-    obj[2][0] = bigtree;
+    obj[2][0] = bigScalarTree;
     obj[2][1] = new OGRealScalar(sum);
+
+    OGNumeric m1 = new OGRealDenseMatrix(new double[][] { { 1.0, 2.0 }, { 3.0, 4.0 } });
+    OGNumeric m2 = new OGRealDenseMatrix(new double[][] { { 7.0, 4.5 }, { 6.0, 8.0 } });
+    OGNumeric m3 = new OGRealDenseMatrix(new double[][] { { 8.0, 6.5 }, { 9.0, 12.0} });
+
+    obj[3][0] = new PLUS(m1, m2);
+    obj[3][1] = m3;
+
+    OGNumeric m4 = new OGRealDenseMatrix(new double[][] { { 6.0, 5.0 }, { 2.0, 1.0 } });
+    OGNumeric m5 = new OGRealDenseMatrix(new double[][] { { 14.0, 11.5 }, { 11.0, 13.0 } });
+
+    obj[4][0] = new PLUS(new PLUS(m1, m2), m4);
+    obj[4][1] = m5;
+
+    double[][] baseMatrix = new double[][]{ { 1.0, 2.0 }, { 4.0, 5.0 } };
+    OGNumeric bigRealMatrixTree = new OGRealDenseMatrix(new double[][] { { 0, 0 }, { 0, 0 } });
+    double[][] realMatrixSum = new double[2][2];
+    for (int i = 1; i < 500; i++) {
+      if (i%2 == 0) {
+        bigRealMatrixTree = new PLUS(new OGRealDenseMatrix(baseMatrix), bigRealMatrixTree);
+      }
+      else {
+        bigRealMatrixTree = new PLUS(bigRealMatrixTree, new OGRealDenseMatrix(baseMatrix));
+      }
+      for (int j = 0; j < 2; j++) {
+        for (int k = 0; k < 2; k++) {
+          realMatrixSum[j][k] += baseMatrix[j][k];
+        }
+      }
+    }
+    obj[5][0] = bigRealMatrixTree;
+    obj[5][1] = new OGRealDenseMatrix(realMatrixSum);
 
     return obj;
   };
 
   @Test(dataProvider = "dataContainer")
-  public void materialiseToJDoubleArray(OGNumeric input, OGRealScalar expected) {
+  public void materialiseToJDoubleArray(OGNumeric input, OGTerminal expected) {
     double[][] answer = Materialisers.toDoubleArrayOfArrays(input);
-    if (!ArraysHelpers.ArraysEquals(new double[][] {expected.getData()}, answer)) {
+    double[][] reference = Materialisers.toDoubleArrayOfArrays(expected);
+    if (!FuzzyEquals.ArrayFuzzyEquals(reference, answer)) {
       throw new MathsException("Arrays not equal");
     }
   }
 
   @Test(dataProvider = "dataContainer")
-  public void materialiseToOGTerminal(OGNumeric input, OGRealScalar expected) {
-    OGRealScalar answer = (OGRealScalar) Materialisers.toOGTerminal(input);
-    if (answer.getData()[0] != expected.getData()[0]) {
+  public void materialiseToOGTerminal(OGNumeric input, OGTerminal expected) {
+    OGTerminal answer = Materialisers.toOGTerminal(input);
+
+    if (!FuzzyEquals.ArrayFuzzyEquals(answer.getData(), expected.getData())) {
       throw new MathsException("Arrays not equal");
     }
   }
 
   @Test(dataProvider = "dataContainer", expectedExceptions = MathsExceptionIllegalArgument.class)
-  public void outsideArgBound(OGExpr input, OGRealScalar expected) {
+  public void outsideArgBound(OGExpr input, OGTerminal expected) {
     OGNumeric n = input.getArg(2);
   }
 

--- a/src/java/src/test/java/com/opengamma/longdog/testnodes/TestPlusMaterialise.java
+++ b/src/java/src/test/java/com/opengamma/longdog/testnodes/TestPlusMaterialise.java
@@ -16,6 +16,7 @@ import com.opengamma.longdog.datacontainers.matrix.OGRealDenseMatrix;
 import com.opengamma.longdog.datacontainers.scalar.OGRealScalar;
 import com.opengamma.longdog.exceptions.MathsException;
 import com.opengamma.longdog.exceptions.MathsExceptionIllegalArgument;
+import com.opengamma.longdog.exceptions.MathsExceptionNativeComputation;
 import com.opengamma.longdog.helpers.FuzzyEquals;
 import com.opengamma.longdog.materialisers.Materialisers;
 import com.opengamma.longdog.nodes.PLUS;
@@ -118,6 +119,14 @@ public class TestPlusMaterialise {
     if (!FuzzyEquals.ArrayFuzzyEquals(answer.getData(), expected.getData())) {
       throw new MathsException("Arrays not equal");
     }
+  }
+
+  @Test(expectedExceptions = MathsExceptionNativeComputation.class)
+  public void invalidDimensions() {
+    OGNumeric m1 = new OGRealDenseMatrix(new double[][] { { 1.0, 2.0} });
+    OGNumeric m2 = new OGRealDenseMatrix(new double[][] { { 1.0, 2.0, 3.0 } });
+    OGNumeric p = new PLUS(m1, m2);
+    Materialisers.toOGTerminal(p);
   }
 
   @Test(dataProvider = "dataContainer", expectedExceptions = MathsExceptionIllegalArgument.class)

--- a/src/java/src/test/java/com/opengamma/longdog/testnodes/TestPlusMaterialiseToComplex.java
+++ b/src/java/src/test/java/com/opengamma/longdog/testnodes/TestPlusMaterialiseToComplex.java
@@ -25,7 +25,7 @@ public class TestPlusMaterialiseToComplex {
 
   @DataProvider
   public Object[][] dataContainer() {
-    Object[][] obj = new Object[6][2];
+    Object[][] obj = new Object[10][2];
 
 
     obj[0][0] = new PLUS(new OGComplexScalar(2.0, 4.0), new OGComplexScalar(3.0, 5.0));
@@ -85,6 +85,22 @@ public class TestPlusMaterialiseToComplex {
     }
     obj[5][0] = bigRealMatrixTree;
     obj[5][1] = new OGComplexDenseMatrix(realMatrixSum, imagMatrixSum);
+
+    OGNumeric m6 = new OGComplexDenseMatrix(new double[][]{ { 2.0, 3.0 }, { 4.0, 5.0 } }, new double[][]{ { 9.0, 6.5 }, { 8.0, 10.0 } });
+
+    obj[6][0] = new PLUS(new OGComplexScalar(1.0, 2.0), m1);
+    obj[6][1] = m6;
+
+    obj[7][0] = new PLUS(m1, new OGComplexScalar(1.0, 2.0));
+    obj[7][1] = m6;
+
+    OGNumeric m7 = new OGComplexDenseMatrix(new double[][] { { 1.0 } }, new double[][] { { 2.0 } });
+
+    obj[8][0] = new PLUS(m1, m7);
+    obj[8][1] = m6;
+
+    obj[9][0] = new PLUS(m7, m1);
+    obj[9][1] = m6;
 
     return obj;
   };

--- a/src/java/src/test/java/com/opengamma/longdog/testnodes/TestPlusMaterialiseToComplex.java
+++ b/src/java/src/test/java/com/opengamma/longdog/testnodes/TestPlusMaterialiseToComplex.java
@@ -17,6 +17,7 @@ import com.opengamma.longdog.datacontainers.other.ComplexArrayContainer;
 import com.opengamma.longdog.datacontainers.scalar.OGComplexScalar;
 import com.opengamma.longdog.exceptions.MathsException;
 import com.opengamma.longdog.exceptions.MathsExceptionIllegalArgument;
+import com.opengamma.longdog.exceptions.MathsExceptionNativeComputation;
 import com.opengamma.longdog.helpers.FuzzyEquals;
 import com.opengamma.longdog.materialisers.Materialisers;
 import com.opengamma.longdog.nodes.PLUS;
@@ -124,6 +125,14 @@ public class TestPlusMaterialiseToComplex {
     if (!FuzzyEquals.ArrayFuzzyEquals(answer.getData(), expected.getData())) {
       throw new MathsException("Arrays not equal");
     }
+  }
+
+  @Test(expectedExceptions = MathsExceptionNativeComputation.class)
+  public void invalidDimensions() {
+    OGNumeric m1 = new OGComplexDenseMatrix(new double[][] { { 1.0, 2.0} }, new double[][] { { 3.0, 4.0 } });
+    OGNumeric m2 = new OGComplexDenseMatrix(new double[][] { { 1.0, 2.0, 3.0 } }, new double[][] { { 4.0, 5.0, 6.0 } });
+    OGNumeric p = new PLUS(m1, m2);
+    Materialisers.toOGTerminal(p);
   }
 
   @Test(dataProvider = "dataContainer", expectedExceptions = MathsExceptionIllegalArgument.class)

--- a/src/java/src/test/java/com/opengamma/longdog/testnodes/TestPlusMaterialiseToComplex.java
+++ b/src/java/src/test/java/com/opengamma/longdog/testnodes/TestPlusMaterialiseToComplex.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (C) 2013 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+package com.opengamma.longdog.testnodes;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.opengamma.longdog.datacontainers.OGNumeric;
+import com.opengamma.longdog.datacontainers.OGTerminal;
+import com.opengamma.longdog.datacontainers.lazy.OGExpr;
+import com.opengamma.longdog.datacontainers.matrix.OGComplexDenseMatrix;
+import com.opengamma.longdog.datacontainers.other.ComplexArrayContainer;
+import com.opengamma.longdog.datacontainers.scalar.OGComplexScalar;
+import com.opengamma.longdog.exceptions.MathsException;
+import com.opengamma.longdog.exceptions.MathsExceptionIllegalArgument;
+import com.opengamma.longdog.helpers.FuzzyEquals;
+import com.opengamma.longdog.materialisers.Materialisers;
+import com.opengamma.longdog.nodes.PLUS;
+
+public class TestPlusMaterialiseToComplex {
+
+  @DataProvider
+  public Object[][] dataContainer() {
+    Object[][] obj = new Object[6][2];
+
+
+    obj[0][0] = new PLUS(new OGComplexScalar(2.0, 4.0), new OGComplexScalar(3.0, 5.0));
+    obj[0][1] = new OGComplexScalar(2.0 + 3.0, 4.0 + 5.0);
+
+    obj[1][0] = new PLUS(new PLUS(new OGComplexScalar(1.0, 4.0), new OGComplexScalar(2.0, 5.0)), new OGComplexScalar(3.0, 6.0));
+    obj[1][1] = new OGComplexScalar(1.0 + 2.0 + 3.0, 4.0 + 5.0 + 6.0);
+
+    OGNumeric bigScalarTree = new OGComplexScalar(0.0, 0.0);
+    double real = 0.0;
+    double imag = 0.0;
+    for (int i = 1; i < 500; i++) {
+      if (i%2 == 0) {
+        bigScalarTree = new PLUS(new OGComplexScalar(i, i*2), bigScalarTree);
+      }
+      else {
+        bigScalarTree = new PLUS(bigScalarTree, new OGComplexScalar(i, i*2));
+      }
+      real += i;
+      imag += i * 2;
+    }
+
+    obj[2][0] = bigScalarTree;
+    obj[2][1] = new OGComplexScalar(real, imag);
+
+    OGNumeric m1 = new OGComplexDenseMatrix(new double[][]{ { 1.0, 2.0 }, { 3.0, 4.0 } }, new double[][]{ { 7.0, 4.5 }, { 6.0, 8.0 } });
+    OGNumeric m2 = new OGComplexDenseMatrix(new double[][]{ { 3.0, 1.0 }, { 5.5, 1.1 } }, new double[][]{ { 6.0, 3.5 }, { 2.3, 4.6 } });
+    OGNumeric m3 = new OGComplexDenseMatrix(new double[][]{ { 4.0, 3.0 }, { 8.5, 5.1 } }, new double[][]{ { 13.0, 8.0 }, { 8.3, 12.6 } });
+
+    obj[3][0] = new PLUS(m1, m2);
+    obj[3][1] = m3;
+
+    OGNumeric m4 = new OGComplexDenseMatrix(new double[][] { { 6.0, 5.0 }, { 2.0, 1.0 } }, new double[][] { { 2.2, 7.1 }, { 3.0, 5.0 } });
+    OGNumeric m5 = new OGComplexDenseMatrix(new double[][] { { 10.0, 8.0 }, { 10.5, 6.1 } }, new double[][] { { 15.2, 15.1 }, { 11.3, 17.6 } });
+
+    obj[4][0] = new PLUS(new PLUS(m1, m2), m4);
+    obj[4][1] = m5;
+
+    double[][] baseReal = new double[][]{ { 1.0, 2.0 }, { 4.0, 5.0 } };
+    double[][] baseImag = new double[][]{ { 1.0, 2.0 }, { 4.0, 5.0 } };
+    OGNumeric bigRealMatrixTree = new OGComplexDenseMatrix(new double[][] { { 0, 0 }, { 0, 0 } }, new double[][] { { 0, 0 }, { 0, 0 } });
+    double[][] realMatrixSum = new double[2][2];
+    double[][] imagMatrixSum = new double[2][2];
+    for (int i = 1; i < 500; i++) {
+      if (i%2 == 0) {
+        bigRealMatrixTree = new PLUS(new OGComplexDenseMatrix(baseReal, baseImag), bigRealMatrixTree);
+      }
+      else {
+        bigRealMatrixTree = new PLUS(bigRealMatrixTree, new OGComplexDenseMatrix(baseReal, baseImag));
+      }
+      for (int j = 0; j < 2; j++) {
+        for (int k = 0; k < 2; k++) {
+          realMatrixSum[j][k] += baseReal[j][k];
+          imagMatrixSum[j][k] += baseImag[j][k];
+        }
+      }
+    }
+    obj[5][0] = bigRealMatrixTree;
+    obj[5][1] = new OGComplexDenseMatrix(realMatrixSum, imagMatrixSum);
+
+    return obj;
+  };
+
+  @Test(dataProvider = "dataContainer")
+  public void materialiseToJDoubleArray(OGNumeric input, OGTerminal expected) {
+    ComplexArrayContainer answer = Materialisers.toComplexArrayContainer(input);
+    ComplexArrayContainer reference = Materialisers.toComplexArrayContainer(expected);
+    if (!FuzzyEquals.ArrayFuzzyEquals(reference.getReal(), answer.getReal())) {
+      throw new MathsException("Arrays not equal");
+    }
+    if (!FuzzyEquals.ArrayFuzzyEquals(reference.getImag(), answer.getImag())) {
+      throw new MathsException("Arrays not equal");
+    }
+  }
+
+  @Test(dataProvider = "dataContainer")
+  public void materialiseToOGTerminal(OGNumeric input, OGTerminal expected) {
+    OGTerminal answer = Materialisers.toOGTerminal(input);
+
+    if (!FuzzyEquals.ArrayFuzzyEquals(answer.getData(), expected.getData())) {
+      throw new MathsException("Arrays not equal");
+    }
+  }
+
+  @Test(dataProvider = "dataContainer", expectedExceptions = MathsExceptionIllegalArgument.class)
+  public void outsideArgBound(OGExpr input, OGTerminal expected) {
+    OGNumeric n = input.getArg(2);
+  }
+
+}


### PR DESCRIPTION
This enables addition of real and complex matrices to work. Some testing is added, to the extent that the addition operation for scalars is tested. More test cases could be added, but given the requirement to overhaul the java side and testing in general this seemed like work that might be duplicated.

Buildbot pass: http://devmaths-lx-1:8011/builders/nyqwk2-testing/builds/781
Coverage:
Java: 85% (slight rise)
build/src/librdag: 0.8% (unchanged)
build/src/jshim: 13.3% (slight drop since more code is generated)
src/librdag: 92.2% (unchanged)
src/librdag/runners: 94.7% (unchanged)
src/jshim: 64.1% (unchanged)
