### PR TITLE
[MAT-337] Catch standard exceptions

### DIFF
--- a/include/jvmmanager.hh
+++ b/include/jvmmanager.hh
@@ -54,6 +54,7 @@ class JVMManager {
     DLLEXPORT_C static jclass getOGComplexSparseMatrixClazz();
     DLLEXPORT_C static jclass getMathsExceptionNativeConversionClazz();
     DLLEXPORT_C static jclass getMathsExceptionNativeComputationClazz();
+    DLLEXPORT_C static jclass getMathsExceptionNativeUnspecifiedClazz();
     DLLEXPORT_C static jmethodID getOGRealScalarClazz_init();
     DLLEXPORT_C static jmethodID getOGComplexScalarClazz_init();
     DLLEXPORT_C static jmethodID getOGRealDenseMatrixClazz_init();
@@ -110,6 +111,7 @@ class JVMManager {
     static jclass _OGComplexSparseMatrixClazz;
     static jclass _MathsExceptionNativeConversionClazz;
     static jclass _MathsExceptionNativeComputationClazz;
+    static jclass _MathsExceptionNativeUnspecifiedClazz;
     static jmethodID _DoubleClazz_init;
     static jmethodID _OGRealScalarClazz_init;
     static jmethodID _OGComplexScalarClazz_init;

--- a/src/java/src/main/CMakeLists.txt
+++ b/src/java/src/main/CMakeLists.txt
@@ -25,16 +25,17 @@ set(JAVA_FILES
     nativeloader/SupportedInstructionSet.java
     nativeloader/NativeLibraries.java
     nativeloader/NativeLibrariesSelfTest.java
-    exceptions/MathsExceptionNullPointer.java
     exceptions/MathsException.java
-    exceptions/MathsExceptionNativeConversion.java
-    exceptions/MathsExceptionNonConformance.java
     exceptions/MathsExceptionIllegalArgument.java
-    exceptions/MathsExceptionOnInitialization.java
-    exceptions/MathsExceptionUnsupportedPlatform.java
-    exceptions/MathsExceptionNotImplemented.java
     exceptions/MathsExceptionNative.java
     exceptions/MathsExceptionNativeComputation.java
+    exceptions/MathsExceptionNativeConversion.java
+    exceptions/MathsExceptionNativeUnspecified.java
+    exceptions/MathsExceptionNonConformance.java
+    exceptions/MathsExceptionNotImplemented.java
+    exceptions/MathsExceptionNullPointer.java
+    exceptions/MathsExceptionOnInitialization.java
+    exceptions/MathsExceptionUnsupportedPlatform.java
     datacontainers/matrix/OGSparseMatrix.java
     datacontainers/matrix/OGComplexDiagonalMatrix.java
     datacontainers/matrix/OGComplexDenseMatrix.java

--- a/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionNativeUnspecified.java
+++ b/src/java/src/main/java/com/opengamma/longdog/exceptions/MathsExceptionNativeUnspecified.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2013 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.longdog.exceptions;
+
+/**
+ * Provides a manner in which maths exceptions relating to native code errors that occur
+ * outside of those that are part of DOGMA - e.g. bad_alloc, etc.
+ */
+public class MathsExceptionNativeUnspecified extends MathsExceptionNative {
+
+  /**
+   * Serial ID
+   */
+  private static final long serialVersionUID = 1873841862632698981L;
+
+  /**
+   * This form of the constructor is used on all OSes, since backtraces cannot be
+   * provided for unspecified exceptions.
+   * @param msg the error message
+   */
+  public MathsExceptionNativeUnspecified(String msg) {
+    super(msg);
+  }
+
+
+}

--- a/src/jshim/exprfactory.cc
+++ b/src/jshim/exprfactory.cc
@@ -4,6 +4,7 @@
  * Please see distribution for license.
  */
 
+#include <stdexcept>
 #include "numeric.hh"
 #include "exprfactory.hh"
 #include "jvmmanager.hh"

--- a/src/jshim/jshim.cc
+++ b/src/jshim/jshim.cc
@@ -197,6 +197,33 @@ void rdagExceptionJava(JNIEnv* env, rdag_error& e)
   }
 }
 
+/**
+ * Throw a new Java MathsExceptionNativeUnspecified from a native exception. If the
+ * Java throw fails, stderr receives a warning and the what() of the exception because
+ * there is little else that can be done.
+ *
+ * @param env the JNI environment pointer
+ * @param e the native exception.
+ */
+void unspecifiedExceptionJava(JNIEnv* env, exception& e)
+{
+  if (checkedLocalCapacity(env, 1) == EXCEPTION_ERROR)
+  {
+    cerr << "Error ensuring local capacity for Java exception." << endl;
+    cerr << e.what();
+  }
+
+  jint throwStatus;
+  throwStatus = env->ThrowNew(JVMManager::getMathsExceptionNativeUnspecifiedClazz(), e.what());
+
+  if (throwStatus)
+  {
+    cerr << "Error ensuring throwing Java exception." << endl;
+    cerr << e.what();
+  }
+}
+
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -239,6 +266,11 @@ JNIEXPORT jobjectArray JNICALL Java_com_opengamma_longdog_materialisers_Material
   catch (rdag_error e)
   {
     rdagExceptionJava(env, e);
+    return nullptr;
+  }
+  catch (exception e)
+  {
+    unspecifiedExceptionJava(env, e);
     return nullptr;
   }
 
@@ -296,6 +328,11 @@ JNIEXPORT jobject JNICALL Java_com_opengamma_longdog_materialisers_Materialisers
     rdagExceptionJava(env, e);
     return nullptr;
   }
+  catch (exception e)
+  {
+    unspecifiedExceptionJava(env, e);
+    return nullptr;
+  }
 
   delete chain;
 
@@ -346,6 +383,11 @@ Java_com_opengamma_longdog_materialisers_Materialisers_materialiseToOGTerminal(J
   catch (rdag_error e)
   {
     rdagExceptionJava(env, e);
+    return nullptr;
+  }
+  catch (exception e)
+  {
+    unspecifiedExceptionJava(env, e);
     return nullptr;
   }
 

--- a/src/jshim/jvmmanager.cc
+++ b/src/jshim/jvmmanager.cc
@@ -104,6 +104,7 @@ JVMManager::registerReferences()
   registerGlobalClassReference("com/opengamma/longdog/datacontainers/matrix/OGComplexSparseMatrix", &_OGComplexSparseMatrixClazz);
   registerGlobalClassReference("com/opengamma/longdog/exceptions/MathsExceptionNativeConversion", &_MathsExceptionNativeConversionClazz);
   registerGlobalClassReference("com/opengamma/longdog/exceptions/MathsExceptionNativeComputation", &_MathsExceptionNativeComputationClazz);
+  registerGlobalClassReference("com/opengamma/longdog/exceptions/MathsExceptionNativeUnspecified", &_MathsExceptionNativeUnspecifiedClazz);
 
   //
   // REGISTER METHOD REFERENCES
@@ -244,6 +245,8 @@ jclass JVMManager::getMathsExceptionNativeConversionClazz()
 { return _MathsExceptionNativeConversionClazz; }
 jclass JVMManager::getMathsExceptionNativeComputationClazz()
 { return _MathsExceptionNativeComputationClazz; }
+jclass JVMManager::getMathsExceptionNativeUnspecifiedClazz()
+{ return _MathsExceptionNativeUnspecifiedClazz; }
 jmethodID JVMManager::getOGRealScalarClazz_init()
 { return _OGRealScalarClazz_init; }
 jmethodID JVMManager::getOGComplexScalarClazz_init()
@@ -309,6 +312,7 @@ jclass JVMManager::_OGRealSparseMatrixClazz = nullptr;
 jclass JVMManager::_OGComplexSparseMatrixClazz = nullptr;
 jclass JVMManager::_MathsExceptionNativeConversionClazz = nullptr;
 jclass JVMManager::_MathsExceptionNativeComputationClazz = nullptr;
+jclass JVMManager::_MathsExceptionNativeUnspecifiedClazz = nullptr;
 jmethodID JVMManager::_DoubleClazz_init = nullptr;
 jmethodID JVMManager::_OGRealScalarClazz_init = nullptr;
 jmethodID JVMManager::_OGComplexScalarClazz_init = nullptr;


### PR DESCRIPTION
This adds catching of standard exceptions to JShim. Since we only
call standard library functions from with JShim and RDAG, we now
catch all the exceptions that can be thrown.

Because standard exceptions do not carry backtrace information, we
can only translate the exception message into a Java exception and
throw it - it is not possible to provide additional information.

The Java-side `MathsExceptionNativeUnspecified` is used for the
standard exceptions, since we do not know which exception will
have been thrown, and it was not one that we specified.

Buildbot pass: http://devmaths-lx-1:8011/builders/nyqwk2-testing/builds/787
Coverage:
Java: 82% (unchanged)
build/src/librdag: 13.7% (unchanged)
build/src/jshim: 0.8% (unchanged)
src/jshim: 62.5% (slightly down due to additional code in untested functions)
src/librdag: 92.2% (unchanged)
src/librdag/runners: 94.7 (unchanged)
