### PR TITLE
Mat-348: Wire in SVD implementation.

### DIFF
--- a/include/lapack.hh
+++ b/include/lapack.hh
@@ -48,6 +48,8 @@ namespace detail
 {
 // constants
 extern char N;
+extern char A;
+extern char T;
 extern int ione;
 extern real16 rone;
 extern complex16 cone;
@@ -60,6 +62,14 @@ extern complex16 czero;
  * The F77 character 'N'
  */
 extern char * N;
+/**
+ * The F77 character 'A'
+ */
+extern char * A;
+/**
+ * The F77 character 'T'
+ */
+extern char * T;
 /**
  * The F77 integer '1'
  */

--- a/include/terminal.hh
+++ b/include/terminal.hh
@@ -423,12 +423,12 @@ class OGComplexSparseMatrix: public OGSparseMatrix<complex16>
 
 
 template<typename T>
-OGTerminal * ConcreteDenseMatrixFactory(T * data, int rows, int cols, DATA_ACCESS access);
+OGTerminal * makeConcreteDenseMatrix(T * data, int rows, int cols, DATA_ACCESS access);
 // PTS
 template<>
-OGTerminal * ConcreteDenseMatrixFactory(real16 * data, int rows, int cols, DATA_ACCESS access);
+OGTerminal * makeConcreteDenseMatrix(real16 * data, int rows, int cols, DATA_ACCESS access);
 template<>
-OGTerminal * ConcreteDenseMatrixFactory(complex16 * data, int rows, int cols, DATA_ACCESS access);
+OGTerminal * makeConcreteDenseMatrix(complex16 * data, int rows, int cols, DATA_ACCESS access);
 
 } // end namespace librdag
 

--- a/include/terminal.hh
+++ b/include/terminal.hh
@@ -421,6 +421,15 @@ class OGComplexSparseMatrix: public OGSparseMatrix<complex16>
     virtual OGTerminal * createComplexOwningCopy() const override;
 };
 
+
+template<typename T>
+OGTerminal * ConcreteDenseMatrixFactory(T * data, int rows, int cols, DATA_ACCESS access);
+// PTS
+template<>
+OGTerminal * ConcreteDenseMatrixFactory(real16 * data, int rows, int cols, DATA_ACCESS access);
+template<>
+OGTerminal * ConcreteDenseMatrixFactory(complex16 * data, int rows, int cols, DATA_ACCESS access);
+
 } // end namespace librdag
 
 #endif // _TERMINAL_HH

--- a/include/terminal.hh
+++ b/include/terminal.hh
@@ -264,11 +264,15 @@ template <typename T> class OGMatrix: public OGArray<T>
     virtual OGComplexMatrix * asFullOGComplexMatrix() const override;
     virtual real16 ** toReal16ArrayOfArrays() const override;
     virtual complex16 ** toComplex16ArrayOfArrays() const override;
+    virtual ExprType_t getType() const override;
     T** toArrayOfArrays() const;
 };
 
 template<> real16 ** OGMatrix<real16>::toReal16ArrayOfArrays() const;
 template<> real16 ** OGMatrix<complex16>::toReal16ArrayOfArrays() const;
+
+template<> ExprType_t OGMatrix<real16>::getType() const ;
+template<> ExprType_t OGMatrix<complex16>::getType() const ;
 
 extern template class OGMatrix<real16>;
 extern template class OGMatrix<complex16>;

--- a/src/generator/dispatchtemplates.py
+++ b/src/generator/dispatchtemplates.py
@@ -170,6 +170,7 @@ dispatch_cc = """\
 #include "warningmacros.h"
 #include "uncopyable.hh"
 #include <iostream>
+#include <sstream>
 
 namespace librdag {
 
@@ -441,7 +442,9 @@ DispatchBinaryOp<T>::eval(RegContainer* reg0, OGTerminal const *arg0, OGTerminal
   {
 %(eval_cases)s
     default:
-      throw rdag_error("Unknown type in dispatch on arg0");
+        stringstream message;
+        message << "Unknown type in dispatch on arg0. Type is: " << arg0->getType() << ".";
+        throw rdag_error(message.str());
   }
   return ret;
 }
@@ -453,7 +456,9 @@ dispatchbinaryop_eval_case_arg0 = """\
       {
 %(eval_arg1_cases)s
         default:
-          throw rdag_error("Unknown type in dispatch on arg1");
+        stringstream message;
+        message << "Unknown type in dispatch on arg1. Type is: " << arg1->getType() << ".";
+        throw rdag_error(message.str());
       }
       break;
 """

--- a/src/java/src/test/java/com/opengamma/longdog/testnodes/TestSVDMaterialise.java
+++ b/src/java/src/test/java/com/opengamma/longdog/testnodes/TestSVDMaterialise.java
@@ -83,7 +83,7 @@ public class TestSVDMaterialise {
   public void reconstructionTest(SVD input, OGRealDenseMatrix expectedU, OGRealDiagonalMatrix expectedS, OGRealDenseMatrix expectedV) {
 
     OGNumeric U = input.getU();
-    OGTerminal S = new OGRealDenseMatrix(Materialisers.toDoubleArrayOfArrays(input.getS()));
+    OGNumeric S = input.getS();
     OGNumeric VT = input.getVT();
 
    OGTerminal reconstructedMatrix =  Materialisers.toOGTerminal(new MTIMES(new MTIMES(U, S), VT));

--- a/src/java/src/test/java/com/opengamma/longdog/testnodes/TestSVDMaterialise.java
+++ b/src/java/src/test/java/com/opengamma/longdog/testnodes/TestSVDMaterialise.java
@@ -12,8 +12,10 @@ import org.testng.annotations.Test;
 import com.opengamma.longdog.datacontainers.OGNumeric;
 import com.opengamma.longdog.datacontainers.OGTerminal;
 import com.opengamma.longdog.datacontainers.lazy.OGExpr;
+import com.opengamma.longdog.datacontainers.matrix.OGComplexDenseMatrix;
 import com.opengamma.longdog.datacontainers.matrix.OGRealDenseMatrix;
 import com.opengamma.longdog.datacontainers.matrix.OGRealDiagonalMatrix;
+import com.opengamma.longdog.datacontainers.other.ComplexArrayContainer;
 import com.opengamma.longdog.exceptions.MathsException;
 import com.opengamma.longdog.exceptions.MathsExceptionIllegalArgument;
 import com.opengamma.longdog.helpers.FuzzyEquals;
@@ -26,26 +28,56 @@ import com.opengamma.longdog.nodes.SVD;
  */
 public class TestSVDMaterialise {
 
-  static OGRealDenseMatrix matrix = new OGRealDenseMatrix(new double[][] { { 1, 2 }, { 3, 4 }, { 5, 6 } });
+  static OGRealDenseMatrix real_matrix = new OGRealDenseMatrix(new double[][] { { 1, 2 }, { 3, 4 }, { 5, 6 } });
+  static OGComplexDenseMatrix complex_matrix = new OGComplexDenseMatrix(new double[][] { { 1, 2 }, { 3, 4 }, { 5, 6 } }, new double[][] { { 10, 20 }, { 30, 40 }, { 50, 60 } });
 
   @DataProvider
-  public Object[][] dataContainer() {
+  public Object[][] realdataContainer() {
     Object[][] obj = new Object[1][4];
 
-    obj[0][0] = new SVD(matrix);
+    obj[0][0] = new SVD(real_matrix);
     obj[0][1] = new OGRealDenseMatrix(new double[][] { { -0.2298476964000714, 0.8834610176985253, 0.4082482904638627 }, { -0.5247448187602936, 0.2407824921325463, -0.8164965809277263 },
       { -0.8196419411205156, -0.4018960334334317, 0.4082482904638631 } });
     obj[0][2] = new OGRealDiagonalMatrix(new double[] { 9.5255180915651074, 0.5143005806586441 }, 3, 2);
     obj[0][3] = new OGRealDenseMatrix(new double[][] { { -0.6196294838293402, -0.7848944532670524 }, { -0.7848944532670524, 0.6196294838293402 } });
-
+   
     return obj;
   };
+  
+  @DataProvider
+  public Object[][] complexdataContainer() {
+    Object[][] obj = new Object[1][4];
 
-  @Test(dataProvider = "dataContainer")
-  public void materialiseToJDoubleArray(SVD input, OGRealDenseMatrix expectedU, OGRealDiagonalMatrix expectedS, OGRealDenseMatrix expectedV) {
+    obj[0][0] = new SVD(complex_matrix);
+    double[][] rp, ip;
+    rp = new double[][] {{     -0.0228707006002169,     -0.0879076568710847,      0.3147401422050641},{     -0.0522140610036492,     -0.0239587534423321,     -0.6294802844101258},{     -0.0815574214070819,      0.0399901499864153,      0.3147401422050625}};
+    ip = new double[][] {{     -0.2287070060021659,     -0.8790765687107978,      0.2600102104752862},{     -0.5221406100364927,     -0.2395875344233279,     -0.5200204209505755},{     -0.8155742140708198,      0.3999014998641418,      0.2600102104752883}};
+    obj[0][1] = new OGComplexDenseMatrix(rp,ip);
+    obj[0][2] = new OGRealDiagonalMatrix(new double[] { 95.7302720469661779,      5.1686568674896343}, 3, 2);
+    double [] d = new double[] {-0.6196294838293402,0,0.7848944532670524,-0.e0,-0.7848944532670524,0,-0.6196294838293402,0};
+    obj[0][3] = new OGComplexDenseMatrix(d,2,2);
+   
+    return obj;
+  };
+  
+  @DataProvider
+  public Object[][] jointdataContainer() {
+    Object[][] obj = new Object[2][];
+    obj[0] = realdataContainer()[0];
+    obj[1] = complexdataContainer()[0];
+    return obj;
+    
+  }
+  
+
+  /**
+   * Check SVD will materialise to a double[][] correctly from a real space result.
+   */
+  @Test(dataProvider = "realdataContainer")
+  public void materialiseToJDoubleArray(SVD input, OGRealDenseMatrix expectedU, OGRealDiagonalMatrix expectedS, OGRealDenseMatrix expectedVT) {
     double[][] U = Materialisers.toDoubleArrayOfArrays(input.getU());
     double[][] S = Materialisers.toDoubleArrayOfArrays(input.getS());
-    double[][] V = Materialisers.toDoubleArrayOfArrays(input.getVT());
+    double[][] VT = Materialisers.toDoubleArrayOfArrays(input.getVT());
 
     if (!FuzzyEquals.ArrayFuzzyEquals(Materialisers.toDoubleArrayOfArrays(expectedU), U)) {
       throw new MathsException("U not equal. Got: " + U[0][0] + " Expected: " + expectedU.getData()[0]);
@@ -55,16 +87,49 @@ public class TestSVDMaterialise {
       throw new MathsException("S not equal. Got: " + S[0][0] + " Expected: " + expectedS.getData()[0]);
     }
 
-    if (!FuzzyEquals.ArrayFuzzyEquals(Materialisers.toDoubleArrayOfArrays(expectedV), V)) {
-      throw new MathsException("V not equal. Got: " + V[0][0] + " Expected: " + expectedV.getData()[0]);
+    if (!FuzzyEquals.ArrayFuzzyEquals(Materialisers.toDoubleArrayOfArrays(expectedVT), VT)) {
+      throw new MathsException("VT not equal. Got: " + VT[0][0] + " Expected: " + expectedVT.getData()[0]);
+    }
+  }
+  
+  /**
+   * Check SVD will materialise to a {@code ComplexArrayContainer} correctly from a complex space result.
+   */
+  @Test(dataProvider = "complexdataContainer")
+  public void materialiseToComplexArrayContainer(SVD input, OGComplexDenseMatrix expectedU, OGRealDiagonalMatrix expectedS, OGComplexDenseMatrix expectedVT) {
+    ComplexArrayContainer U = Materialisers.toComplexArrayContainer(input.getU());
+    double[][] S = Materialisers.toDoubleArrayOfArrays(input.getS());
+    ComplexArrayContainer VT = Materialisers.toComplexArrayContainer(input.getVT());
+
+    if (!FuzzyEquals.ArrayFuzzyEquals(Materialisers.toComplexArrayContainer(expectedU).getReal(), U.getReal())) {
+      throw new MathsException("U not equal. Got: " + U.toString() + " Expected: " + expectedU.toString());
+    }
+    
+    if (!FuzzyEquals.ArrayFuzzyEquals(Materialisers.toComplexArrayContainer(expectedU).getImag(), U.getImag())) {
+      throw new MathsException("U not equal. Got: " + U.toString() + " Expected: " + expectedU.toString());
+    }
+
+    if (!FuzzyEquals.ArrayFuzzyEquals(Materialisers.toDoubleArrayOfArrays(expectedS), S)) {
+      throw new MathsException("S not equal. Got: " + S[0][0] + " Expected: " + expectedS.getData()[0]);
+    }
+
+    if (!FuzzyEquals.ArrayFuzzyEquals(Materialisers.toComplexArrayContainer(expectedVT).getReal(), VT.getReal())) {
+      throw new MathsException("VT not equal. Got: " + VT.toString() + " Expected: " + expectedVT.toString());
+    }
+    
+    if (!FuzzyEquals.ArrayFuzzyEquals(Materialisers.toComplexArrayContainer(expectedVT).getImag(), VT.getImag())) {
+      throw new MathsException("VT not equal. Got: " + VT.toString() + " Expected: " + expectedVT.toString());
     }
   }
 
-  @Test(dataProvider = "dataContainer")
-  public void materialiseToOGTerminal(SVD input, OGRealDenseMatrix expectedU, OGRealDiagonalMatrix expectedS, OGRealDenseMatrix expectedV) {
+  /**
+   * Check SVD will materialise to a OGTerminal correctly.
+   */
+  @Test(dataProvider = "jointdataContainer")
+  public void materialiseToOGTerminal(SVD input, OGTerminal expectedU, OGRealDiagonalMatrix expectedS, OGTerminal expectedVT) {
     OGTerminal U = Materialisers.toOGTerminal(input.getU());
     OGTerminal S = Materialisers.toOGTerminal(input.getS());
-    OGTerminal V = Materialisers.toOGTerminal(input.getVT());
+    OGTerminal VT = Materialisers.toOGTerminal(input.getVT());
 
     if (!FuzzyEquals.ArrayFuzzyEquals(U.getData(), expectedU.getData())) {
       throw new MathsException("U not equal. Got: " + U.toString() + " Expected: " + expectedU.getData()[0]);
@@ -74,26 +139,32 @@ public class TestSVDMaterialise {
       throw new MathsException("S not equal. Got: " + S.toString() + " Expected: " + expectedS.getData()[0]);
     }
 
-    if (!FuzzyEquals.ArrayFuzzyEquals(V.getData(), expectedV.getData())) {
-      throw new MathsException("Arrays not equal. Got: " + V.toString() + " Expected: " + expectedV.getData()[0]);
+    if (!FuzzyEquals.ArrayFuzzyEquals(VT.getData(), expectedVT.getData())) {
+      throw new MathsException("VT not equal. Got: " + VT.toString() + " Expected: " + expectedVT.getData()[0]);
     }
   }
 
-  @Test(dataProvider = "dataContainer")
-  public void reconstructionTest(SVD input, OGRealDenseMatrix expectedU, OGRealDiagonalMatrix expectedS, OGRealDenseMatrix expectedV) {
+  /**
+   * Check SVD will reconstruct correctly. i.e. A = U*S*V**T;
+   */
+  @Test(dataProvider = "jointdataContainer")
+  public void reconstructionTest(SVD input, OGTerminal expectedU, OGRealDiagonalMatrix expectedS, OGTerminal expectedV) {
 
     OGNumeric U = input.getU();
     OGNumeric S = input.getS();
     OGNumeric VT = input.getVT();
 
    OGTerminal reconstructedMatrix =  Materialisers.toOGTerminal(new MTIMES(new MTIMES(U, S), VT));
-    if (!FuzzyEquals.ArrayFuzzyEquals(matrix.getData(), reconstructedMatrix.getData())) {
-      throw new MathsException("Arrays not equal. Got: " + matrix.toString() + "\n Expected: " + reconstructedMatrix.toString());
+    if (!FuzzyEquals.ArrayFuzzyEquals(Materialisers.toOGTerminal(input.getArg(0)).getData(), reconstructedMatrix.getData(), 1e-15, 4e-14)) { // numerical fuzz on recontruction
+      throw new MathsException("Arrays not equal. Got: " + reconstructedMatrix.toString() + "\n Expected: " + Materialisers.toOGTerminal(input.getArg(0)).toString());
     }
   }
 
-  @Test(dataProvider = "dataContainer", expectedExceptions = MathsExceptionIllegalArgument.class)
-  public void outsideArgBound(OGExpr input, OGRealDenseMatrix expectedU, OGRealDiagonalMatrix expectedS, OGRealDenseMatrix expectedV) {
+  /**
+   * Check SVD will throw on access to illegal arg position.
+   */
+  @Test(dataProvider = "jointdataContainer", expectedExceptions = MathsExceptionIllegalArgument.class)
+  public void outsideArgBound(OGExpr input, OGTerminal expectedU, OGRealDiagonalMatrix expectedS, OGTerminal expectedVT) {
     input.getArg(1);
   }
 

--- a/src/java/src/test/java/com/opengamma/longdog/testnodes/TestSVDMaterialise.java
+++ b/src/java/src/test/java/com/opengamma/longdog/testnodes/TestSVDMaterialise.java
@@ -9,80 +9,93 @@ package com.opengamma.longdog.testnodes;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import com.opengamma.longdog.datacontainers.OGNumeric;
+import com.opengamma.longdog.datacontainers.OGTerminal;
 import com.opengamma.longdog.datacontainers.lazy.OGExpr;
 import com.opengamma.longdog.datacontainers.matrix.OGRealDenseMatrix;
+import com.opengamma.longdog.datacontainers.matrix.OGRealDiagonalMatrix;
 import com.opengamma.longdog.datacontainers.scalar.OGRealScalar;
 import com.opengamma.longdog.exceptions.MathsException;
 import com.opengamma.longdog.exceptions.MathsExceptionIllegalArgument;
 import com.opengamma.longdog.helpers.FuzzyEquals;
 import com.opengamma.longdog.materialisers.Materialisers;
+import com.opengamma.longdog.nodes.MTIMES;
 import com.opengamma.longdog.nodes.SVD;
 
+/**
+ * A very basic numerical test of the SVD.
+ */
 public class TestSVDMaterialise {
+
+  static OGRealDenseMatrix matrix = new OGRealDenseMatrix(new double[][] { { 1, 2 }, { 3, 4 }, { 5, 6 } });
 
   @DataProvider
   public Object[][] dataContainer() {
     Object[][] obj = new Object[1][4];
 
-    obj[0][0] = new SVD(new OGRealDenseMatrix(new double[][] { { 1, 2 },  { 3, 4 },  { 5, 6 } }));
-    obj[0][1] = new OGRealScalar(1.0);
-    obj[0][2] = new OGRealScalar(2.0);
-    obj[0][3] = new OGRealScalar(3.0);
+    obj[0][0] = new SVD(matrix);
+    obj[0][1] = new OGRealDenseMatrix(new double[][] { { -0.2298476964000714, 0.8834610176985253, 0.4082482904638627 }, { -0.5247448187602936, 0.2407824921325463, -0.8164965809277263 },
+      { -0.8196419411205156, -0.4018960334334317, 0.4082482904638631 } });
+    obj[0][2] = new OGRealDiagonalMatrix(new double[] { 9.5255180915651074, 0.5143005806586441 }, 3, 2);
+    obj[0][3] = new OGRealDenseMatrix(new double[][] { { -0.6196294838293402, -0.7848944532670524 }, { -0.7848944532670524, 0.6196294838293402 } });
 
     return obj;
   };
 
   @Test(dataProvider = "dataContainer")
-  public void materialiseToJDoubleArray(SVD input, OGRealScalar expectedU, OGRealScalar expectedS, OGRealScalar expectedV) {
+  public void materialiseToJDoubleArray(SVD input, OGRealDenseMatrix expectedU, OGRealDiagonalMatrix expectedS, OGRealDenseMatrix expectedV) {
     double[][] U = Materialisers.toDoubleArrayOfArrays(input.getU());
     double[][] S = Materialisers.toDoubleArrayOfArrays(input.getS());
     double[][] V = Materialisers.toDoubleArrayOfArrays(input.getVT());
 
-    if (!FuzzyEquals.ArrayFuzzyEquals(expectedU.getData(), U[0])) {
+    if (!FuzzyEquals.ArrayFuzzyEquals(Materialisers.toDoubleArrayOfArrays(expectedU), U)) {
       throw new MathsException("U not equal. Got: " + U[0][0] + " Expected: " + expectedU.getData()[0]);
     }
 
-    if (!FuzzyEquals.ArrayFuzzyEquals(expectedS.getData(), S[0])) {
+    if (!FuzzyEquals.ArrayFuzzyEquals(Materialisers.toDoubleArrayOfArrays(expectedS), S)) {
       throw new MathsException("S not equal. Got: " + S[0][0] + " Expected: " + expectedS.getData()[0]);
     }
 
-    if (!FuzzyEquals.ArrayFuzzyEquals(expectedV.getData(), V[0])) {
+    if (!FuzzyEquals.ArrayFuzzyEquals(Materialisers.toDoubleArrayOfArrays(expectedV), V)) {
       throw new MathsException("V not equal. Got: " + V[0][0] + " Expected: " + expectedV.getData()[0]);
     }
   }
 
   @Test(dataProvider = "dataContainer")
-  public void materialiseToOGTerminal(SVD input, OGRealScalar expectedU, OGRealScalar expectedS, OGRealScalar expectedV) {
-    OGRealScalar U = (OGRealScalar) Materialisers.toOGTerminal(input.getU());
-    OGRealScalar S = (OGRealScalar) Materialisers.toOGTerminal(input.getS());
-    OGRealScalar V = (OGRealScalar) Materialisers.toOGTerminal(input.getVT());
+  public void materialiseToOGTerminal(SVD input, OGRealDenseMatrix expectedU, OGRealDiagonalMatrix expectedS, OGRealDenseMatrix expectedV) {
+    OGTerminal U = Materialisers.toOGTerminal(input.getU());
+    OGTerminal S = Materialisers.toOGTerminal(input.getS());
+    OGTerminal V = Materialisers.toOGTerminal(input.getVT());
 
-    if (U.getData().length != 1) {
-      throw new MathsException("Scalar holding more than one value");
-    }
-    if (!FuzzyEquals.SingleValueFuzzyEquals(U.getData()[0], expectedU.getData()[0])) {
+    if (!FuzzyEquals.ArrayFuzzyEquals(U.getData(), expectedU.getData())) {
       throw new MathsException("U not equal. Got: " + U.toString() + " Expected: " + expectedU.getData()[0]);
     }
 
-    if (S.getData().length != 1) {
-      throw new MathsException("Scalar holding more than one value");
-    }
-    if (!FuzzyEquals.SingleValueFuzzyEquals(S.getData()[0], expectedS.getData()[0])) {
+    if (!FuzzyEquals.ArrayFuzzyEquals(S.getData(), expectedS.getData())) {
       throw new MathsException("S not equal. Got: " + S.toString() + " Expected: " + expectedS.getData()[0]);
     }
 
-    if (V.getData().length != 1) {
-      throw new MathsException("Scalar holding more than one value");
-    }
-    if (!FuzzyEquals.SingleValueFuzzyEquals(V.getData()[0], expectedV.getData()[0])) {
+    if (!FuzzyEquals.ArrayFuzzyEquals(V.getData(), expectedV.getData())) {
       throw new MathsException("Arrays not equal. Got: " + V.toString() + " Expected: " + expectedV.getData()[0]);
     }
   }
 
+  @Test(dataProvider = "dataContainer")
+  public void reconstructionTest(SVD input, OGRealDenseMatrix expectedU, OGRealDiagonalMatrix expectedS, OGRealDenseMatrix expectedV) {
+
+    // TODO: FIXME: MAT-353 Need SELECTRESULT to be understood correctly by librdag. 
+    OGTerminal U = Materialisers.toOGTerminal(input.getU());
+    OGTerminal S = new OGRealDenseMatrix(Materialisers.toDoubleArrayOfArrays(input.getS()));
+    OGTerminal VT = Materialisers.toOGTerminal(input.getVT());
+
+   OGTerminal reconstructedMatrix =  Materialisers.toOGTerminal(new MTIMES(new MTIMES(U, S), VT));
+    if (!FuzzyEquals.ArrayFuzzyEquals(matrix.getData(), reconstructedMatrix.getData())) {
+      throw new MathsException("Arrays not equal. Got: " + matrix.toString() + "\n Expected: " + reconstructedMatrix.toString());
+    }
+  }
+
   @Test(dataProvider = "dataContainer", expectedExceptions = MathsExceptionIllegalArgument.class)
-  public void outsideArgBound(OGExpr input, OGRealScalar expectedU, OGRealScalar expectedS, OGRealScalar expectedV) {
-    OGNumeric n = input.getArg(1);
+  public void outsideArgBound(OGExpr input, OGRealDenseMatrix expectedU, OGRealDiagonalMatrix expectedS, OGRealDenseMatrix expectedV) {
+    input.getArg(1);
   }
 
 }

--- a/src/java/src/test/java/com/opengamma/longdog/testnodes/TestSVDMaterialise.java
+++ b/src/java/src/test/java/com/opengamma/longdog/testnodes/TestSVDMaterialise.java
@@ -9,11 +9,11 @@ package com.opengamma.longdog.testnodes;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import com.opengamma.longdog.datacontainers.OGNumeric;
 import com.opengamma.longdog.datacontainers.OGTerminal;
 import com.opengamma.longdog.datacontainers.lazy.OGExpr;
 import com.opengamma.longdog.datacontainers.matrix.OGRealDenseMatrix;
 import com.opengamma.longdog.datacontainers.matrix.OGRealDiagonalMatrix;
-import com.opengamma.longdog.datacontainers.scalar.OGRealScalar;
 import com.opengamma.longdog.exceptions.MathsException;
 import com.opengamma.longdog.exceptions.MathsExceptionIllegalArgument;
 import com.opengamma.longdog.helpers.FuzzyEquals;
@@ -82,10 +82,9 @@ public class TestSVDMaterialise {
   @Test(dataProvider = "dataContainer")
   public void reconstructionTest(SVD input, OGRealDenseMatrix expectedU, OGRealDiagonalMatrix expectedS, OGRealDenseMatrix expectedV) {
 
-    // TODO: FIXME: MAT-353 Need SELECTRESULT to be understood correctly by librdag. 
-    OGTerminal U = Materialisers.toOGTerminal(input.getU());
+    OGNumeric U = input.getU();
     OGTerminal S = new OGRealDenseMatrix(Materialisers.toDoubleArrayOfArrays(input.getS()));
-    OGTerminal VT = Materialisers.toOGTerminal(input.getVT());
+    OGNumeric VT = input.getVT();
 
    OGTerminal reconstructedMatrix =  Materialisers.toOGTerminal(new MTIMES(new MTIMES(U, S), VT));
     if (!FuzzyEquals.ArrayFuzzyEquals(matrix.getData(), reconstructedMatrix.getData())) {

--- a/src/librdag/lapack.cc
+++ b/src/librdag/lapack.cc
@@ -14,6 +14,8 @@ namespace lapack {
 namespace detail
 {
   char N = 'N';
+  char A = 'A';
+  char T = 'T';
   int ione = 1;
   real16 rone = 1.e0;
   complex16 cone = {1.e0, 0.e0};
@@ -23,6 +25,8 @@ namespace detail
 
 // f77 constants
 char *      N     = &detail::N;
+char *      A     = &detail::A;
+char *      T     = &detail::T;
 int *       ione  = &detail::ione;
 real16 *    rone  = &detail::rone;
 complex16 * cone  = &detail::cone;

--- a/src/librdag/runners/mtimesrunner.cc
+++ b/src/librdag/runners/mtimesrunner.cc
@@ -46,14 +46,14 @@ template<typename T> void * mtimes_dense_runner(RegContainer* reg0, const OGMatr
     tmp = new T[n];
     memcpy(tmp,data2,n*sizeof(T));
     lapack::xscal(&n,&deref,tmp,lapack::ione);
-    ret = ConcreteDenseMatrixFactory(tmp, rowsArray2, colsArray2, OWNER);
+    ret = makeConcreteDenseMatrix(tmp, rowsArray2, colsArray2, OWNER);
   } else if (colsArray2 == 1 && rowsArray2 == 1) { // We have matrix * scalar
     T deref = data2[0];
     int n = rowsArray1 * colsArray1;
     tmp = new T[n];
     memcpy(tmp,data1,n*sizeof(T));
     lapack::xscal(&n,&deref,tmp,lapack::ione);
-    ret = ConcreteDenseMatrixFactory(tmp, rowsArray1, colsArray1, OWNER);
+    ret = makeConcreteDenseMatrix(tmp, rowsArray1, colsArray1, OWNER);
   } else {
     if(colsArray1!=rowsArray2)
     {
@@ -64,7 +64,7 @@ template<typename T> void * mtimes_dense_runner(RegContainer* reg0, const OGMatr
     if (colsArray2 == 1) { // A*x
       tmp = new T[rowsArray1]();
       lapack::xgemv(lapack::N, &rowsArray1, &colsArray1, &fp_one, data1, &rowsArray1, data2, lapack::ione, &fp_one, tmp, lapack::ione);
-      ret = ConcreteDenseMatrixFactory(tmp, rowsArray1, 1, OWNER);
+      ret = makeConcreteDenseMatrix(tmp, rowsArray1, 1, OWNER);
     } else {
       int fm = rowsArray1;
       int fn = colsArray2;
@@ -75,7 +75,7 @@ template<typename T> void * mtimes_dense_runner(RegContainer* reg0, const OGMatr
       tmp = new T[fm * fn];
       int ldc = fm;
       lapack::xgemm(lapack::N, lapack::N, &fm, &fn, &fk, &fp_one, data1, &lda, data2, &ldb, &beta, tmp, &ldc);
-      ret = ConcreteDenseMatrixFactory(tmp, fm, fn, OWNER);
+      ret = makeConcreteDenseMatrix(tmp, fm, fn, OWNER);
     }
   }
   // shove ret into register

--- a/src/librdag/runners/mtimesrunner.cc
+++ b/src/librdag/runners/mtimesrunner.cc
@@ -24,24 +24,6 @@
 
 namespace librdag {
 
-template<typename T>
-OGTerminal * concreteDenseFactory(T * data, int rows, int cols, DATA_ACCESS access)
-{
-  throw rdag_error("Concrete type unknown");
-}
-
-template<>
-OGTerminal * concreteDenseFactory(real16 * data, int rows, int cols, DATA_ACCESS access)
-{
-  return new OGRealMatrix(data, rows, cols, access);
-}
-
-template<>
-OGTerminal * concreteDenseFactory(complex16 * data, int rows, int cols, DATA_ACCESS access)
-{
-  return new OGComplexMatrix(data, rows, cols, access);
-}
-
 template<typename T> void * mtimes_dense_runner(RegContainer* reg0, const OGMatrix<T>* arg0, const OGMatrix<T>* arg1)
 {
   int colsArray1 = arg0->getCols();
@@ -64,14 +46,14 @@ template<typename T> void * mtimes_dense_runner(RegContainer* reg0, const OGMatr
     tmp = new T[n];
     memcpy(tmp,data2,n*sizeof(T));
     lapack::xscal(&n,&deref,tmp,lapack::ione);
-    ret = concreteDenseFactory(tmp, rowsArray2, colsArray2, OWNER);
+    ret = ConcreteDenseMatrixFactory(tmp, rowsArray2, colsArray2, OWNER);
   } else if (colsArray2 == 1 && rowsArray2 == 1) { // We have matrix * scalar
     T deref = data2[0];
     int n = rowsArray1 * colsArray1;
     tmp = new T[n];
     memcpy(tmp,data1,n*sizeof(T));
     lapack::xscal(&n,&deref,tmp,lapack::ione);
-    ret = concreteDenseFactory(tmp, rowsArray1, colsArray1, OWNER);
+    ret = ConcreteDenseMatrixFactory(tmp, rowsArray1, colsArray1, OWNER);
   } else {
     if(colsArray1!=rowsArray2)
     {
@@ -82,7 +64,7 @@ template<typename T> void * mtimes_dense_runner(RegContainer* reg0, const OGMatr
     if (colsArray2 == 1) { // A*x
       tmp = new T[rowsArray1]();
       lapack::xgemv(lapack::N, &rowsArray1, &colsArray1, &fp_one, data1, &rowsArray1, data2, lapack::ione, &fp_one, tmp, lapack::ione);
-      ret = concreteDenseFactory(tmp, rowsArray1, 1, OWNER);
+      ret = ConcreteDenseMatrixFactory(tmp, rowsArray1, 1, OWNER);
     } else {
       int fm = rowsArray1;
       int fn = colsArray2;
@@ -93,7 +75,7 @@ template<typename T> void * mtimes_dense_runner(RegContainer* reg0, const OGMatr
       tmp = new T[fm * fn];
       int ldc = fm;
       lapack::xgemm(lapack::N, lapack::N, &fm, &fn, &fk, &fp_one, data1, &lda, data2, &ldb, &beta, tmp, &ldc);
-      ret = concreteDenseFactory(tmp, fm, fn, OWNER);
+      ret = ConcreteDenseMatrixFactory(tmp, fm, fn, OWNER);
     }
   }
   // shove ret into register

--- a/src/librdag/runners/norm2runner.cc
+++ b/src/librdag/runners/norm2runner.cc
@@ -33,9 +33,11 @@ NORM2Runner::run(RegContainer * reg, OGRealScalar const * arg) const
 
 template<typename T>
 void
-dense_runner(RegContainer * reg, OGMatrix<T> const * arg)
+norm2_dense_runner(RegContainer * reg, OGMatrix<T> const * arg)
 {
   const OGRealScalar* ret = nullptr; // the returned item
+
+  arg->debug_print();
 
   // Matrix in scalar context, i.e. a 1x1 matrix, norm2 is simply abs(value)
   if(arg->getRows()==1 && arg->getCols()==1)
@@ -81,14 +83,14 @@ dense_runner(RegContainer * reg, OGMatrix<T> const * arg)
 void *
 NORM2Runner::run(RegContainer * reg, OGRealMatrix const * arg) const
 {
-  dense_runner(reg, arg);
+  norm2_dense_runner(reg, arg);
   return nullptr;
 }
 
 void *
 NORM2Runner::run(RegContainer * reg, OGComplexMatrix const * arg) const
 {
-  dense_runner(reg, arg);
+  norm2_dense_runner(reg, arg);
   return nullptr;
 }
 

--- a/src/librdag/runners/norm2runner.cc
+++ b/src/librdag/runners/norm2runner.cc
@@ -37,8 +37,6 @@ norm2_dense_runner(RegContainer * reg, OGMatrix<T> const * arg)
 {
   const OGRealScalar* ret = nullptr; // the returned item
 
-  arg->debug_print();
-
   // Matrix in scalar context, i.e. a 1x1 matrix, norm2 is simply abs(value)
   if(arg->getRows()==1 && arg->getCols()==1)
   {

--- a/src/librdag/runners/svdrunner.cc
+++ b/src/librdag/runners/svdrunner.cc
@@ -41,9 +41,9 @@ template<typename T> void svd_dense_runner(RegContainer* reg, const OGMatrix<T>*
   // call lapack
   lapack::xgesvd(lapack::A, lapack::A, &m, &n, A, &lda, S, U, &ldu, VT, &ldvt, &info);
 
-  reg->push_back(new OGMatrix<T>(U, m, m, OWNER));
+  reg->push_back(ConcreteDenseMatrixFactory(U, m, m, OWNER));
   reg->push_back(new OGRealDiagonalMatrix(S, m, n, OWNER));
-  reg->push_back(new OGMatrix<T>(VT, n, n, OWNER));
+  reg->push_back(ConcreteDenseMatrixFactory(VT, n, n, OWNER));
   delete[] A;
 }
 

--- a/src/librdag/runners/svdrunner.cc
+++ b/src/librdag/runners/svdrunner.cc
@@ -41,9 +41,9 @@ template<typename T> void svd_dense_runner(RegContainer* reg, const OGMatrix<T>*
   // call lapack
   lapack::xgesvd(lapack::A, lapack::A, &m, &n, A, &lda, S, U, &ldu, VT, &ldvt, &info);
 
-  reg->push_back(ConcreteDenseMatrixFactory(U, m, m, OWNER));
+  reg->push_back(makeConcreteDenseMatrix(U, m, m, OWNER));
   reg->push_back(new OGRealDiagonalMatrix(S, m, n, OWNER));
-  reg->push_back(ConcreteDenseMatrixFactory(VT, n, n, OWNER));
+  reg->push_back(makeConcreteDenseMatrix(VT, n, n, OWNER));
   delete[] A;
 }
 

--- a/src/librdag/runners/svdrunner.cc
+++ b/src/librdag/runners/svdrunner.cc
@@ -20,7 +20,7 @@
  */
 namespace librdag {
 
-template<typename T> void dense_runner(RegContainer* reg, const OGMatrix<T>* arg)
+template<typename T> void svd_dense_runner(RegContainer* reg, const OGMatrix<T>* arg)
 {
   int m = arg->getRows();
   int n = arg->getCols();
@@ -59,14 +59,14 @@ SVDRunner::run(RegContainer *reg, OGRealScalar const *arg) const
 void *
 SVDRunner::run(RegContainer *reg, OGRealMatrix const *arg) const
 {
-  dense_runner(reg, arg);
+  svd_dense_runner(reg, arg);
   return nullptr;
 }
 
 void *
 SVDRunner::run(RegContainer *reg, OGComplexMatrix const *arg) const
 {
-  dense_runner(reg, arg);
+  svd_dense_runner(reg, arg);
   return nullptr;
 }
 

--- a/src/librdag/terminal.cc
+++ b/src/librdag/terminal.cc
@@ -1500,19 +1500,19 @@ OGComplexSparseMatrix::createComplexOwningCopy() const
 // Concrete template factory for dense matrices
 
 template<typename T>
-OGTerminal * ConcreteDenseMatrixFactory(T * data, int rows, int cols, DATA_ACCESS access)
+OGTerminal * makeConcreteDenseMatrix(T * data, int rows, int cols, DATA_ACCESS access)
 {
   throw rdag_error("Concrete type unknown");
 }
 
 template<>
-OGTerminal * ConcreteDenseMatrixFactory(real16 * data, int rows, int cols, DATA_ACCESS access)
+OGTerminal * makeConcreteDenseMatrix(real16 * data, int rows, int cols, DATA_ACCESS access)
 {
   return new OGRealMatrix(data, rows, cols, access);
 }
 
 template<>
-OGTerminal * ConcreteDenseMatrixFactory(complex16 * data, int rows, int cols, DATA_ACCESS access)
+OGTerminal * makeConcreteDenseMatrix(complex16 * data, int rows, int cols, DATA_ACCESS access)
 {
   return new OGComplexMatrix(data, rows, cols, access);
 }

--- a/src/librdag/terminal.cc
+++ b/src/librdag/terminal.cc
@@ -1497,4 +1497,26 @@ OGComplexSparseMatrix::createComplexOwningCopy() const
   return this->createOwningCopy();
 }
 
+
+// Concrete template factory for dense matrices
+
+template<typename T>
+OGTerminal * ConcreteDenseMatrixFactory(T * data, int rows, int cols, DATA_ACCESS access)
+{
+  throw rdag_error("Concrete type unknown");
+}
+
+template<>
+OGTerminal * ConcreteDenseMatrixFactory(real16 * data, int rows, int cols, DATA_ACCESS access)
+{
+  return new OGRealMatrix(data, rows, cols, access);
+}
+
+template<>
+OGTerminal * ConcreteDenseMatrixFactory(complex16 * data, int rows, int cols, DATA_ACCESS access)
+{
+  return new OGComplexMatrix(data, rows, cols, access);
+}
+
+
 } // namespace librdag

--- a/src/librdag/terminal.cc
+++ b/src/librdag/terminal.cc
@@ -810,6 +810,20 @@ OGMatrix<complex16>::toReal16ArrayOfArrays() const
   throw rdag_error("Error in in partial template specialisation for OGMatrix<complex16>::toReal16ArrayOfArrays(). Cannot convert a matrix backed by complex16 type to a real16 type.");
 }
 
+template<>
+ExprType_t
+OGMatrix<real16>::getType() const
+{
+  return REAL_MATRIX_ENUM;
+}
+
+template<>
+ExprType_t
+OGMatrix<complex16>::getType() const
+{
+  return COMPLEX_MATRIX_ENUM;
+}
+
 template class OGMatrix<real16>;
 template class OGMatrix<complex16>;
 

--- a/src/librdag/terminal.cc
+++ b/src/librdag/terminal.cc
@@ -734,16 +734,15 @@ template<typename T>
 void
 OGMatrix<T>::debug_print() const
 {
-  cout << std::endl;
-  int lim = (this->getCols()-1);
+  cout << std::endl << "OGMatrix<T>:" << std::endl;
   int rows = this->getRows();
   for(int i = 0 ; i < rows; i++)
   {
-    for(int j = 0 ; j < lim-1; j++)
+    for(int j = 0 ; j < this->getCols()-1; j++)
     {
-      cout << setprecision(__DEBUG_PRECISION) << this->getData()[j*rows+i] << ", ";
+      cout << setprecision(__DEBUG_PRECISION) << this->getData()[j*this->getRows()+i] << ", ";
     }
-    cout << this->getData()[lim*rows+i] << std::endl;
+    cout << setprecision(__DEBUG_PRECISION) << this->getData()[(this->getCols() - 1)*this->getRows()+i] << std::endl;
   }
 }
 

--- a/src/librdag/test/nodes/CMakeLists.txt
+++ b/src/librdag/test/nodes/CMakeLists.txt
@@ -22,9 +22,10 @@ add_multitarget_library(testhelper
                         TARGETS ${TARGET_TYPES})
 
 set(TESTS
+    check_mtimes
     check_norm2
     check_selectresult
-    check_mtimes
+    check_svd
    )
 
 # Compile and link each test and add to the list of tests

--- a/src/librdag/test/nodes/check_selectresult.cc
+++ b/src/librdag/test/nodes/check_selectresult.cc
@@ -23,11 +23,10 @@ using ::testing::Values;
  */
 
 
-TEST(SELECTRESULTTests,NORM2)
+TEST(SELECTRESULTTests,CheckBehaviour)
 {
-  OGTerminal* r0 = new OGRealScalar(1.0);
-  OGTerminal* r1 = new OGRealScalar(2.0);
-  OGTerminal* r2 = new OGRealScalar(3.0);
+  OGTerminal* one = new OGRealScalar(1.0);
+  OGTerminal* r0 = new OGRealScalar(10.0);
   ArgContainer *args = new ArgContainer();
   args->push_back(r0);
   SVD* svd = new SVD(args);
@@ -46,7 +45,7 @@ TEST(SELECTRESULTTests,NORM2)
   }
   const RegContainer * regs = s0->getRegs();
   const OGNumeric * answer = (*regs)[0];
-  EXPECT_TRUE((*r0) ==~ (*(answer->asOGTerminal())));
+  EXPECT_TRUE((*one) ==~ (*(answer->asOGTerminal())));
 
   // Check selecting 1 (S)
   ArgContainer* args1 = new ArgContainer();
@@ -60,7 +59,7 @@ TEST(SELECTRESULTTests,NORM2)
   }
   regs = s1->getRegs();
   answer = (*regs)[0];
-  EXPECT_TRUE((*r1) ==~ (*(answer->asOGTerminal())));
+  EXPECT_TRUE((*r0) ==~ (*(answer->asOGTerminal())));
 
   // Check selecting 2 (V)
   ArgContainer* args2 = new ArgContainer();
@@ -74,13 +73,12 @@ TEST(SELECTRESULTTests,NORM2)
   }
   regs = s2->getRegs();
   answer = (*regs)[0];
-  EXPECT_TRUE((*r2) ==~ (*(answer->asOGTerminal())));
+  EXPECT_TRUE((*one) ==~ (*(answer->asOGTerminal())));
 
   // Clean up
+  delete one;
   delete s0;
   delete d;
-  delete r1;
-  delete r2;
   delete el0;
   delete s1;
   delete el1;

--- a/src/librdag/test/nodes/check_svd.cc
+++ b/src/librdag/test/nodes/check_svd.cc
@@ -1,0 +1,185 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+
+#include "gtest/gtest.h"
+#include "terminal.hh"
+#include "execution.hh"
+#include "dispatch.hh"
+#include "testnodes.hh"
+#include "debug.h"
+
+using namespace std;
+using namespace librdag;
+using namespace testnodes;
+using ::testing::TestWithParam;
+using ::testing::Values;
+
+/*
+ * Check SVD node behaves correctly
+ */
+
+
+TEST(SVDTests,CheckScalar)
+{
+  OGTerminal* one = new OGRealScalar(1.0);
+  OGTerminal* r0 = new OGRealScalar(10.0);
+  ArgContainer *args = new ArgContainer();
+  args->push_back(r0);
+  SVD* svd = new SVD(args);
+
+  Dispatcher * d = new Dispatcher();
+
+  // Check selecting 0 (U)
+  ArgContainer* args0 = new ArgContainer();
+  args0->push_back(svd);
+  args0->push_back(new OGIntegerScalar(0));
+  SELECTRESULT* s0 = new SELECTRESULT(args0);
+  ExecutionList* el0 = new ExecutionList(s0);
+  for (auto it = el0->begin(); it != el0->end(); ++it)
+  {
+    d->dispatch(*it);
+  }
+  const RegContainer * regs = s0->getRegs();
+  const OGNumeric * answer = (*regs)[0];
+  EXPECT_TRUE((*one) ==~ (*(answer->asOGTerminal())));
+
+  // Check selecting 1 (S)
+  ArgContainer* args1 = new ArgContainer();
+  args1->push_back(svd->copy());
+  args1->push_back(new OGIntegerScalar(1));
+  SELECTRESULT* s1 = new SELECTRESULT(args1);
+  ExecutionList* el1 = new ExecutionList(s1);
+  for (auto it = el1->begin(); it != el1->end(); ++it)
+  {
+    d->dispatch(*it);
+  }
+  regs = s1->getRegs();
+  answer = (*regs)[0];
+  EXPECT_TRUE((*r0) ==~ (*(answer->asOGTerminal())));
+
+  // Check selecting 2 (V)
+  ArgContainer* args2 = new ArgContainer();
+  args2->push_back(svd->copy());
+  args2->push_back(new OGIntegerScalar(2));
+  SELECTRESULT* s2 = new SELECTRESULT(args2);
+  ExecutionList* el2 = new ExecutionList(s2);
+  for (auto it = el2->begin(); it != el2->end(); ++it)
+  {
+    d->dispatch(*it);
+  }
+  regs = s2->getRegs();
+  answer = (*regs)[0];
+  EXPECT_TRUE((*one) ==~ (*(answer->asOGTerminal())));
+
+  // Clean up
+  delete one;
+  delete s0;
+  delete d;
+  delete el0;
+  delete s1;
+  delete el1;
+  delete s2;
+  delete el2;
+}
+
+
+TEST(SVDTests,CheckRealMatrix)
+{
+
+  // answers
+  OGRealMatrix* U = new OGRealMatrix(new real16[9] {-0.2298476964000714,-0.5247448187602936,-0.8196419411205156,0.8834610176985253,0.2407824921325463,-0.4018960334334317,0.4082482904638627,-0.8164965809277263,0.4082482904638631},3,3,OWNER);
+  OGTerminal* S = new OGRealDiagonalMatrix(new real16[2] {9.525518091565107,  0.514300580658644},3,2,OWNER);
+  OGTerminal * VT = new OGRealMatrix(new real16[4]{-0.6196294838293402,-0.7848944532670524,-0.7848944532670524,0.6196294838293402}, 2,2, OWNER);
+
+  // input
+  OGTerminal* M = new OGRealMatrix(new real16[6]{1,3,5,2,4,6},3,2,OWNER);
+  ArgContainer *args = new ArgContainer();
+  args->push_back(M);
+  SVD* svd = new SVD(args);
+
+  // computed answer pointers
+  const OGNumeric * answerU, * answerS, * answerVT, * reconstruct;
+  // computed answer reg containers
+  const RegContainer * regs0, * regs1, * regs2, * regs3;
+
+  Dispatcher * d = new Dispatcher();
+
+  // Check selecting 0 (U)
+  ArgContainer* args0 = new ArgContainer();
+  args0->push_back(svd);
+  args0->push_back(new OGIntegerScalar(0));
+  SELECTRESULT* s0 = new SELECTRESULT(args0);
+  ExecutionList* el0 = new ExecutionList(s0);
+  for (auto it = el0->begin(); it != el0->end(); ++it)
+  {
+    d->dispatch(*it);
+  }
+  regs0 = s0->getRegs();
+  answerU = (*regs0)[0];
+  EXPECT_TRUE((*U) ==~ (*(answerU->asOGTerminal())));
+
+  // Check selecting 1 (S)
+  ArgContainer* args1 = new ArgContainer();
+  args1->push_back(svd->copy());
+  args1->push_back(new OGIntegerScalar(1));
+  SELECTRESULT* s1 = new SELECTRESULT(args1);
+  ExecutionList* el1 = new ExecutionList(s1);
+  for (auto it = el1->begin(); it != el1->end(); ++it)
+  {
+    d->dispatch(*it);
+  }
+  regs1 = s1->getRegs();
+  answerS = (*regs1)[0];
+  EXPECT_TRUE((*S) ==~ (*(answerS->asOGTerminal())));
+
+  // Check selecting 2 (V)
+  ArgContainer* args2 = new ArgContainer();
+  args2->push_back(svd->copy());
+  args2->push_back(new OGIntegerScalar(2));
+  SELECTRESULT* s2 = new SELECTRESULT(args2);
+  ExecutionList* el2 = new ExecutionList(s2);
+  for (auto it = el2->begin(); it != el2->end(); ++it)
+  {
+    d->dispatch(*it);
+  }
+  regs2 = s2->getRegs();
+  answerVT = (*regs2)[0];
+  EXPECT_TRUE((*VT) ==~ (*(answerVT->asOGTerminal())));
+
+  // reconstruction test i.e. recover A from U,S,V**T as A=U*S*V**T
+  ArgContainer* args3 = new ArgContainer();
+  args3->push_back(answerU->asOGTerminal()->createOwningCopy());
+  args3->push_back(answerS->asOGTerminal()->createOwningCopy());
+
+  MTIMES * m1 = new MTIMES(args3);
+  ArgContainer* args4 = new ArgContainer();
+  args4->push_back(m1);
+  args4->push_back(answerVT->asOGTerminal()->createOwningCopy());
+  MTIMES * m2 = new MTIMES(args4);
+  ExecutionList* el3 = new ExecutionList(m2);
+  for (auto it = el3->begin(); it != el3->end(); ++it)
+  {
+    d->dispatch(*it);
+  }
+  regs3 = m2->getRegs();
+  reconstruct = (*regs3)[0];
+  EXPECT_TRUE((*M) ==~ (*(reconstruct->asOGTerminal())));
+
+  // Clean up
+  delete s0;
+  delete d;
+  delete el0;
+  delete s1;
+  delete el1;
+  delete s2;
+  delete el2;
+  delete m2;
+  delete el3;
+  delete S;
+  delete U;
+  delete VT;
+}

--- a/src/librdag/test/nodes/check_svd.cc
+++ b/src/librdag/test/nodes/check_svd.cc
@@ -10,7 +10,7 @@
 #include "execution.hh"
 #include "dispatch.hh"
 #include "testnodes.hh"
-#include "debug.h"
+#include "equals.hh"
 
 using namespace std;
 using namespace librdag;
@@ -120,7 +120,7 @@ TEST(SVDTests,CheckRealMatrix)
   }
   regs0 = s0->getRegs();
   answerU = (*regs0)[0];
-  EXPECT_TRUE((*U) ==~ (*(answerU->asOGTerminal())));
+  EXPECT_TRUE((*U) % (*(answerU->asOGTerminal())));
 
   // Check selecting 1 (S)
   ArgContainer* args1 = new ArgContainer();
@@ -148,7 +148,7 @@ TEST(SVDTests,CheckRealMatrix)
   }
   regs2 = s2->getRegs();
   answerVT = (*regs2)[0];
-  EXPECT_TRUE((*VT) ==~ (*(answerVT->asOGTerminal())));
+  EXPECT_TRUE((*VT) % (*(answerVT->asOGTerminal())));
 
   // reconstruction test i.e. recover A from U,S,V**T as A=U*S*V**T
   ArgContainer* args3 = new ArgContainer();
@@ -168,6 +168,107 @@ TEST(SVDTests,CheckRealMatrix)
   regs3 = m2->getRegs();
   reconstruct = (*regs3)[0];
   EXPECT_TRUE((*M) ==~ (*(reconstruct->asOGTerminal())));
+
+  // Clean up
+  delete s0;
+  delete d;
+  delete el0;
+  delete s1;
+  delete el1;
+  delete s2;
+  delete el2;
+  delete m2;
+  delete el3;
+  delete S;
+  delete U;
+  delete VT;
+}
+
+
+
+
+TEST(SVDTests,CheckComplexMatrix)
+{
+
+  // answers
+  OGComplexMatrix* U = new OGComplexMatrix(new complex16[9] {{     -0.0228707006002169,      -0.2287070060021659}, {     -0.0522140610036492,      -0.5221406100364927}, {     -0.0815574214070819,      -0.8155742140708198}, {     -0.0879076568710847,      -0.8790765687107978}, {     -0.0239587534423321,      -0.2395875344233279}, {      0.0399901499864153,       0.3999014998641418}, {      0.3147401422050641,       0.2600102104752862}, {     -0.6294802844101258,      -0.5200204209505755}, {      0.3147401422050625,       0.2600102104752883}},3,3,OWNER);
+  OGTerminal* S = new OGRealDiagonalMatrix(new real16[2] {95.7302720469661779,5.1686568674896343},3,2,OWNER);
+  OGTerminal * VT = new OGComplexMatrix(new complex16[4]{{-0.6196294838293402,0},{0.7848944532670524,-0.e0},{-0.7848944532670524,0},{-0.6196294838293402,0}}, 2,2, OWNER);
+
+  // input
+  OGTerminal* M = new OGComplexMatrix(new complex16[6]{{1,10}, {3,30}, {5,50}, {2,20}, {4,40}, {6,60}},3,2,OWNER);
+  ArgContainer *args = new ArgContainer();
+  args->push_back(M);
+  SVD* svd = new SVD(args);
+
+  // computed answer pointers
+  const OGNumeric * answerU, * answerS, * answerVT, * reconstruct;
+  // computed answer reg containers
+  const RegContainer * regs0, * regs1, * regs2, * regs3;
+
+  Dispatcher * d = new Dispatcher();
+
+  // Check selecting 0 (U)
+  ArgContainer* args0 = new ArgContainer();
+  args0->push_back(svd);
+  args0->push_back(new OGIntegerScalar(0));
+  SELECTRESULT* s0 = new SELECTRESULT(args0);
+  ExecutionList* el0 = new ExecutionList(s0);
+  for (auto it = el0->begin(); it != el0->end(); ++it)
+  {
+    d->dispatch(*it);
+  }
+  regs0 = s0->getRegs();
+  answerU = (*regs0)[0];
+  EXPECT_TRUE((*U) % (*(answerU->asOGTerminal())));
+
+  // Check selecting 1 (S)
+  ArgContainer* args1 = new ArgContainer();
+  args1->push_back(svd->copy());
+  args1->push_back(new OGIntegerScalar(1));
+  SELECTRESULT* s1 = new SELECTRESULT(args1);
+  ExecutionList* el1 = new ExecutionList(s1);
+  for (auto it = el1->begin(); it != el1->end(); ++it)
+  {
+    d->dispatch(*it);
+  }
+  regs1 = s1->getRegs();
+  answerS = (*regs1)[0];
+  EXPECT_TRUE((*S) ==~ (*(answerS->asOGTerminal())));
+
+  // Check selecting 2 (V)
+  ArgContainer* args2 = new ArgContainer();
+  args2->push_back(svd->copy());
+  args2->push_back(new OGIntegerScalar(2));
+  SELECTRESULT* s2 = new SELECTRESULT(args2);
+  ExecutionList* el2 = new ExecutionList(s2);
+  for (auto it = el2->begin(); it != el2->end(); ++it)
+  {
+    d->dispatch(*it);
+  }
+  regs2 = s2->getRegs();
+  answerVT = (*regs2)[0];
+  EXPECT_TRUE((*VT) % (*(answerVT->asOGTerminal())));
+
+  // reconstruction test i.e. recover A from U,S,V**T as A=U*S*V**T
+  ArgContainer* args3 = new ArgContainer();
+  args3->push_back(answerU->asOGTerminal()->createOwningCopy());
+  args3->push_back(answerS->asOGTerminal()->createOwningCopy());
+
+  MTIMES * m1 = new MTIMES(args3);
+  ArgContainer* args4 = new ArgContainer();
+  args4->push_back(m1);
+  args4->push_back(answerVT->asOGTerminal()->createOwningCopy());
+  MTIMES * m2 = new MTIMES(args4);
+  ExecutionList* el3 = new ExecutionList(m2);
+  for (auto it = el3->begin(); it != el3->end(); ++it)
+  {
+    d->dispatch(*it);
+  }
+  regs3 = m2->getRegs();
+  reconstruct = (*regs3)[0];
+  // FP fuzz causes grief on reconstruction
+  EXPECT_TRUE(ArrayFuzzyEquals(M->asOGComplexMatrix()->getData(),reconstruct->asOGComplexMatrix()->getData(),1e-15,1e-15));
 
   // Clean up
   delete s0;


### PR DESCRIPTION
This PR is to add in the actual implementation of the SVD node to replace the dummy behaviour that was put in place as a test.
- Performs wiring to `xgesvd()`.
- Adds unit tests including
  - Reconstruction tests
  - Behaviour tests

BB Multi-Pass: [http://devmaths-lx-1:8011/builders/nyqwk2-testing/builds/797](http://devmaths-lx-1:8011/builders/nyqwk2-testing/builds/797)

Coverage:
Java: 85% (up a bit)
build/src/jshim 0.8% (no change)
build/src/librdag 13.5% (down a bit)
src/jshim       62.5% (no change)
src/librdag     91.2% (down a bit)
src/librdag/runners 100.0% (up a lot)
src/librdag/test/nodes 96.4% (down a bit)
