### PR TITLE
[MAT-372] PtrVector: ownership a runtime property

### DIFF
--- a/cmake/modules/NativeLibraryBuilder.cmake
+++ b/cmake/modules/NativeLibraryBuilder.cmake
@@ -28,7 +28,7 @@ macro(jar_native_library lib)
 
   # if the lib is imported, we know what it is called!
   if(_ncfg)
-      set(_output_name ${_ncfg})
+    get_filename_component(_output_name ${_ncfg} NAME)
   else()
     get_filename_component(_basename ${_location} NAME_WE)
     if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")

--- a/include/containers.hh
+++ b/include/containers.hh
@@ -17,7 +17,8 @@ using namespace std;
 namespace librdag {
 
 /*
- * A vector that holds pointers. Null pointers are not allowed.
+ * A vector that holds pointers. Null pointers are not allowed. If it owns its pointers,
+ * then it deletes them on destruction.
  */
 template<typename cTp>
 class PtrVector
@@ -33,42 +34,19 @@ class PtrVector
     citerator begin() const;
     citerator end() const;
     cTp operator[](size_t n) const;
-    virtual PtrVector* copy() const = 0;
+    virtual PtrVector* copy() const;
+    void set_ownership(bool owning);
+    bool get_ownership() const;
   private:
-    vector<cTp>* _vector;
+    vector<cTp> _vector;
+    bool _owning;
     void _check_arg(cTp arg);
-};
-
-/*
- * A vector that holds pointers that point to data that it does not own.
- */
-template<typename cTp>
-class NonOwningPtrVector: public PtrVector<cTp>
-{
-  public:
-    virtual NonOwningPtrVector* copy() const override;
-};
-
-/*
- * A vector that holds pointers that point to data that it owns.
- *
- * Classes held in an OwningPtrVector must define a method copy() that returns
- * a pointer to a copy of itself.
- */
-template<typename cTp>
-class OwningPtrVector: public PtrVector<cTp>
-{
-  public:
-    virtual ~OwningPtrVector() override;
-    virtual OwningPtrVector* copy() const override;
 };
 
 class OGNumeric;
 
-extern template class NonOwningPtrVector<const int*>;
-extern template class NonOwningPtrVector<const OGNumeric*>;
-extern template class OwningPtrVector<const int*>;
-extern template class OwningPtrVector<const OGNumeric*>;
+extern template class PtrVector<const int*>;
+extern template class PtrVector<const OGNumeric*>;
 
 } // namespace librdag
 

--- a/include/execution.hh
+++ b/include/execution.hh
@@ -15,7 +15,7 @@ namespace librdag {
 class OGNumeric;
 
 // Internal data structure for the ExecutionList.
-typedef NonOwningPtrVector<const OGNumeric*> _ExpressionList;
+typedef PtrVector<const OGNumeric*> _ExpressionList;
 
 // An ExecutionList holds a list of expression nodes that are in order such that
 // no node has inputs that are computed by a node further down the list. Thus,

--- a/include/expressionbase.hh
+++ b/include/expressionbase.hh
@@ -24,8 +24,8 @@ namespace librdag
  * Container for expression arguments
  */
 
-typedef OwningPtrVector<const OGNumeric*> ArgContainer;
-typedef OwningPtrVector<const OGNumeric*>  RegContainer;
+typedef PtrVector<const OGNumeric*> ArgContainer;
+typedef PtrVector<const OGNumeric*>  RegContainer;
 
 /**
  *  Expr type

--- a/src/librdag/expressionbase.cc
+++ b/src/librdag/expressionbase.cc
@@ -21,8 +21,12 @@ namespace librdag
 
 OGExpr::OGExpr()
 {
+  // _args must be initialised by a subclass.
   _args = nullptr;
+  // _regs are safe to immediately own their contents because we don't put anything
+  // in them during construction.
   _regs = new RegContainer();
+  _regs->set_ownership(true);
 }
 
 OGExpr::~OGExpr()
@@ -82,6 +86,9 @@ OGUnaryExpr::OGUnaryExpr(const OGNumeric* arg): OGExpr{}
   }
   _args = new ArgContainer();
   _args->push_back(arg);
+  // We got all the way through building the OGUnaryExpr object, so it
+  // is now safe to own the arguments.
+  _args->set_ownership(true);
 }
 
 OGBinaryExpr::OGBinaryExpr(const OGNumeric* arg0, const OGNumeric* arg1): OGExpr{}
@@ -97,6 +104,9 @@ OGBinaryExpr::OGBinaryExpr(const OGNumeric* arg0, const OGNumeric* arg1): OGExpr
   _args = new ArgContainer();
   _args->push_back(arg0);
   _args->push_back(arg1);
+  // We got all the way through building the OGBinaryExpr object, so it
+  // is now safe to own the arguments.
+  _args->set_ownership(true);
 }
 
 /**
@@ -153,6 +163,9 @@ SELECTRESULT::SELECTRESULT(const OGNumeric* arg0, const OGNumeric* arg1): OGExpr
   _args = new ArgContainer();
   _args->push_back(arg0);
   _args->push_back(arg1);
+  // We got all the way through building the SELECTRESULT object, so it
+  // is now safe to own the arguments.
+  _args->set_ownership(true);
 }
 
 OGNumeric*

--- a/src/librdag/test/check_containers.cc
+++ b/src/librdag/test/check_containers.cc
@@ -16,7 +16,8 @@ using namespace librdag;
  */
 TEST(ContainerTest, OwningPtrVectorTest) {
   // Default constructor
-  OwningPtrVector<const int*> *pv1 = new OwningPtrVector<const int*>();
+  PtrVector<const int*> *pv1 = new PtrVector<const int*>();
+  pv1->set_ownership(true);
   EXPECT_EQ(0, pv1->size());
 
   // Add elements
@@ -50,11 +51,11 @@ TEST(ContainerTest, OwningPtrVectorTest) {
   }
   EXPECT_EQ(5, i);
 
-  // Copy the OwningPtrVector
-  OwningPtrVector<const int*> *pv2 = pv1->copy();
+  // Copy the PtrVector
+  PtrVector<const int*> *pv2 = pv1->copy();
 
   // Test the copy is the same as the original
-  OwningPtrVector<const int*>::citerator it1, it2;
+  PtrVector<const int*>::citerator it1, it2;
   for (it1 = pv1->begin(), it2 = pv2->begin(); it1 != pv1->end(), it2 != pv2->end(); ++it1, ++it2)
   {
     EXPECT_EQ(**it1, **it2);
@@ -77,7 +78,7 @@ TEST(ContainerTest, OwningPtrVectorTest) {
  */
 TEST(ContainerTest, NonOwningPtrVectorTest) {
   // Default constructor
-  NonOwningPtrVector<const int*> *pv1 = new NonOwningPtrVector<const int*>();
+  PtrVector<const int*> *pv1 = new PtrVector<const int*>();
   EXPECT_EQ(0, pv1->size());
 
   // Add elements
@@ -111,11 +112,11 @@ TEST(ContainerTest, NonOwningPtrVectorTest) {
   }
   EXPECT_EQ(5, i);
 
-  // Copy the NonOwningPtrVector
-  NonOwningPtrVector<const int*> *pv2 = pv1->copy();
+  // Copy the PtrVector
+  PtrVector<const int*> *pv2 = pv1->copy();
 
   // Test the copy is the same as the original
-  NonOwningPtrVector<const int*>::citerator it1, it2;
+  PtrVector<const int*>::citerator it1, it2;
   for (it1 = pv1->begin(), it2 = pv2->begin(); it1 != pv1->end(), it2 != pv2->end(); ++it1, ++it2)
   {
     EXPECT_EQ( *it1,  *it2);

--- a/src/librdag/test/check_containers.cc
+++ b/src/librdag/test/check_containers.cc
@@ -5,6 +5,7 @@
  */
 
 #include "containers.hh"
+#include "terminal.hh"
 #include "gtest/gtest.h"
 
 using namespace std;
@@ -136,4 +137,37 @@ TEST(ContainerTest, NonOwningPtrVectorTest) {
     delete i_ptr_list[i];
   }
   free(i_ptr_list);
+}
+
+TEST(ContainerTest, CopyNonPrimitiveTest)
+{
+  PtrVector<const OGNumeric*>* pv1 = new PtrVector<const OGNumeric*>{};
+  OGNumeric* s1 = new OGRealScalar(1.0);
+  OGNumeric* s2 = new OGRealScalar(2.0);
+
+  pv1->push_back(s1);
+  pv1->push_back(s2);
+
+  // Non-owning copy - check size and pointers are equal
+  PtrVector<const OGNumeric*>* pv1copy1 = pv1->copy();
+  EXPECT_EQ(2, pv1copy1->size());
+  EXPECT_EQ((*pv1)[0], (*pv1copy1)[0]);
+  EXPECT_EQ((*pv1)[1], (*pv1copy1)[1]);
+
+  // Set owning
+  pv1->set_ownership(true);
+
+  // Owning copy - check size equal, pointers distinct, pointed-to objects equal
+  PtrVector<const OGNumeric*>* pv1copy2 = pv1->copy();
+  EXPECT_EQ(2, pv1copy2->size());
+  EXPECT_NE((*pv1)[0], (*pv1copy2)[0]);
+  EXPECT_NE((*pv1)[1], (*pv1copy2)[1]);
+  EXPECT_EQ(1.0, ((OGRealScalar*)(*pv1copy2)[0])->getValue());
+  EXPECT_EQ(2.0, ((OGRealScalar*)(*pv1copy2)[1])->getValue());
+
+  // Cleanup - pv1copy1 should not delete pv1's elements.
+  // pv1copy2 deletes its own elements.
+  delete pv1copy1;
+  delete pv1copy2;
+  delete pv1;
 }


### PR DESCRIPTION
OwningPtrVector and NonOwningPtrVector are collapsed into the
single PtrVector type. A PtrVector always begins life as a non-
owning entity. It can then be made to own its elements later on.

This is because it is almost never desirable to own elements
immediately, because some work may have to be done to populate it,
which could throw an exception.

Buildbot pass pending - waiting on suitable Mac to build on.
Change-Id: I4a5f82c6af193dcd54d8ba41230b68eafffb14f7
