### PR TITLE
[MAT-246] ArgContainers constructed by expressions

### DIFF
--- a/include/expressionbase.hh
+++ b/include/expressionbase.hh
@@ -41,9 +41,9 @@ class OGExpr: public OGNumeric
     virtual void accept(Visitor &v) const override;
     virtual const RegContainer * getRegs() const;
   protected:
-    OGExpr(ArgContainer* args);
-  private:
+    OGExpr();
     ArgContainer * _args;
+  private:
     RegContainer * _regs;
 };
 
@@ -54,13 +54,13 @@ class OGExpr: public OGNumeric
 class OGUnaryExpr: public OGExpr
 {
   protected:
-    OGUnaryExpr(ArgContainer* args);
+    OGUnaryExpr(const OGNumeric* arg);
 };
 
 class OGBinaryExpr : public OGExpr
 {
   protected:
-    OGBinaryExpr(ArgContainer* args);
+    OGBinaryExpr(const OGNumeric* arg0, const OGNumeric* arg1);
 };
 
 /**
@@ -70,17 +70,17 @@ class OGBinaryExpr : public OGExpr
 class COPY: public OGUnaryExpr
 {
   public:
-    COPY(ArgContainer *args);
+    COPY(const OGNumeric* arg);
     virtual OGNumeric* copy() const override;
     virtual const COPY* asCOPY() const override;
     virtual void debug_print() const override;
     virtual ExprType_t getType() const override;
 };
 
-class SELECTRESULT: public OGBinaryExpr
+class SELECTRESULT: public OGExpr
 {
   public:
-    SELECTRESULT(ArgContainer *args);
+    SELECTRESULT(const OGNumeric* arg0, const OGNumeric* arg1);
     virtual OGNumeric* copy() const override;
     virtual const SELECTRESULT* asSELECTRESULT() const override;
     virtual void debug_print() const override;
@@ -90,7 +90,7 @@ class SELECTRESULT: public OGBinaryExpr
 class NORM2: public OGUnaryExpr
 {
   public:
-    NORM2(ArgContainer *args);
+    NORM2(const OGNumeric* arg);
     virtual OGNumeric* copy() const override;
     virtual const NORM2* asNORM2() const override;
     virtual void debug_print() const override;
@@ -101,7 +101,7 @@ class NORM2: public OGUnaryExpr
 class SVD: public OGUnaryExpr
 {
   public:
-    SVD(ArgContainer* args);
+    SVD(const OGNumeric* arg);
     virtual OGNumeric* copy() const override;
     virtual const SVD* asSVD() const override;
     virtual void debug_print() const override;
@@ -111,10 +111,10 @@ class SVD: public OGUnaryExpr
 class MTIMES: public OGBinaryExpr
 {
   public:
-    MTIMES(ArgContainer *args);
+    MTIMES(const OGNumeric* arg0, const OGNumeric* arg1);
     virtual OGNumeric* copy() const override;
     virtual const MTIMES* asMTIMES() const override;
-   virtual void debug_print() const override;
+    virtual void debug_print() const override;
     virtual ExprType_t getType() const override;
 };
 

--- a/include/exprfactory.hh
+++ b/include/exprfactory.hh
@@ -4,16 +4,16 @@
  * Please see distribution for license.
  */
 
+#include <vector>
 #include "expressionbase.hh"
 #include "containers.hh"
 #include "jvmmanager.hh"
 
 using librdag::OGNumeric;
-using librdag::ArgContainer;
 
 namespace convert {
 
-ArgContainer* generateArgs(jobject obj);
+vector<const OGNumeric*>* generateArgs(jobject obj);
 OGNumeric* createExpression(jobject obj);
 OGNumeric* createExprWithID(jlong ID, jobject obj);
 

--- a/src/generator/createexpressions.py
+++ b/src/generator/createexpressions.py
@@ -4,7 +4,8 @@
 # Please see distribution for license.
 #
 
-from createexprtemplates import createexpr_cc, terminal_case, expr_case
+from createexprtemplates import createexpr_cc, terminal_case, expr_case, \
+                                unary_args, binary_args
 
 class CreateExpressions(object):
     def __init__(self, nodes):
@@ -22,6 +23,10 @@ class CreateExpressions(object):
             if node.is_terminal:
                 cases += terminal_case % d
             else:
+                if node.argcount == 1:
+                    d['args'] = unary_args
+                else: # 2 or -1 (selectresult) - either way its binary
+                    d['args'] = binary_args
                 cases += expr_case % d
         d = { 'switch_cases': cases }
         return createexpr_cc % d

--- a/src/generator/createexprtemplates.py
+++ b/src/generator/createexprtemplates.py
@@ -28,6 +28,7 @@ using namespace librdag;
 OGNumeric* createExprWithID(jlong ID, jobject obj)
 {
   librdag::OGNumeric * _expr = nullptr;
+  vector<const OGNumeric*>* args;
 
   switch(ID)
   {
@@ -62,6 +63,11 @@ terminal_case = """\
 expr_case = """\
     case %(enumname)s:
       DEBUG_PRINT("%(typename)s function\\n");
-      _expr = new %(typename)s(generateArgs(obj));
+      args = generateArgs(obj);
+      _expr = new %(typename)s(%(args)s);
       break;
 """
+
+unary_args = "(*args)[0]"
+
+binary_args = "(*args)[0], (*args)[1]"

--- a/src/generator/expression.py
+++ b/src/generator/expression.py
@@ -6,7 +6,9 @@
 
 from exprtemplates import expression_hh, expr_class, expression_cc, expr_methods, \
                           numeric_hh, numeric_fwd_decl, numeric_cast_method, \
-                          numeric_cc, numeric_method
+                          numeric_cc, numeric_method, unary_constructor, \
+                          binary_constructor, unary_copy_method, binary_copy_method, \
+                          unary_ctor_method, binary_ctor_method
 
 class Expressions(object):
     def __init__(self, nodes):
@@ -21,6 +23,11 @@ class Expressions(object):
         classes = ''
         for node in self.nodes:
             d = { 'classname': node.typename, 'parentclass': node.parentclass }
+            if node.argcount == 1:
+                constructor = unary_constructor % d
+            else: # 2 or -1 (selectresult) - is binary in either case
+                constructor = binary_constructor % d
+            d['constructor'] = constructor
             classes += expr_class % d
         d = { 'expression_classes': classes }
         return expression_hh % d
@@ -30,6 +37,14 @@ class Expressions(object):
         methods = ''
         for node in self.nodes:
             d = { 'classname': node.typename, 'parentclass': node.parentclass }
+            if node.argcount == 1:
+                copy_method = unary_copy_method % d
+                ctor_method = unary_ctor_method % d
+            else: # 2 or -1 (selectresult) - is binary in either case
+                copy_method = binary_copy_method % d
+                ctor_method = binary_ctor_method % d
+            d['copy_method'] = copy_method
+            d['ctor_method'] = ctor_method
             methods += expr_methods % d
         d = { 'expression_methods': methods }
         return expression_cc % d

--- a/src/generator/exprtemplates.py
+++ b/src/generator/exprtemplates.py
@@ -51,13 +51,19 @@ expr_class = """\
 class %(classname)s: public %(parentclass)s
 {
   public:
-    %(classname)s(ArgContainer *args);
+%(constructor)s
     virtual OGNumeric* copy() const override;
     virtual const %(classname)s* as%(classname)s() const override;
     virtual void debug_print() const override;
     virtual ExprType_t getType() const override;
 };
 """
+
+unary_constructor = """\
+    %(classname)s(const OGNumeric* arg);"""
+
+binary_constructor = """\
+    %(classname)s(const OGNumeric* arg0, const OGNumeric* arg1);"""
 
 # Expressions cc
 
@@ -91,12 +97,12 @@ expr_methods = """\
  * %(classname)s node
  */
 
-%(classname)s::%(classname)s(ArgContainer* args): %(parentclass)s(args) {}
+%(ctor_method)s
 
 OGNumeric*
 %(classname)s::copy() const
 {
-  return new %(classname)s(this->getArgs()->copy());
+%(copy_method)s
 }
 
 const %(classname)s*
@@ -118,6 +124,18 @@ ExprType_t
 }
 
 """
+
+unary_ctor_method = """\
+%(classname)s::%(classname)s(const OGNumeric* arg): OGUnaryExpr{arg} {}"""
+
+binary_ctor_method = """\
+%(classname)s::%(classname)s(const OGNumeric* arg1, const OGNumeric* arg2): OGBinaryExpr{arg1, arg2} {}"""
+
+unary_copy_method = """\
+  return new %(classname)s((*_args)[0]->copy());"""
+
+binary_copy_method = """\
+  return new %(classname)s((*_args)[0]->copy(), (*_args)[1]->copy());"""
 
 # Numeric header file
 

--- a/src/jshim/exprfactory.cc
+++ b/src/jshim/exprfactory.cc
@@ -17,9 +17,10 @@ using namespace librdag;
 /**
  * Generate the libRDAG expression objects for a given Java object
  * @param obj a Java OGNumeric type
- * @return a pointer to an ArgContainer representing the parameters
+ * @return a pointer to a vector of pointers that point at the arguments. This return type is
+ * temporary, and will disappear when the tree generation is converted to the procedural variant.
  */
-ArgContainer* generateArgs(jobject obj)
+vector<const OGNumeric*>* generateArgs(jobject obj)
 {
   // get object array
   jmethodID method = JVMManager::getOGExprClazz_getExprs();
@@ -29,10 +30,11 @@ ArgContainer* generateArgs(jobject obj)
   jobjectArray * args = reinterpret_cast<jobjectArray *>(&dataobj);
   jsize len = env->GetArrayLength((jarray)*args);
   DEBUG_PRINT("JOGExpr arg size is %d\n",(int)len);
-  ArgContainer* local_args = new ArgContainer();
+  vector<const OGNumeric*>* local_args = new vector<const OGNumeric*>();
   for(int i=0; i<len; i++)
   {
     jobject tmp = (jobject) env->GetObjectArrayElement(*args, i);
+    checkEx(env);
     local_args->push_back(createExpression(tmp));
   }
   return local_args;
@@ -49,6 +51,7 @@ OGNumeric* createExpression(jobject obj)
   JNIEnv *env=nullptr;
   JVMManager::getEnv((void **)&env);
   jobject typeobj = env->CallObjectMethod(obj, JVMManager::getOGNumericClazz_getType());
+  checkEx(env);
   jlong ID = env->GetLongField(typeobj, JVMManager::getOGExprEnumClazz__hashdefined());
   VAL64BIT_PRINT("Class type", ID);
 

--- a/src/jshim/test/check_jdispatch.cc
+++ b/src/jshim/test/check_jdispatch.cc
@@ -25,9 +25,7 @@ TEST(JDispatch, Test_DispatchToReal16ArrayOfArrays_OGExpr)
 {
   DispatchToReal16ArrayOfArrays * d = new DispatchToReal16ArrayOfArrays();
   OGRealScalar * scal = new OGRealScalar(10);
-  ArgContainer * args = new ArgContainer();
-  args->push_back(scal);
-  OGExpr * expr = new NORM2(args);
+  OGExpr * expr = new NORM2(scal);
   ASSERT_ANY_THROW(d->visit(expr));
   delete d;
   delete expr;
@@ -193,9 +191,7 @@ TEST(JDispatch, Test_DispatchToComplex16ArrayOfArrays_OGExpr)
 {
   DispatchToComplex16ArrayOfArrays * d = new DispatchToComplex16ArrayOfArrays();
   OGRealScalar * scal = new OGRealScalar(10);
-  ArgContainer * args = new ArgContainer();
-  args->push_back(scal);
-  OGExpr * expr = new NORM2(args);
+  OGExpr * expr = new NORM2(scal);
   ASSERT_ANY_THROW(d->visit(expr));
   delete d;
   delete expr;

--- a/src/librdag/test/check_dispatch.cc
+++ b/src/librdag/test/check_dispatch.cc
@@ -29,10 +29,7 @@ TEST(DispatchTest, SimpleTest) {
     // One binary node holding two terminals
   OGNumeric *real1 = new OGRealScalar(1.0);
   OGNumeric *real2 = new OGRealScalar(2.0);
-  ArgContainer* plusArgs = new ArgContainer();
-  plusArgs->push_back(real1);
-  plusArgs->push_back(real2);
-  OGExpr *plus = new PLUS(plusArgs);
+  OGExpr *plus = new PLUS(real1, real2);
   ExecutionList* el1 = new ExecutionList(plus);
   const OGNumeric * val;
   int counter = 0;

--- a/src/librdag/test/check_entrypt.cc
+++ b/src/librdag/test/check_entrypt.cc
@@ -63,21 +63,15 @@ TEST_P(EntryptNegateTest, Running)
 
 TreeResultPair negatepair(double v)
 {
-  ArgContainer* args = new ArgContainer();
-  args->push_back(new OGRealScalar(v));
-  const OGNumeric* negate = new NEGATE(args);
+  const OGNumeric* negate = new NEGATE(new OGRealScalar(v));
   const OGNumeric* expected = new OGRealScalar(-v);
   return TreeResultPair(negate, expected);
 }
 
 TreeResultPair doublenegate(double v)
 {
-  ArgContainer* args = new ArgContainer();
-  args->push_back(new OGRealScalar(v));
-  const OGNumeric* negate = new NEGATE(args);
-  args = new ArgContainer();
-  args->push_back(negate);
-  negate = new NEGATE(args);
+  const OGNumeric* negate = new NEGATE(new OGRealScalar(v));
+  negate = new NEGATE(negate);
   const OGNumeric* expected = new OGRealScalar(v);
   return TreeResultPair(negate, expected);
 }
@@ -88,9 +82,7 @@ double realNegData[6] = { -1.0, -2.0, -3.0, -4.0, -5.0, -6.0 };
 TreeResultPair negaterealmatrix()
 {
   const OGTerminal* ogrealmatrix = new OGRealMatrix(realData, 2, 3);
-  ArgContainer* arg = new ArgContainer();
-  arg->push_back(ogrealmatrix);
-  const OGNumeric* negate = new NEGATE(arg);
+  const OGNumeric* negate = new NEGATE(ogrealmatrix);
   const OGTerminal* ogrealnegmatrix = new OGRealMatrix(realNegData, 2, 3);
   return TreeResultPair(negate, ogrealnegmatrix);
 }
@@ -103,9 +95,7 @@ complex16 complexNegData[6] = { {-1.0, -2.0}, {-3.0, -4.0},  {-5.0,  -6.0},
 TreeResultPair negatecomplexmatrix()
 {
   const OGTerminal* ogcomplexmatrix = new OGComplexMatrix(complexData, 2, 3);
-  ArgContainer* arg = new ArgContainer();
-  arg->push_back(ogcomplexmatrix);
-  const OGNumeric* negate = new NEGATE(arg);
+  const OGNumeric* negate = new NEGATE(ogcomplexmatrix);
   const OGTerminal* ogcomplexnegmatrix = new OGComplexMatrix(complexNegData, 2, 3);
   return TreeResultPair(negate, ogcomplexnegmatrix);
 }
@@ -129,24 +119,15 @@ TEST_P(EntryptPlusTest, Running)
 
 TreeResultPair plustestsimple()
 {
-  ArgContainer* args = new ArgContainer();
-  args->push_back(new OGRealScalar(2.0));
-  args->push_back(new OGRealScalar(3.0));
-  const OGNumeric* plus = new PLUS(args);
+  const OGNumeric* plus = new PLUS(new OGRealScalar(2.0), new OGRealScalar(3.0));
   const OGNumeric* expected = new OGRealScalar(2.0+3.0);
   return TreeResultPair(plus, expected);
 }
 
 TreeResultPair plustesttwoplus()
 {
-  ArgContainer* args = new ArgContainer();
-  args->push_back(new OGRealScalar(2.0));
-  args->push_back(new OGRealScalar(3.0));
-  const OGNumeric* plus = new PLUS(args);
-  args = new ArgContainer();
-  args->push_back(new OGRealScalar(1.0));
-  args->push_back(plus);
-  plus = new PLUS(args);
+  const OGNumeric* plus = new PLUS(new OGRealScalar(2.0), new OGRealScalar(3.0));
+  plus = new PLUS(new OGRealScalar(1.0), plus);
   const OGNumeric* expected = new OGRealScalar(1.0+2.0+3.0);
   return TreeResultPair(plus, expected);
 }
@@ -158,19 +139,15 @@ TreeResultPair plustestbigtree()
   for (int i = 0; i < 5000; ++i)
   {
     sum += i;
-    ArgContainer* args = new ArgContainer();
 
     if (i%2 == 0)
     {
-      args->push_back(new OGRealScalar(i));
-      args->push_back(bigtree);
+      bigtree = new PLUS(new OGRealScalar(i), bigtree);
     }
     else
     {
-      args->push_back(bigtree);
-      args->push_back(new OGRealScalar(i));
+      bigtree = new PLUS(bigtree, new OGRealScalar(i));
     }
-    bigtree = new PLUS(args);
   }
 
   return TreeResultPair(bigtree, new OGRealScalar(sum));

--- a/src/librdag/test/check_execution.cc
+++ b/src/librdag/test/check_execution.cc
@@ -40,9 +40,7 @@ TEST(LinearisationTest, UnaryTreeLinearisation)
 {
   // One unary node holding one terminal
   OGNumeric* real = new OGRealScalar(1.0);
-  ArgContainer *copyArgs = new ArgContainer();
-  copyArgs->push_back(real);
-  OGNumeric* copy = new COPY(copyArgs);
+  OGNumeric* copy = new COPY(real);
   ExecutionList* el1 = new ExecutionList(copy);
   EXPECT_EQ(2, el1->size());
   // Check ordering
@@ -63,12 +61,9 @@ TEST(LinearisationTest, UnaryTreeLinearisation)
 TEST(LinearisationTest, BinaryTreeLinearisation)
 {
   // One binary node holding two terminals
-  OGNumeric *real1 = new OGRealScalar(1.0);
-  OGNumeric *real2 = new OGRealScalar(2.0);
-  ArgContainer* plusArgs = new ArgContainer();
-  plusArgs->push_back(real1);
-  plusArgs->push_back(real2);
-  OGNumeric *plus = new PLUS(plusArgs);
+  OGNumeric* real1 = new OGRealScalar(1.0);
+  OGNumeric* real2 = new OGRealScalar(2.0);
+  OGNumeric *plus = new PLUS(real1, real2);
   ExecutionList* el1 = new ExecutionList(plus);
   EXPECT_EQ(3, el1->size());
   // Check ordering. We iterate over the list and get
@@ -107,15 +102,10 @@ TEST(LinearisationTest, BinaryUnaryLinearisation)
    *          \
    *           2.0
    */
-  OGNumeric *real1 = new OGRealScalar(1.0);
-  OGNumeric *real2 = new OGRealScalar(2.0);
-  ArgContainer *copyArgs = new ArgContainer();
-  copyArgs->push_back(real2);
-  OGNumeric* copy = new COPY(copyArgs);
-  ArgContainer* plusArgs = new ArgContainer();
-  plusArgs->push_back(real1);
-  plusArgs->push_back(copy);
-  OGNumeric *plus = new PLUS(plusArgs);
+  OGNumeric* real1 = new OGRealScalar(1.0);
+  OGNumeric* real2 = new OGRealScalar(2.0);
+  OGNumeric* copy = new COPY(real2);
+  OGNumeric *plus = new PLUS(real1, copy);
   ExecutionList *el1 = new ExecutionList(plus);
   // Check ordering. We iterate over the list and get
   // its contents first.

--- a/src/librdag/test/check_expressions.cc
+++ b/src/librdag/test/check_expressions.cc
@@ -21,12 +21,9 @@ TYPED_TEST_CASE_P(BinaryExprTest);
 
 TYPED_TEST_P(BinaryExprTest, Functionality){
   // Constructor
-  ArgContainer* args = new ArgContainer();
   OGRealScalar* real = new OGRealScalar(3.14);
   OGComplexScalar *complx = new OGComplexScalar(complex16(2.7182, 2.7182));
-  args->push_back(real);
-  args->push_back(complx);
-  TypeParam *expr = new TypeParam(args);
+  TypeParam *expr = new TypeParam(real, complx);
   ASSERT_EQ(2, expr->getNArgs());
   const ArgContainer* gotArgs = expr->getArgs();
   EXPECT_EQ(real, ((*gotArgs)[0])->asOGRealScalar());
@@ -36,12 +33,8 @@ TYPED_TEST_P(BinaryExprTest, Functionality){
   expr->debug_print();
 
   // Constructor with null args
-  EXPECT_THROW(new TypeParam(nullptr), rdag_error);
-
-  // Constructor with args of wrong length
-  ArgContainer* wrongArgs = new ArgContainer();
-  wrongArgs->push_back(real->copy());
-  EXPECT_THROW(new TypeParam(wrongArgs), rdag_error);
+  EXPECT_THROW(new TypeParam(nullptr, real), rdag_error);
+  EXPECT_THROW(new TypeParam(real, nullptr), rdag_error);
 
   // Cleanup
   delete expr;
@@ -61,10 +54,8 @@ TYPED_TEST_CASE_P(UnaryExprTest);
 
 TYPED_TEST_P(UnaryExprTest, Functionality){
   // Constructor
-  ArgContainer* args = new ArgContainer();
   OGRealScalar *real = new OGRealScalar(3.14);
-  args->push_back(real);
-  TypeParam *expr = new TypeParam(args);
+  TypeParam *expr = new TypeParam(real);
   ASSERT_EQ(1, expr->getNArgs());
   const ArgContainer* gotArgs = expr->getArgs();
   EXPECT_EQ(real, ((*gotArgs)[0])->asOGRealScalar());
@@ -74,12 +65,6 @@ TYPED_TEST_P(UnaryExprTest, Functionality){
 
   // Constructor with null args
   EXPECT_THROW(new TypeParam(nullptr), rdag_error);
-
-  // Constructor with args of wrong length
-  ArgContainer* wrongArgs = new ArgContainer();
-  wrongArgs->push_back(real->copy());
-  wrongArgs->push_back(real->copy());
-  EXPECT_THROW(new TypeParam(wrongArgs), rdag_error);
 
   // Cleanup
   delete expr;
@@ -95,12 +80,9 @@ INSTANTIATE_TYPED_TEST_CASE_P(Unary, UnaryExprTest, UnaryExprTypes);
 
 TEST(OGExprTest, SELECTRESULT){
   // Constructor
-  ArgContainer* args = new ArgContainer();
   OGRealScalar *real = new OGRealScalar(3.14);
   OGIntegerScalar *index = new OGIntegerScalar(2);
-  args->push_back(real);
-  args->push_back(index);
-  OGExpr *selectresult = new SELECTRESULT(args);
+  OGExpr *selectresult = new SELECTRESULT(real, index);
   ASSERT_EQ(2, selectresult->getNArgs());
   const ArgContainer* gotArgs = selectresult->getArgs();
   EXPECT_EQ(real, ((*gotArgs)[0])->asOGRealScalar());
@@ -110,18 +92,13 @@ TEST(OGExprTest, SELECTRESULT){
   selectresult->debug_print();
 
   // Constructor with null args
-  EXPECT_THROW(new SELECTRESULT(nullptr), rdag_error);
-
-  // Constructor with args of wrong length
-  ArgContainer* wrongArgs = new ArgContainer();
-  wrongArgs->push_back(real->copy());
-  EXPECT_THROW(new SELECTRESULT(wrongArgs), rdag_error);
+  EXPECT_THROW(new SELECTRESULT(nullptr, index), rdag_error);
+  EXPECT_THROW(new SELECTRESULT(real, nullptr), rdag_error);
 
   // Constructor where second argument is not an integer type
-  ArgContainer* wrongTypeArgs = new ArgContainer();
-  wrongTypeArgs->push_back(real->copy());
-  wrongTypeArgs->push_back(real->copy());
-  EXPECT_THROW(new SELECTRESULT(wrongTypeArgs), rdag_error);
+  OGNumeric* realcopy = real->copy();
+  EXPECT_THROW(new SELECTRESULT(real, realcopy), rdag_error);
+  delete realcopy;
 
   // Cleanup
   delete selectresult;
@@ -241,9 +218,7 @@ TEST(VirtualCopyTest, ComplexSparseMatrix){
 
 TEST(VirtualCopyTest, COPY) {
   OGRealScalar *real = new OGRealScalar(1.0);
-  ArgContainer *a = new ArgContainer();
-  a->push_back(real);
-  COPY *copy1 = new COPY(a);
+  COPY *copy1 = new COPY(real);
   COPY const *copy2 = copy1->copy()->asCOPY();
   ASSERT_NE(nullptr, copy2);
   const ArgContainer* a1 = copy1->getArgs();
@@ -265,10 +240,7 @@ TEST(VirtualCopyTest, COPY) {
 TEST(VirtualCopyTest, PLUS) {
   OGRealScalar *real1 = new OGRealScalar(1.0);
   OGRealScalar *real2 = new OGRealScalar(2.0);
-  ArgContainer *a = new ArgContainer();
-  a->push_back(real1);
-  a->push_back(real2);
-  PLUS *plus1 = new PLUS(a);
+  PLUS *plus1 = new PLUS(real1, real2);
   const PLUS *plus2 = plus1->copy()->asPLUS();
   ASSERT_NE(nullptr, plus2);
   const ArgContainer* a1 = plus1->getArgs();
@@ -297,9 +269,7 @@ TEST(VirtualCopyTest, PLUS) {
 
 TEST(VirtualCopyTest, NEGATE) {
   OGRealScalar *real1 = new OGRealScalar(1.0);
-  ArgContainer *a = new ArgContainer();
-  a->push_back(real1);
-  NEGATE *negate1 = new NEGATE(a);
+  NEGATE *negate1 = new NEGATE(real1);
   const NEGATE *negate2 = negate1->copy()->asNEGATE();
   ASSERT_NE(nullptr, negate2);
   const ArgContainer* a1 = negate1->getArgs();
@@ -321,9 +291,7 @@ TEST(VirtualCopyTest, NEGATE) {
 TEST(VirtualCopyTest, SVD) {
   double matData[6] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 };
   OGRealMatrix *realMat = new OGRealMatrix(matData, 3, 2);
-  ArgContainer *a = new ArgContainer();
-  a->push_back(realMat);
-  SVD *svd1 = new SVD(a);
+  SVD *svd1 = new SVD(realMat);
   SVD const *svd2 = svd1->copy()->asSVD();
   ASSERT_NE(nullptr, svd2);
   const ArgContainer* a1 = svd1->getArgs();
@@ -348,14 +316,9 @@ TEST(VirtualCopyTest, SVD) {
 TEST(VirtualCopyTest, SELECTRESULT) {
   double matData[6] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 };
   OGRealMatrix *realMat = new OGRealMatrix(matData, 3, 2);
-  ArgContainer *svdArgs = new ArgContainer();
-  svdArgs->push_back(realMat);
-  SVD *svd = new SVD(svdArgs);
+  SVD *svd = new SVD(realMat);
   OGIntegerScalar* i = new OGIntegerScalar(0);
-  ArgContainer *srArgs = new ArgContainer();
-  srArgs->push_back(svd);
-  srArgs->push_back(i);
-  SELECTRESULT *sr1 = new SELECTRESULT(srArgs);
+  SELECTRESULT *sr1 = new SELECTRESULT(svd, i);
   const SELECTRESULT *sr2 = sr1->copy()->asSELECTRESULT();
   ASSERT_NE(nullptr, sr2);
   const ArgContainer* a1 = sr1->getArgs();

--- a/src/librdag/test/check_rtti.cc
+++ b/src/librdag/test/check_rtti.cc
@@ -36,15 +36,13 @@ void check_rtti(OGNumeric* node, string name)
   CHECK_CAST(OGComplexSparseMatrix);
 }
 
-// Creates an ArgContainer with one argument for use in construction of a unary node.
+// Creates an OGRealScalar for use in construction of a unary node.
 class RTTIUnaryTest: public testing::Test
 {
   protected:
     virtual void SetUp()
     {
-      OGNumeric *real = new OGRealScalar(1.0);
-      _args = new ArgContainer();
-      _args->push_back(real);
+      arg = new OGRealScalar(1.0);
     }
 
     virtual void TearDown()
@@ -52,20 +50,17 @@ class RTTIUnaryTest: public testing::Test
       delete node;
     }
     OGNumeric* node;
-    ArgContainer* _args;
+    OGNumeric* arg;
 };
 
-// Creates an ArgContainer with two arguments for use in construction of a binary node.
+// Creates two OGRealScalars for use in construction of a binary node.
 class RTTIBinaryTest: public testing::Test
 {
   protected:
     virtual void SetUp()
     {
-      OGNumeric *real1 = new OGRealScalar(1.0);
-      OGNumeric *real2 = new OGRealScalar(2.0);
-      _args = new ArgContainer();
-      _args->push_back(real1);
-      _args->push_back(real2);
+      arg0 = new OGRealScalar(1.0);
+      arg1 = new OGRealScalar(2.0);
     }
 
     virtual void TearDown()
@@ -73,7 +68,8 @@ class RTTIBinaryTest: public testing::Test
       delete node;
     }
     OGNumeric* node;
-    ArgContainer* _args;
+    OGNumeric* arg0;
+    OGNumeric* arg1;
 };
 
 // Clears up the node after use to keep format of tests uniform between terminal and expr tests.
@@ -88,39 +84,35 @@ class RTTITerminalTest: public testing::Test
 };
 
 TEST_F(RTTIUnaryTest, TestCOPY) {
-  node = new COPY(_args);
+  node = new COPY(arg);
   check_rtti(node, "COPY");
 }
 
 TEST_F(RTTIUnaryTest, TestSVD) {
-  node = new SVD(_args);
+  node = new SVD(arg);
   check_rtti(node, "SVD");
 }
 
 TEST_F(RTTIBinaryTest, TestPLUS) {
-  node = new PLUS(_args);
+  node = new PLUS(arg0, arg1);
   check_rtti(node, "PLUS");
 }
 
 TEST_F(RTTIBinaryTest, TestMTIMES) {
-  node = new MTIMES(_args);
+  node = new MTIMES(arg0, arg1);
   check_rtti(node, "MTIMES");
 }
 
-
 TEST_F(RTTIUnaryTest, TestNEGATE) {
-  node = new NEGATE(_args);
+  node = new NEGATE(arg);
   check_rtti(node, "NEGATE");
 }
 
 // Not using the fixture because SELECTRESULT requires specific arg types
 TEST(RTTITest, TestSELECTRESULT) {
-  ArgContainer* args = new ArgContainer();
   OGRealScalar *real = new OGRealScalar(3.14);
   OGIntegerScalar *index = new OGIntegerScalar(0);
-  args->push_back(real);
-  args->push_back(index);
-  OGNumeric* node = new SELECTRESULT(args);
+  OGNumeric* node = new SELECTRESULT(real, index);
   check_rtti(node, "SELECTRESULT");
   delete node;
 }

--- a/src/librdag/test/check_terminals.cc
+++ b/src/librdag/test/check_terminals.cc
@@ -111,9 +111,7 @@ class FakeVisitor: public librdag::Visitor
  */
 TEST(TerminalsTest, OGTerminalTest) {
   OGNumeric * terminal_t = new OGRealScalar(3.14e0);
-  ArgContainer * args = new ArgContainer();
-  args->push_back(terminal_t);
-  OGNumeric * expr_t = new NEGATE(args);
+  OGNumeric * expr_t = new NEGATE(terminal_t);
   const OGTerminal * term;
   term = terminal_t->asOGTerminal();
   ASSERT_NE(term,nullptr);

--- a/src/librdag/test/nodes/check_mtimes.cc
+++ b/src/librdag/test/nodes/check_mtimes.cc
@@ -59,10 +59,9 @@ INSTANTIATE_NODE_TEST_CASE_P(MTIMESTests,MTIMES,
 
 
 TEST(MTIMESTests, CheckBadCommuteThrows) {
-  ArgContainer * args = new ArgContainer();
-  args->push_back(new OGRealMatrix(new real16[6]{1,3,5,2,4,6},3,2,OWNER));
-  args->push_back(new OGRealMatrix(new real16[7]{10,30,20,40,50,60,70},1,7,OWNER));
-  MTIMES * node = new MTIMES(args);
+  OGNumeric* m1 = new OGRealMatrix(new real16[6]{1,3,5,2,4,6},3,2,OWNER);
+  OGNumeric* m2 = new OGRealMatrix(new real16[7]{10,30,20,40,50,60,70},1,7,OWNER);
+  MTIMES * node = new MTIMES(m1, m2);
   ExecutionList * el1 = new ExecutionList(node);
   Dispatcher * v = new Dispatcher();
   ASSERT_THROW(

--- a/src/librdag/test/nodes/check_selectresult.cc
+++ b/src/librdag/test/nodes/check_selectresult.cc
@@ -27,17 +27,12 @@ TEST(SELECTRESULTTests,CheckBehaviour)
 {
   OGTerminal* one = new OGRealScalar(1.0);
   OGTerminal* r0 = new OGRealScalar(10.0);
-  ArgContainer *args = new ArgContainer();
-  args->push_back(r0);
-  SVD* svd = new SVD(args);
+  SVD* svd = new SVD(r0);
 
   Dispatcher * d = new Dispatcher();
 
   // Check selecting 0 (U)
-  ArgContainer* args0 = new ArgContainer();
-  args0->push_back(svd);
-  args0->push_back(new OGIntegerScalar(0));
-  SELECTRESULT* s0 = new SELECTRESULT(args0);
+  SELECTRESULT* s0 = new SELECTRESULT(svd, new OGIntegerScalar(0));
   ExecutionList* el0 = new ExecutionList(s0);
   for (auto it = el0->begin(); it != el0->end(); ++it)
   {
@@ -48,10 +43,7 @@ TEST(SELECTRESULTTests,CheckBehaviour)
   EXPECT_TRUE((*one) ==~ (*(answer->asOGTerminal())));
 
   // Check selecting 1 (S)
-  ArgContainer* args1 = new ArgContainer();
-  args1->push_back(svd->copy());
-  args1->push_back(new OGIntegerScalar(1));
-  SELECTRESULT* s1 = new SELECTRESULT(args1);
+  SELECTRESULT* s1 = new SELECTRESULT(svd->copy(), new OGIntegerScalar(1));
   ExecutionList* el1 = new ExecutionList(s1);
   for (auto it = el1->begin(); it != el1->end(); ++it)
   {
@@ -62,10 +54,7 @@ TEST(SELECTRESULTTests,CheckBehaviour)
   EXPECT_TRUE((*r0) ==~ (*(answer->asOGTerminal())));
 
   // Check selecting 2 (V)
-  ArgContainer* args2 = new ArgContainer();
-  args2->push_back(svd->copy());
-  args2->push_back(new OGIntegerScalar(2));
-  SELECTRESULT* s2 = new SELECTRESULT(args2);
+  SELECTRESULT* s2 = new SELECTRESULT(svd->copy(), new OGIntegerScalar(2));
   ExecutionList* el2 = new ExecutionList(s2);
   for (auto it = el2->begin(); it != el2->end(); ++it)
   {

--- a/src/librdag/test/nodes/check_svd.cc
+++ b/src/librdag/test/nodes/check_svd.cc
@@ -27,17 +27,12 @@ TEST(SVDTests,CheckScalar)
 {
   OGTerminal* one = new OGRealScalar(1.0);
   OGTerminal* r0 = new OGRealScalar(10.0);
-  ArgContainer *args = new ArgContainer();
-  args->push_back(r0);
-  SVD* svd = new SVD(args);
+  SVD* svd = new SVD(r0);
 
   Dispatcher * d = new Dispatcher();
 
   // Check selecting 0 (U)
-  ArgContainer* args0 = new ArgContainer();
-  args0->push_back(svd);
-  args0->push_back(new OGIntegerScalar(0));
-  SELECTRESULT* s0 = new SELECTRESULT(args0);
+  SELECTRESULT* s0 = new SELECTRESULT(svd, new OGIntegerScalar(0));
   ExecutionList* el0 = new ExecutionList(s0);
   for (auto it = el0->begin(); it != el0->end(); ++it)
   {
@@ -48,10 +43,7 @@ TEST(SVDTests,CheckScalar)
   EXPECT_TRUE((*one) ==~ (*(answer->asOGTerminal())));
 
   // Check selecting 1 (S)
-  ArgContainer* args1 = new ArgContainer();
-  args1->push_back(svd->copy());
-  args1->push_back(new OGIntegerScalar(1));
-  SELECTRESULT* s1 = new SELECTRESULT(args1);
+  SELECTRESULT* s1 = new SELECTRESULT(svd->copy(), new OGIntegerScalar(1));
   ExecutionList* el1 = new ExecutionList(s1);
   for (auto it = el1->begin(); it != el1->end(); ++it)
   {
@@ -62,10 +54,7 @@ TEST(SVDTests,CheckScalar)
   EXPECT_TRUE((*r0) ==~ (*(answer->asOGTerminal())));
 
   // Check selecting 2 (V)
-  ArgContainer* args2 = new ArgContainer();
-  args2->push_back(svd->copy());
-  args2->push_back(new OGIntegerScalar(2));
-  SELECTRESULT* s2 = new SELECTRESULT(args2);
+  SELECTRESULT* s2 = new SELECTRESULT(svd->copy(), new OGIntegerScalar(2));
   ExecutionList* el2 = new ExecutionList(s2);
   for (auto it = el2->begin(); it != el2->end(); ++it)
   {
@@ -97,9 +86,7 @@ TEST(SVDTests,CheckRealMatrix)
 
   // input
   OGTerminal* M = new OGRealMatrix(new real16[6]{1,3,5,2,4,6},3,2,OWNER);
-  ArgContainer *args = new ArgContainer();
-  args->push_back(M);
-  SVD* svd = new SVD(args);
+  SVD* svd = new SVD(M);
 
   // computed answer pointers
   const OGNumeric * answerU, * answerS, * answerVT, * reconstruct;
@@ -109,10 +96,7 @@ TEST(SVDTests,CheckRealMatrix)
   Dispatcher * d = new Dispatcher();
 
   // Check selecting 0 (U)
-  ArgContainer* args0 = new ArgContainer();
-  args0->push_back(svd);
-  args0->push_back(new OGIntegerScalar(0));
-  SELECTRESULT* s0 = new SELECTRESULT(args0);
+  SELECTRESULT* s0 = new SELECTRESULT(svd, new OGIntegerScalar(0));
   ExecutionList* el0 = new ExecutionList(s0);
   for (auto it = el0->begin(); it != el0->end(); ++it)
   {
@@ -123,10 +107,7 @@ TEST(SVDTests,CheckRealMatrix)
   EXPECT_TRUE((*U) % (*(answerU->asOGTerminal())));
 
   // Check selecting 1 (S)
-  ArgContainer* args1 = new ArgContainer();
-  args1->push_back(svd->copy());
-  args1->push_back(new OGIntegerScalar(1));
-  SELECTRESULT* s1 = new SELECTRESULT(args1);
+  SELECTRESULT* s1 = new SELECTRESULT(svd->copy(), new OGIntegerScalar(1));
   ExecutionList* el1 = new ExecutionList(s1);
   for (auto it = el1->begin(); it != el1->end(); ++it)
   {
@@ -137,10 +118,7 @@ TEST(SVDTests,CheckRealMatrix)
   EXPECT_TRUE((*S) ==~ (*(answerS->asOGTerminal())));
 
   // Check selecting 2 (V)
-  ArgContainer* args2 = new ArgContainer();
-  args2->push_back(svd->copy());
-  args2->push_back(new OGIntegerScalar(2));
-  SELECTRESULT* s2 = new SELECTRESULT(args2);
+  SELECTRESULT* s2 = new SELECTRESULT(svd->copy(), new OGIntegerScalar(2));
   ExecutionList* el2 = new ExecutionList(s2);
   for (auto it = el2->begin(); it != el2->end(); ++it)
   {
@@ -151,15 +129,9 @@ TEST(SVDTests,CheckRealMatrix)
   EXPECT_TRUE((*VT) % (*(answerVT->asOGTerminal())));
 
   // reconstruction test i.e. recover A from U,S,V**T as A=U*S*V**T
-  ArgContainer* args3 = new ArgContainer();
-  args3->push_back(answerU->asOGTerminal()->createOwningCopy());
-  args3->push_back(answerS->asOGTerminal()->createOwningCopy());
-
-  MTIMES * m1 = new MTIMES(args3);
-  ArgContainer* args4 = new ArgContainer();
-  args4->push_back(m1);
-  args4->push_back(answerVT->asOGTerminal()->createOwningCopy());
-  MTIMES * m2 = new MTIMES(args4);
+  MTIMES * m1 = new MTIMES(answerU->asOGTerminal()->createOwningCopy(),
+                           answerS->asOGTerminal()->createOwningCopy());
+  MTIMES * m2 = new MTIMES(m1, answerVT->asOGTerminal()->createOwningCopy());
   ExecutionList* el3 = new ExecutionList(m2);
   for (auto it = el3->begin(); it != el3->end(); ++it)
   {
@@ -197,9 +169,7 @@ TEST(SVDTests,CheckComplexMatrix)
 
   // input
   OGTerminal* M = new OGComplexMatrix(new complex16[6]{{1,10}, {3,30}, {5,50}, {2,20}, {4,40}, {6,60}},3,2,OWNER);
-  ArgContainer *args = new ArgContainer();
-  args->push_back(M);
-  SVD* svd = new SVD(args);
+  SVD* svd = new SVD(M);
 
   // computed answer pointers
   const OGNumeric * answerU, * answerS, * answerVT, * reconstruct;
@@ -209,10 +179,7 @@ TEST(SVDTests,CheckComplexMatrix)
   Dispatcher * d = new Dispatcher();
 
   // Check selecting 0 (U)
-  ArgContainer* args0 = new ArgContainer();
-  args0->push_back(svd);
-  args0->push_back(new OGIntegerScalar(0));
-  SELECTRESULT* s0 = new SELECTRESULT(args0);
+  SELECTRESULT* s0 = new SELECTRESULT(svd, new OGIntegerScalar(0));
   ExecutionList* el0 = new ExecutionList(s0);
   for (auto it = el0->begin(); it != el0->end(); ++it)
   {
@@ -223,10 +190,7 @@ TEST(SVDTests,CheckComplexMatrix)
   EXPECT_TRUE((*U) % (*(answerU->asOGTerminal())));
 
   // Check selecting 1 (S)
-  ArgContainer* args1 = new ArgContainer();
-  args1->push_back(svd->copy());
-  args1->push_back(new OGIntegerScalar(1));
-  SELECTRESULT* s1 = new SELECTRESULT(args1);
+  SELECTRESULT* s1 = new SELECTRESULT(svd->copy(), new OGIntegerScalar(1));
   ExecutionList* el1 = new ExecutionList(s1);
   for (auto it = el1->begin(); it != el1->end(); ++it)
   {
@@ -237,10 +201,7 @@ TEST(SVDTests,CheckComplexMatrix)
   EXPECT_TRUE((*S) ==~ (*(answerS->asOGTerminal())));
 
   // Check selecting 2 (V)
-  ArgContainer* args2 = new ArgContainer();
-  args2->push_back(svd->copy());
-  args2->push_back(new OGIntegerScalar(2));
-  SELECTRESULT* s2 = new SELECTRESULT(args2);
+  SELECTRESULT* s2 = new SELECTRESULT(svd->copy(), new OGIntegerScalar(2));
   ExecutionList* el2 = new ExecutionList(s2);
   for (auto it = el2->begin(); it != el2->end(); ++it)
   {
@@ -251,15 +212,9 @@ TEST(SVDTests,CheckComplexMatrix)
   EXPECT_TRUE((*VT) % (*(answerVT->asOGTerminal())));
 
   // reconstruction test i.e. recover A from U,S,V**T as A=U*S*V**T
-  ArgContainer* args3 = new ArgContainer();
-  args3->push_back(answerU->asOGTerminal()->createOwningCopy());
-  args3->push_back(answerS->asOGTerminal()->createOwningCopy());
-
-  MTIMES * m1 = new MTIMES(args3);
-  ArgContainer* args4 = new ArgContainer();
-  args4->push_back(m1);
-  args4->push_back(answerVT->asOGTerminal()->createOwningCopy());
-  MTIMES * m2 = new MTIMES(args4);
+  MTIMES * m1 = new MTIMES(answerU->asOGTerminal()->createOwningCopy(),
+                           answerS->asOGTerminal()->createOwningCopy());
+  MTIMES * m2 = new MTIMES(m1, answerVT->asOGTerminal()->createOwningCopy());
   ExecutionList* el3 = new ExecutionList(m2);
   for (auto it = el3->begin(); it != el3->end(); ++it)
   {

--- a/src/librdag/test/nodes/testnodes.cc
+++ b/src/librdag/test/nodes/testnodes.cc
@@ -75,9 +75,7 @@ CheckUnary<T>::getResultPair() const
 template<typename T> void
 CheckUnary<T>::execute()
 {
-  ArgContainer * args = new ArgContainer();
-  args->push_back(_input);
-  T * node = new T(args);
+  T * node = new T(_input);
   ExecutionList * el1 = new ExecutionList(node);
   for (auto it = el1->begin(); it != el1->end(); ++it)
   {
@@ -143,10 +141,7 @@ CheckBinary<T>::getResultPair() const
 template<typename T> void
 CheckBinary<T>::execute()
 {
-  ArgContainer * args = new ArgContainer();
-  args->push_back(_first_input);
-  args->push_back(_second_input);
-  T * node = new T(args);
+  T * node = new T(_first_input, _second_input);
   ExecutionList * el1 = new ExecutionList(node);
   for (auto it = el1->begin(); it != el1->end(); ++it)
   {


### PR DESCRIPTION
It is no longer necessary to construct an ArgContainer outside
an expression constructor. Instead, expressions take their actual
arguments and build the ArgContainer themselves, in order to
simplify memory management.

The use of a vector<const OGNumeric*>\* for passing the results of
generateArgs() is a temporary measure, and will be removed when
the translation is converted to a procedural implementation.

Some missing exception checks are also added as they were spotted
during modification of the JNI interface.

Buildbot pass: http://devmaths-lx-1:8011/builders/nyqwk2-testing/builds/817
Coverage: 
Java: 91% 
build/src/jshim: 0.6% (unchanged)
build/src/librdag: 13.5% (unchanged)
src/jshim: 61.3% (down 0.1% due to a couple of extra lines in untested regions)
src/librdag: 90.9% (down 0.6% due to slightly shrinking the portion of code that was tested)
src/librdag/runners: 100% (unchanged)
