### PR TITLE
Exception fixes.

### DIFF
--- a/src/jshim/jshim.cc
+++ b/src/jshim/jshim.cc
@@ -252,11 +252,9 @@ JNIEXPORT jobjectArray JNICALL Java_com_opengamma_maths_materialisers_Materialis
     const librdag::OGTerminal* answer = entrypt(chain);
     DEBUG_PRINT("Returning from entrypt function\n");
 
-    DispatchToReal16ArrayOfArrays *visitor = new DispatchToReal16ArrayOfArrays();
-    answer->accept(*visitor);
-
-    returnVal = convertCreal16ArrOfArr2JDoubleArrOfArr(env, visitor->getData(), visitor->getRows(), visitor->getCols());
-    delete visitor;
+    DispatchToReal16ArrayOfArrays visitor{};
+    answer->accept(visitor);
+    returnVal = convertCreal16ArrOfArr2JDoubleArrOfArr(env, visitor.getData(), visitor.getRows(), visitor.getCols());
   }
   catch (convert_error e)
   {
@@ -306,13 +304,11 @@ JNIEXPORT jobject JNICALL Java_com_opengamma_maths_materialisers_Materialisers_m
     const librdag::OGTerminal* answer = entrypt(chain);
 
 
-    DispatchToComplex16ArrayOfArrays *visitor = new DispatchToComplex16ArrayOfArrays();
-    answer->accept(*visitor);
+    DispatchToComplex16ArrayOfArrays visitor{};
+    answer->accept(visitor);
 
-    jobjectArray realPart = extractRealPartOfCcomplex16ArrOfArr2JDoubleArrOfArr(env, visitor->getData(), visitor->getRows(), visitor->getCols());
-    jobjectArray complexPart = extractImagPartOfCcomplex16ArrOfArr2JDoubleArrOfArr(env, visitor->getData(), visitor->getRows(), visitor->getCols());
-
-    delete visitor;
+    jobjectArray realPart = extractRealPartOfCcomplex16ArrOfArr2JDoubleArrOfArr(env, visitor.getData(), visitor.getRows(), visitor.getCols());
+    jobjectArray complexPart = extractImagPartOfCcomplex16ArrOfArr2JDoubleArrOfArr(env, visitor.getData(), visitor.getRows(), visitor.getCols());
 
     returnVal = env->NewObject(JVMManager::getComplexArrayContainerClazz(),
                                JVMManager::getComplexArrayContainerClazz_ctor_DAoA_DAoA(),
@@ -370,10 +366,9 @@ Java_com_opengamma_maths_materialisers_Materialisers_materialiseToOGTerminal(JNI
     DEBUG_PRINT("Calling entrypt function\n");
     const librdag::OGTerminal* answer = entrypt(chain);
 
-    DispatchToOGTerminal *visitor = new DispatchToOGTerminal(env);
-    answer->accept(*visitor);
-    result = visitor->getObject();
-    delete visitor;
+    DispatchToOGTerminal visitor{env};
+    answer->accept(visitor);
+    result = visitor.getObject();
   }
   catch (convert_error e)
   {

--- a/src/jshim/jterminals.cc
+++ b/src/jshim/jterminals.cc
@@ -58,7 +58,13 @@ JOGRealScalar::JOGRealScalar(jobject obj): OGRealScalar(0.0)
 
 JOGRealScalar::~JOGRealScalar()
 {
-  unbindOGArrayData<real16, jdoubleArray>(this->_dataRef, _backingObject);
+  try {
+    unbindOGArrayData<real16, jdoubleArray>(this->_dataRef, _backingObject);
+  }
+  catch (convert_error e)
+  {
+    cerr << "Warning (~JOGRealScalar): convert_error thrown when unbinding Java array data" << endl;
+  }
   this->_backingObject = nullptr;
   this->_dataRef = nullptr;
 }
@@ -88,7 +94,14 @@ JOGComplexScalar::JOGComplexScalar(jobject obj): OGComplexScalar(0.0)
 
 JOGComplexScalar::~JOGComplexScalar()
 {
-  unbindOGArrayData<complex16, jdoubleArray>(this->_dataRef, _backingObject);
+  try {
+    unbindOGArrayData<complex16, jdoubleArray>(this->_dataRef, _backingObject);
+  }
+  catch (convert_error e)
+  {
+    cerr << "Warning (~JOGComplexScalar): convert_error thrown when unbinding Java array data" << endl;
+  }
+
   this->_backingObject = nullptr;
   this->_dataRef = nullptr;
 }
@@ -154,7 +167,14 @@ JOGRealMatrix::JOGRealMatrix(jobject obj): OGRealMatrix
 
 JOGRealMatrix::~JOGRealMatrix()
 {
-  unbindOGArrayData<real16, jdoubleArray>(this->getData(), _backingObject);
+  try {
+    unbindOGArrayData<real16, jdoubleArray>(this->getData(), _backingObject);
+  }
+  catch (convert_error e)
+  {
+    cerr << "Warning (~JOGRealMatrix): convert_error thrown when unbinding Java array data" << endl;
+  }
+
   this->_backingObject = nullptr;
 }
 
@@ -179,7 +199,14 @@ JOGComplexMatrix::JOGComplexMatrix(jobject obj): OGComplexMatrix
 }
 
 JOGComplexMatrix::~JOGComplexMatrix() {
-  unbindOGArrayData<complex16, jdoubleArray>(this->getData(), _backingObject);
+  try {
+    unbindOGArrayData<complex16, jdoubleArray>(this->getData(), _backingObject);
+  }
+  catch (convert_error e)
+  {
+    cerr << "Warning (~JOGComplexMatrix): convert_error thrown when unbinding Java array data" << endl;
+  }
+
   this->_backingObject = nullptr;
 }
 
@@ -205,7 +232,14 @@ JOGLogicalMatrix::JOGLogicalMatrix(jobject obj): OGLogicalMatrix
 
 JOGLogicalMatrix::~JOGLogicalMatrix()
 {
-  unbindOGArrayData<real16, jdoubleArray>(this->getData(), _backingObject);
+  try {
+    unbindOGArrayData<real16, jdoubleArray>(this->getData(), _backingObject);
+  }
+  catch (convert_error e)
+  {
+    cerr << "Warning (~JOGLogicalMatrix): convert_error thrown when unbinding Java array data" << endl;
+  }
+
   this->_backingObject = nullptr;
 }
 
@@ -233,9 +267,16 @@ JOGRealSparseMatrix::JOGRealSparseMatrix(jobject obj): OGRealSparseMatrix
 
 JOGRealSparseMatrix::~JOGRealSparseMatrix()
 {
-  unbindPrimitiveArrayData<real16, jdoubleArray>(this->getData(), _backingObject, JVMManager::getOGTerminalClazz_getData());
-  unbindPrimitiveArrayData<jint, jintArray>(reinterpret_cast<jint*>(this->getRowIdx()), _backingObject, JVMManager::getOGSparseMatrixClazz_getRowIdx());
-  unbindPrimitiveArrayData<jint, jintArray>(reinterpret_cast<jint*>(this->getColPtr()), _backingObject, JVMManager::getOGSparseMatrixClazz_getColPtr());
+  try {
+    unbindPrimitiveArrayData<real16, jdoubleArray>(this->getData(), _backingObject, JVMManager::getOGTerminalClazz_getData());
+    unbindPrimitiveArrayData<jint, jintArray>(reinterpret_cast<jint*>(this->getRowIdx()), _backingObject, JVMManager::getOGSparseMatrixClazz_getRowIdx());
+    unbindPrimitiveArrayData<jint, jintArray>(reinterpret_cast<jint*>(this->getColPtr()), _backingObject, JVMManager::getOGSparseMatrixClazz_getColPtr());
+  }
+  catch (convert_error e)
+  {
+    cerr << "Warning (~JOGRealSparseMatrix): convert_error thrown when unbinding Java array data" << endl;
+  }
+
   this->_backingObject = nullptr;
 }
 
@@ -274,9 +315,16 @@ JOGComplexSparseMatrix::JOGComplexSparseMatrix(jobject obj): OGComplexSparseMatr
 
 JOGComplexSparseMatrix::~JOGComplexSparseMatrix()
 {
-  unbindPrimitiveArrayData<complex16, jdoubleArray>(this->getData(), _backingObject, JVMManager::getOGTerminalClazz_getData());
-  unbindPrimitiveArrayData<jint, jintArray>(reinterpret_cast<jint*>(this->getRowIdx()), _backingObject, JVMManager::getOGSparseMatrixClazz_getRowIdx());
-  unbindPrimitiveArrayData<jint, jintArray>(reinterpret_cast<jint*>(this->getColPtr()), _backingObject, JVMManager::getOGSparseMatrixClazz_getColPtr());
+  try {
+    unbindPrimitiveArrayData<complex16, jdoubleArray>(this->getData(), _backingObject, JVMManager::getOGTerminalClazz_getData());
+    unbindPrimitiveArrayData<jint, jintArray>(reinterpret_cast<jint*>(this->getRowIdx()), _backingObject, JVMManager::getOGSparseMatrixClazz_getRowIdx());
+    unbindPrimitiveArrayData<jint, jintArray>(reinterpret_cast<jint*>(this->getColPtr()), _backingObject, JVMManager::getOGSparseMatrixClazz_getColPtr());
+  }
+  catch (convert_error e)
+  {
+    cerr << "Warning (~JOGComplexSparseMatrix): convert_error thrown when unbinding Java array data" << endl;
+  }
+
   this->_backingObject = nullptr;
 }
 
@@ -314,7 +362,14 @@ JOGRealDiagonalMatrix::JOGRealDiagonalMatrix(jobject obj):OGRealDiagonalMatrix
 
 JOGRealDiagonalMatrix::~JOGRealDiagonalMatrix()
 {
-  unbindOGArrayData<real16, jdoubleArray>(this->getData(), _backingObject);
+  try {
+    unbindOGArrayData<real16, jdoubleArray>(this->getData(), _backingObject);
+  }
+  catch (convert_error e)
+  {
+    cerr << "Warning (~JOGRealDiagonalMatrix): convert_error thrown when unbinding Java array data" << endl;
+  }
+
   this->_backingObject = nullptr;
 }
 
@@ -340,7 +395,14 @@ JOGComplexDiagonalMatrix::JOGComplexDiagonalMatrix(jobject obj):OGComplexDiagona
 
 JOGComplexDiagonalMatrix::~JOGComplexDiagonalMatrix()
 {
-  unbindOGArrayData<complex16, jdoubleArray>(this->getData(), _backingObject);
+  try {
+    unbindOGArrayData<complex16, jdoubleArray>(this->getData(), _backingObject);
+  }
+  catch (convert_error e)
+  {
+    cerr << "Warning (~JOGRealDiagonalMatrix): convert_error thrown when unbinding Java array data" << endl;
+  }
+
   this->_backingObject = nullptr;
 }
 

--- a/src/jshim/jterminals.cc
+++ b/src/jshim/jterminals.cc
@@ -35,6 +35,7 @@ DLLEXPORT_C jint getIntFromVoidJMethod(jmethodID id, jobject obj)
   }
   jint data = 0x7ff00000;
   data = env->CallIntMethod(obj, id);
+  checkEx(env);
   return data;
 }
 


### PR DESCRIPTION
This PR is mainly about MAT-359, which fixes the issue where exceptions could be thrown in destructors (which results in undefined behaviour). However, it also contains a MAT-336 change.

MAT-359: Exceptions are prevented from leaving destructors by catching them. The code called in the destructors only throws `convert_error` instances. When an exception is caught, we print a message to standard error, because there is little else we can do. It would be more ideal if we could log this as a message to get picked up elsewhere, but we have no facility for doing this at the moment.

MAT-336: In jshim, visitors are stack-allocated instead of heap-allocated, so we do not need to worry about freeing them ourselves anymore.

I also spotted that we were missing an exception check after a CallIntMethod call.

Buildbot pass: http://devmaths-lx-1:8011/builders/nyqwk2-testing/builds/802
Coverage:
Java: 85% (unchanged)
build/src/jshim: 0.8% (unchanged)
build/src/librdag: 13.5% (unchanged)
src/jshim: 61.4% (down slightly since there's more code in the untested jshim parts)
src/librdag: 91.2% (unchanged)
src/librdag/runners: 100% (unchanged)
