### PR TITLE
Make _args and _regs non-pointers

### DIFF
--- a/include/expressionbase.hh
+++ b/include/expressionbase.hh
@@ -35,16 +35,16 @@ class OGExpr: public OGNumeric
   public:
     virtual ~OGExpr();
     const ArgContainer& getArgs() const;
+    RegContainer& getRegs() const;
     size_t getNArgs() const;
     virtual const OGExpr* asOGExpr() const override;
     virtual void debug_print() const override;
     virtual void accept(Visitor &v) const override;
-    virtual const RegContainer * getRegs() const;
   protected:
     OGExpr();
     ArgContainer _args;
   private:
-    RegContainer * _regs;
+    mutable RegContainer _regs;
 };
 
 /**

--- a/include/expressionbase.hh
+++ b/include/expressionbase.hh
@@ -34,7 +34,7 @@ class OGExpr: public OGNumeric
 {
   public:
     virtual ~OGExpr();
-    const ArgContainer* getArgs() const;
+    const ArgContainer& getArgs() const;
     size_t getNArgs() const;
     virtual const OGExpr* asOGExpr() const override;
     virtual void debug_print() const override;
@@ -42,7 +42,7 @@ class OGExpr: public OGNumeric
     virtual const RegContainer * getRegs() const;
   protected:
     OGExpr();
-    ArgContainer * _args;
+    ArgContainer _args;
   private:
     RegContainer * _regs;
 };

--- a/src/generator/dispatchtemplates.py
+++ b/src/generator/dispatchtemplates.py
@@ -115,17 +115,17 @@ template<typename T> class DispatchUnaryOp: public DispatchOp<T>
     virtual ~DispatchUnaryOp();
 
     // will run the operation
-    T eval(RegContainer* reg, const OGTerminal* arg) const;
+    T eval(RegContainer& reg, const OGTerminal* arg) const;
     // Methods for specific terminals
 %(dispatchunaryop_terminal_methods)s
     // Backstop methods for generic implementation
-    virtual T run(RegContainer * reg, OGRealMatrix const * arg) const = 0;
-    virtual T run(RegContainer * reg, OGComplexMatrix const * arg) const = 0;
+    virtual T run(RegContainer& reg, OGRealMatrix const * arg) const = 0;
+    virtual T run(RegContainer& reg, OGComplexMatrix const * arg) const = 0;
 };
 """
 
 dispatchunaryop_run = """\
-    virtual T run(RegContainer* reg, const %(nodetype)s* arg) const;
+    virtual T run(RegContainer& reg, const %(nodetype)s* arg) const;
 """
 
 dispatchbinaryop_class = """\
@@ -138,18 +138,18 @@ template<typename T> class  DispatchBinaryOp: public DispatchOp<T>
     using DispatchOp<T>::getConvertTo;
     virtual ~DispatchBinaryOp();
     // will run the operation
-    T eval(RegContainer SUPPRESS_UNUSED * reg0, OGTerminal const *arg0, OGTerminal const *arg1) const;
+    T eval(RegContainer SUPPRESS_UNUSED & reg0, OGTerminal const *arg0, OGTerminal const *arg1) const;
 
     // Methods for specific terminals
 %(dispatchbinaryop_terminal_methods)s
     // Required backstop impls
-    virtual T run(RegContainer* reg0, const OGComplexMatrix* arg0, const OGComplexMatrix* arg1) const = 0;
-    virtual T run(RegContainer* reg0, const OGRealMatrix* arg0, const OGRealMatrix* arg1) const = 0;
+    virtual T run(RegContainer& reg0, const OGComplexMatrix* arg0, const OGComplexMatrix* arg1) const = 0;
+    virtual T run(RegContainer& reg0, const OGRealMatrix* arg0, const OGRealMatrix* arg1) const = 0;
 };
 """
 
 dispatchbinaryop_run = """\
-    virtual T run(RegContainer* reg0, const %(node0type)s* arg0, const %(node1type)s* arg1) const;
+    virtual T run(RegContainer& reg0, const %(node0type)s* arg0, const %(node1type)s* arg1) const;
 """
 
 # Dispatch cc file
@@ -302,42 +302,42 @@ Dispatcher::dispatch(%(nodetype)s const SUPPRESS_UNUSED * thing) const
 
 dispatcher_binary_implementation = """\
   const ArgContainer& args = thing->getArgs();
-  const RegContainer * regs = thing->getRegs();
+  RegContainer& regs = thing->getRegs();
   const OGNumeric * arg0 = args[0];
   const OGNumeric * arg1 = args[1];
   const OGTerminal* arg0t = arg0->asOGTerminal();
   const OGTerminal* arg1t = arg1->asOGTerminal();
   if (arg0t == nullptr)
   {
-    arg0t = (*(arg0->asOGExpr()->getRegs()))[0]->asOGTerminal();
+    arg0t = arg0->asOGExpr()->getRegs()[0]->asOGTerminal();
   }
   if (arg1t == nullptr)
   {
-    arg1t = (*(arg1->asOGExpr()->getRegs()))[0]->asOGTerminal();
+    arg1t = arg1->asOGExpr()->getRegs()[0]->asOGTerminal();
   }
-  this->_%(nodetype)sRunner->eval(const_cast<RegContainer *>(regs), arg0t, arg1t);
+  this->_%(nodetype)sRunner->eval(regs, arg0t, arg1t);
 """
 
 dispatcher_unary_implementation = """\
   const ArgContainer& args = thing->getArgs();
-  const RegContainer* regs = thing->getRegs();
+  RegContainer& regs = thing->getRegs();
   const OGNumeric *arg = args[0];
   const OGTerminal *argt = arg->asOGTerminal();
   if (argt == nullptr)
   {
-    argt = (*(arg->asOGExpr()->getRegs()))[0]->asOGTerminal();
+    argt = arg->asOGExpr()->getRegs()[0]->asOGTerminal();
   }
-  _%(nodetype)sRunner->eval(const_cast<RegContainer *>(regs), argt);
+  _%(nodetype)sRunner->eval(regs, argt);
 """
 
 dispatcher_select_implementation = """\
   const ArgContainer& args = thing->getArgs();
-  const RegContainer* regs = thing->getRegs();
+  RegContainer& regs = thing->getRegs();
   const OGNumeric *arg0 = args[0];
   const OGNumeric *arg1 = args[1];
-  const RegContainer* arg0r = arg0->asOGExpr()->getRegs();
+  const RegContainer& arg0r = arg0->asOGExpr()->getRegs();
   const OGIntegerScalar* arg1i = arg1->asOGIntegerScalar();
-  this->_%(nodetype)sRunner->eval(const_cast<RegContainer *>(regs), arg0r, arg1i);
+  this->_%(nodetype)sRunner->eval(regs, arg0r, arg1i);
 """
 
 # DispatchOp methods
@@ -381,7 +381,7 @@ DispatchUnaryOp<T>::~DispatchUnaryOp() {}
 dispatchunaryop_eval = """\
 template<typename T>
 T
-DispatchUnaryOp<T>::eval(RegContainer* reg, const OGTerminal* arg) const
+DispatchUnaryOp<T>::eval(RegContainer& reg, const OGTerminal* arg) const
 {
   ExprType_t argID = arg->getType();
   T ret = nullptr;
@@ -405,7 +405,7 @@ dispatchunaryop_eval_case = """\
 dispatchunaryop_terminal_method = """\
 template<typename T>
 T
-DispatchUnaryOp<T>::run(RegContainer* reg, const %(nodetype)s* arg) const
+DispatchUnaryOp<T>::run(RegContainer& reg, const %(nodetype)s* arg) const
 {
   %(typetoconvertto)s* conv = this->getConvertTo()->convertTo%(typetoconvertto)s(arg);
   T ret = run(reg, conv);
@@ -432,7 +432,7 @@ DispatchBinaryOp<T>::~DispatchBinaryOp(){}
 dispatchbinaryop_eval = """\
 template <typename T>
 T
-DispatchBinaryOp<T>::eval(RegContainer* reg0, OGTerminal const *arg0, OGTerminal const *arg1) const
+DispatchBinaryOp<T>::eval(RegContainer& reg0, OGTerminal const *arg0, OGTerminal const *arg1) const
 {
   ExprType_t arg0ID = arg0->getType();
   ExprType_t arg1ID = arg1->getType();
@@ -473,7 +473,7 @@ dispatchbinaryop_eval_case_arg1 = """\
 dispatchbinaryop_terminal_method = """\
 template<typename T>
 T
-DispatchBinaryOp<T>::run(RegContainer* reg0,
+DispatchBinaryOp<T>::run(RegContainer& reg0,
                          const %(node0type)s* arg0,
                          const %(node1type)s* arg1) const
 {

--- a/src/generator/dispatchtemplates.py
+++ b/src/generator/dispatchtemplates.py
@@ -301,10 +301,10 @@ Dispatcher::dispatch(%(nodetype)s const SUPPRESS_UNUSED * thing) const
 """
 
 dispatcher_binary_implementation = """\
-  const ArgContainer * args = thing->getArgs();
+  const ArgContainer& args = thing->getArgs();
   const RegContainer * regs = thing->getRegs();
-  const OGNumeric * arg0 = (*args)[0];
-  const OGNumeric * arg1 = (*args)[1];
+  const OGNumeric * arg0 = args[0];
+  const OGNumeric * arg1 = args[1];
   const OGTerminal* arg0t = arg0->asOGTerminal();
   const OGTerminal* arg1t = arg1->asOGTerminal();
   if (arg0t == nullptr)
@@ -319,9 +319,9 @@ dispatcher_binary_implementation = """\
 """
 
 dispatcher_unary_implementation = """\
-  const ArgContainer* args = thing->getArgs();
+  const ArgContainer& args = thing->getArgs();
   const RegContainer* regs = thing->getRegs();
-  const OGNumeric *arg = (*args)[0];
+  const OGNumeric *arg = args[0];
   const OGTerminal *argt = arg->asOGTerminal();
   if (argt == nullptr)
   {
@@ -331,10 +331,10 @@ dispatcher_unary_implementation = """\
 """
 
 dispatcher_select_implementation = """\
-  const ArgContainer* args = thing->getArgs();
+  const ArgContainer& args = thing->getArgs();
   const RegContainer* regs = thing->getRegs();
-  const OGNumeric *arg0 = (*args)[0];
-  const OGNumeric *arg1 = (*args)[1];
+  const OGNumeric *arg0 = args[0];
+  const OGNumeric *arg1 = args[1];
   const RegContainer* arg0r = arg0->asOGExpr()->getRegs();
   const OGIntegerScalar* arg1i = arg1->asOGIntegerScalar();
   this->_%(nodetype)sRunner->eval(const_cast<RegContainer *>(regs), arg0r, arg1i);

--- a/src/generator/exprtemplates.py
+++ b/src/generator/exprtemplates.py
@@ -132,10 +132,10 @@ binary_ctor_method = """\
 %(classname)s::%(classname)s(const OGNumeric* arg1, const OGNumeric* arg2): OGBinaryExpr{arg1, arg2} {}"""
 
 unary_copy_method = """\
-  return new %(classname)s((*_args)[0]->copy());"""
+  return new %(classname)s(_args[0]->copy());"""
 
 binary_copy_method = """\
-  return new %(classname)s((*_args)[0]->copy(), (*_args)[1]->copy());"""
+  return new %(classname)s(_args[0]->copy(), _args[1]->copy());"""
 
 # Numeric header file
 

--- a/src/generator/runnertemplates.py
+++ b/src/generator/runnertemplates.py
@@ -57,20 +57,20 @@ class %(nodename)sRunner: public DispatchVoidBinaryOp, private Uncopyable
 {
   public:
     using DispatchBinaryOp<void *>::run;
-    virtual void * run(RegContainer* reg0, const OGComplexMatrix* arg0, const OGComplexMatrix* arg1) const override;
-    virtual void * run(RegContainer* reg0, const OGRealMatrix*    arg0, const OGRealMatrix*    arg1) const override;
-    virtual void * run(RegContainer* reg0, const OGRealScalar*    arg0, const OGRealScalar*    arg1) const override;
+    virtual void * run(RegContainer& reg0, const OGComplexMatrix* arg0, const OGComplexMatrix* arg1) const override;
+    virtual void * run(RegContainer& reg0, const OGRealMatrix*    arg0, const OGRealMatrix*    arg1) const override;
+    virtual void * run(RegContainer& reg0, const OGRealScalar*    arg0, const OGRealScalar*    arg1) const override;
 };
 
 """
 
 binary_runner_function =  """\
 void *
-%(nodename)sRunner::run(RegContainer* reg0, const %(arg0type)s* arg0, const %(arg1type)s* arg1) const
+%(nodename)sRunner::run(RegContainer& reg0, const %(arg0type)s* arg0, const %(arg1type)s* arg1) const
 {
   const %(returntype)s* ret;
 %(implementation)s
-  reg0->push_back(ret);
+  reg0.push_back(ret);
   return nullptr;
 }
 
@@ -82,8 +82,8 @@ integer_parameter_runner_class_definition = """\
 class %(nodename)sRunner: public DispatchVoidOp, private Uncopyable
 {
   public:
-    virtual void* eval(RegContainer* reg, RegContainer const *arg0, OGIntegerScalar const *arg1) const;
-    virtual void* run(RegContainer* reg0, const RegContainer* arg0, const OGIntegerScalar* arg1) const;
+    virtual void* eval(RegContainer& reg, const RegContainer& arg0, OGIntegerScalar const *arg1) const;
+    virtual void* run(RegContainer& reg0, const RegContainer& arg0, const OGIntegerScalar* arg1) const;
 };
 
 """
@@ -182,19 +182,19 @@ unary_runner_class_definition = """\
 class %(nodename)sRunner: public DispatchVoidUnaryOp, private Uncopyable
 {
   public:
-    virtual void * run(RegContainer* reg, const OGRealScalar*    arg) const override;
-    virtual void * run(RegContainer* reg, const OGRealMatrix*    arg) const override;
-    virtual void * run(RegContainer* reg, const OGComplexMatrix* arg) const override;
+    virtual void * run(RegContainer& reg, const OGRealScalar*    arg) const override;
+    virtual void * run(RegContainer& reg, const OGRealMatrix*    arg) const override;
+    virtual void * run(RegContainer& reg, const OGComplexMatrix* arg) const override;
 };
 """
 
 unary_runner_function = """\
 void *
-%(nodename)sRunner::run(RegContainer* reg, const %(argtype)s* arg) const
+%(nodename)sRunner::run(RegContainer& reg, const %(argtype)s* arg) const
 {
   const %(returntype)s* ret;
 %(implementation)s
-  reg->push_back(ret);
+  reg.push_back(ret);
   return nullptr;
 }
 
@@ -238,7 +238,7 @@ unaryfunction_matrix_runner_implementation = """\
 
 unimplementedunary_runner_function = """\
 void *
-%(nodename)sRunner::run(RegContainer SUPPRESS_UNUSED * reg, %(argtype)s const SUPPRESS_UNUSED * arg) const
+%(nodename)sRunner::run(RegContainer SUPPRESS_UNUSED & reg, %(argtype)s const SUPPRESS_UNUSED * arg) const
 {
   throw rdag_error("Unimplemented unary expression node");
   return nullptr;
@@ -247,7 +247,7 @@ void *
 
 unimplementedbinary_runner_function =  """\
 void *
-%(nodename)sRunner::run(RegContainer SUPPRESS_UNUSED * reg0,
+%(nodename)sRunner::run(RegContainer SUPPRESS_UNUSED & reg0,
                         %(arg0type)s const SUPPRESS_UNUSED * arg0,
                         %(arg1type)s const SUPPRESS_UNUSED * arg1) const
 {

--- a/src/librdag/entrypt.cc
+++ b/src/librdag/entrypt.cc
@@ -157,10 +157,10 @@ entrypt(const OGNumeric* expr)
       }
     }
 
-    const RegContainer * reg = expr->asOGExpr()->getRegs();
+    const RegContainer& regs = expr->asOGExpr()->getRegs();
     
     // Make a copy of the result because it gets blown away by the deletion of the tree
-    const OGNumeric * answer = (*reg)[0]->copy();
+    const OGNumeric * answer = regs[0]->copy();
     const OGTerminal * returnTerm = answer->asOGTerminal();
     
     if(returnTerm==nullptr)

--- a/src/librdag/entrypt.cc
+++ b/src/librdag/entrypt.cc
@@ -54,10 +54,10 @@ class PrintTreeVisitor: public librdag::Visitor
       cout << "Have OGExpr type ";
       thing->debug_print();
       cout << "\n";
-      librdag::ArgContainer const *tmp = thing->getArgs();
+      const ArgContainer& tmp = thing->getArgs();
       //hmmm perhaps we should either store the args as a raw array, or insist on everything being a vector.
       // anyway, walk over given args
-      for(auto it = tmp->begin();  it != tmp->end(); it++)
+      for(auto it = tmp.begin();  it != tmp.end(); it++)
       {
         _walker->talkandwalk(*(it));
       }

--- a/src/librdag/execution.cc
+++ b/src/librdag/execution.cc
@@ -66,12 +66,12 @@ ExecutionList::ExecutionList(const OGNumeric* tree)
         argPos.pop();
         argPos.push(pos);
         // Get our args
-        const ArgContainer* currentArgs = current->asOGExpr()->getArgs();
+        const ArgContainer& currentArgs = current->asOGExpr()->getArgs();
         // Has our last arg already been traversed?
-        if (pos < currentArgs->size())
+        if (pos < currentArgs.size())
         {
           // No, so go down that child now
-          treePos.push((*currentArgs)[pos]);
+          treePos.push(currentArgs[pos]);
           argPos.push(0);
           dir = Direction::DOWN;
         }
@@ -91,8 +91,8 @@ ExecutionList::ExecutionList(const OGNumeric* tree)
         // We're on our way down, so we need to push the next node on to the stack
         
         // Get the first arg and go down to it
-        const ArgContainer* args = current->asOGExpr()->getArgs();
-        treePos.push((*args)[0]);
+        const ArgContainer& args = current->asOGExpr()->getArgs();
+        treePos.push(args[0]);
         argPos.push(0);
       }
     }

--- a/src/librdag/expressionbase.cc
+++ b/src/librdag/expressionbase.cc
@@ -23,14 +23,10 @@ OGExpr::OGExpr()
 {
   // _regs are safe to immediately own their contents because we don't put anything
   // in them during construction.
-  _regs = new RegContainer();
-  _regs->set_ownership(true);
+  _regs.set_ownership(true);
 }
 
-OGExpr::~OGExpr()
-{
-  delete _regs;
-}
+OGExpr::~OGExpr() {}
 
 const ArgContainer&
 OGExpr::getArgs() const
@@ -56,7 +52,7 @@ OGExpr::asOGExpr() const
   return this;
 }
 
-const RegContainer *
+RegContainer&
 OGExpr::getRegs() const
 {
   return _regs;

--- a/src/librdag/expressionbase.cc
+++ b/src/librdag/expressionbase.cc
@@ -21,8 +21,6 @@ namespace librdag
 
 OGExpr::OGExpr()
 {
-  // _args must be initialised by a subclass.
-  _args = nullptr;
   // _regs are safe to immediately own their contents because we don't put anything
   // in them during construction.
   _regs = new RegContainer();
@@ -31,14 +29,10 @@ OGExpr::OGExpr()
 
 OGExpr::~OGExpr()
 {
-  if (_args != nullptr)
-  {
-    delete _args;
-  }
   delete _regs;
 }
 
-const ArgContainer*
+const ArgContainer&
 OGExpr::getArgs() const
 {
   return _args;
@@ -47,11 +41,11 @@ OGExpr::getArgs() const
 size_t
 OGExpr::getNArgs() const
 {
-  return _args->size();
+  return _args.size();
 }
 
 void
-OGExpr::accept(Visitor &v) const
+OGExpr::accept(Visitor& v) const
 {
   v.visit(this);
 }
@@ -84,11 +78,10 @@ OGUnaryExpr::OGUnaryExpr(const OGNumeric* arg): OGExpr{}
   {
     throw rdag_error("Null operand passed to unary expression");
   }
-  _args = new ArgContainer();
-  _args->push_back(arg);
+  _args.push_back(arg);
   // We got all the way through building the OGUnaryExpr object, so it
   // is now safe to own the arguments.
-  _args->set_ownership(true);
+  _args.set_ownership(true);
 }
 
 OGBinaryExpr::OGBinaryExpr(const OGNumeric* arg0, const OGNumeric* arg1): OGExpr{}
@@ -101,12 +94,11 @@ OGBinaryExpr::OGBinaryExpr(const OGNumeric* arg0, const OGNumeric* arg1): OGExpr
   {
     throw rdag_error("Null operand passed to binary expression in arg1");
   }
-  _args = new ArgContainer();
-  _args->push_back(arg0);
-  _args->push_back(arg1);
+  _args.push_back(arg0);
+  _args.push_back(arg1);
   // We got all the way through building the OGBinaryExpr object, so it
   // is now safe to own the arguments.
-  _args->set_ownership(true);
+  _args.set_ownership(true);
 }
 
 /**
@@ -122,7 +114,7 @@ COPY::COPY(const OGNumeric* arg): OGUnaryExpr{arg} {}
 OGNumeric*
 COPY::copy() const
 {
-  return new COPY((*_args)[0]->copy());
+  return new COPY(_args[0]->copy());
 }
 
 const COPY*
@@ -160,18 +152,17 @@ SELECTRESULT::SELECTRESULT(const OGNumeric* arg0, const OGNumeric* arg1): OGExpr
   {
     throw rdag_error("Second argument of SelectResult is not an integer");
   }
-  _args = new ArgContainer();
-  _args->push_back(arg0);
-  _args->push_back(arg1);
+  _args.push_back(arg0);
+  _args.push_back(arg1);
   // We got all the way through building the SELECTRESULT object, so it
   // is now safe to own the arguments.
-  _args->set_ownership(true);
+  _args.set_ownership(true);
 }
 
 OGNumeric*
 SELECTRESULT::copy() const
 {
-  return new SELECTRESULT((*_args)[0]->copy(), (*_args)[1]->copy());
+  return new SELECTRESULT(_args[0]->copy(), _args[1]->copy());
 }
 
 const SELECTRESULT*
@@ -203,7 +194,7 @@ OGNumeric*
 NORM2::copy() const
 {
 
-  return new NORM2((*_args)[0]->copy());
+  return new NORM2(_args[0]->copy());
 }
 
 const NORM2*
@@ -233,7 +224,7 @@ SVD::SVD(const OGNumeric* arg): OGUnaryExpr{arg} {}
 OGNumeric*
 SVD::copy() const
 {
-  return new SVD((*_args)[0]->copy());
+  return new SVD(_args[0]->copy());
 }
 
 const SVD*
@@ -263,7 +254,7 @@ MTIMES::MTIMES(const OGNumeric* arg0, const OGNumeric* arg1): OGBinaryExpr{arg0,
 OGNumeric*
 MTIMES::copy() const
 {
-  return new MTIMES((*_args)[0]->copy(), (*_args)[1]->copy());
+  return new MTIMES(_args[0]->copy(), _args[1]->copy());
 }
 
 const MTIMES*

--- a/src/librdag/runners/mtimesrunner.cc
+++ b/src/librdag/runners/mtimesrunner.cc
@@ -24,7 +24,7 @@
 
 namespace librdag {
 
-template<typename T> void * mtimes_dense_runner(RegContainer* reg0, const OGMatrix<T>* arg0, const OGMatrix<T>* arg1)
+template<typename T> void * mtimes_dense_runner(RegContainer& reg0, const OGMatrix<T>* arg0, const OGMatrix<T>* arg1)
 {
   int colsArray1 = arg0->getCols();
   int colsArray2 = arg1->getCols();
@@ -79,7 +79,7 @@ template<typename T> void * mtimes_dense_runner(RegContainer* reg0, const OGMatr
     }
   }
   // shove ret into register
-  reg0->push_back(ret);
+  reg0.push_back(ret);
   return nullptr;
 }
 
@@ -87,24 +87,24 @@ template<typename T> void * mtimes_dense_runner(RegContainer* reg0, const OGMatr
 
 
 // MTIMES runner:
-void * MTIMESRunner::run(RegContainer * reg0, const OGComplexMatrix * arg0, const OGComplexMatrix * arg1) const
+void * MTIMESRunner::run(RegContainer& reg0, const OGComplexMatrix * arg0, const OGComplexMatrix * arg1) const
 {
   mtimes_dense_runner(reg0, arg0, arg1);
   return nullptr;
 }
 
 
-void * MTIMESRunner::run(RegContainer* reg0, const OGRealMatrix*    arg0, const OGRealMatrix*    arg1) const
+void * MTIMESRunner::run(RegContainer& reg0, const OGRealMatrix*    arg0, const OGRealMatrix*    arg1) const
 {
   mtimes_dense_runner(reg0, arg0, arg1);
   return nullptr;
 }
 
 void *
-MTIMESRunner::run(RegContainer SUPPRESS_UNUSED * reg0, const OGRealScalar SUPPRESS_UNUSED *    arg0, const OGRealScalar SUPPRESS_UNUSED *    arg1) const
+MTIMESRunner::run(RegContainer& reg0, const OGRealScalar* arg0, const OGRealScalar* arg1) const
 {
     OGTerminal * ret = new OGRealScalar(arg0->getValue()*arg1->getValue());
-    reg0->push_back(ret);
+    reg0.push_back(ret);
     return nullptr;
 }
 

--- a/src/librdag/runners/norm2runner.cc
+++ b/src/librdag/runners/norm2runner.cc
@@ -23,17 +23,17 @@
 namespace librdag {
 
 void *
-NORM2Runner::run(RegContainer * reg, OGRealScalar const * arg) const
+NORM2Runner::run(RegContainer& reg, OGRealScalar const * arg) const
 {
   const OGRealScalar* ret;
   ret = new OGRealScalar(fabs(arg->getValue()));
-  reg->push_back(ret);
+  reg.push_back(ret);
   return nullptr;
 }
 
 template<typename T>
 void
-norm2_dense_runner(RegContainer * reg, OGMatrix<T> const * arg)
+norm2_dense_runner(RegContainer& reg, OGMatrix<T> const * arg)
 {
   const OGRealScalar* ret = nullptr; // the returned item
 
@@ -75,18 +75,18 @@ norm2_dense_runner(RegContainer * reg, OGMatrix<T> const * arg)
   }
 
   // shove ret into register
-  reg->push_back(ret);
+  reg.push_back(ret);
 }
 
 void *
-NORM2Runner::run(RegContainer * reg, OGRealMatrix const * arg) const
+NORM2Runner::run(RegContainer& reg, OGRealMatrix const * arg) const
 {
   norm2_dense_runner(reg, arg);
   return nullptr;
 }
 
 void *
-NORM2Runner::run(RegContainer * reg, OGComplexMatrix const * arg) const
+NORM2Runner::run(RegContainer& reg, OGComplexMatrix const * arg) const
 {
   norm2_dense_runner(reg, arg);
   return nullptr;

--- a/src/librdag/runners/selectresultrunner.cc
+++ b/src/librdag/runners/selectresultrunner.cc
@@ -20,15 +20,15 @@ namespace librdag {
  */
 
 void*
-SELECTRESULTRunner::eval(RegContainer* reg, RegContainer const * arg0, OGIntegerScalar const * arg1) const
+SELECTRESULTRunner::eval(RegContainer& reg, const RegContainer& arg0, OGIntegerScalar const * arg1) const
 {
   return run(reg, arg0, arg1);
 }
 
 void*
-SELECTRESULTRunner::run(RegContainer * reg0, const RegContainer* arg0, const OGIntegerScalar* arg1) const
+SELECTRESULTRunner::run(RegContainer& reg0, const RegContainer& arg0, const OGIntegerScalar* arg1) const
 {
-  reg0->push_back((*arg0)[arg1->getValue()]->copy());
+  reg0.push_back(arg0[arg1->getValue()]->copy());
   return nullptr;
 }
 

--- a/src/librdag/runners/svdrunner.cc
+++ b/src/librdag/runners/svdrunner.cc
@@ -20,7 +20,7 @@
  */
 namespace librdag {
 
-template<typename T> void svd_dense_runner(RegContainer* reg, const OGMatrix<T>* arg)
+template<typename T> void svd_dense_runner(RegContainer& reg, const OGMatrix<T>* arg)
 {
   int m = arg->getRows();
   int n = arg->getCols();
@@ -41,30 +41,30 @@ template<typename T> void svd_dense_runner(RegContainer* reg, const OGMatrix<T>*
   // call lapack
   lapack::xgesvd(lapack::A, lapack::A, &m, &n, A, &lda, S, U, &ldu, VT, &ldvt, &info);
 
-  reg->push_back(makeConcreteDenseMatrix(U, m, m, OWNER));
-  reg->push_back(new OGRealDiagonalMatrix(S, m, n, OWNER));
-  reg->push_back(makeConcreteDenseMatrix(VT, n, n, OWNER));
+  reg.push_back(makeConcreteDenseMatrix(U, m, m, OWNER));
+  reg.push_back(new OGRealDiagonalMatrix(S, m, n, OWNER));
+  reg.push_back(makeConcreteDenseMatrix(VT, n, n, OWNER));
   delete[] A;
 }
 
 void *
-SVDRunner::run(RegContainer *reg, OGRealScalar const *arg) const
+SVDRunner::run(RegContainer& reg, OGRealScalar const *arg) const
 {
   // real space svd is just u=1, s=value, v=1
-  reg->push_back(new OGRealScalar(1.e0));
-  reg->push_back(new OGRealScalar(arg->getValue()));
-  reg->push_back(new OGRealScalar(1.e0));
+  reg.push_back(new OGRealScalar(1.e0));
+  reg.push_back(new OGRealScalar(arg->getValue()));
+  reg.push_back(new OGRealScalar(1.e0));
   return nullptr;
 }
 void *
-SVDRunner::run(RegContainer *reg, OGRealMatrix const *arg) const
+SVDRunner::run(RegContainer& reg, OGRealMatrix const *arg) const
 {
   svd_dense_runner(reg, arg);
   return nullptr;
 }
 
 void *
-SVDRunner::run(RegContainer *reg, OGComplexMatrix const *arg) const
+SVDRunner::run(RegContainer& reg, OGComplexMatrix const *arg) const
 {
   svd_dense_runner(reg, arg);
   return nullptr;

--- a/src/librdag/test/check_dispatch.cc
+++ b/src/librdag/test/check_dispatch.cc
@@ -39,8 +39,8 @@ TEST(DispatchTest, SimpleTest) {
     val = *it;
     dispatchfn(val);
   }
-  const RegContainer * reg = plus->getRegs();
-  const OGNumeric * answer = (*reg)[0];
+  const RegContainer& reg = plus->getRegs();
+  const OGNumeric * answer = reg[0];
   answer->debug_print();
   delete plus;
   delete el1;

--- a/src/librdag/test/check_expressions.cc
+++ b/src/librdag/test/check_expressions.cc
@@ -25,9 +25,9 @@ TYPED_TEST_P(BinaryExprTest, Functionality){
   OGComplexScalar *complx = new OGComplexScalar(complex16(2.7182, 2.7182));
   TypeParam *expr = new TypeParam(real, complx);
   ASSERT_EQ(2, expr->getNArgs());
-  const ArgContainer* gotArgs = expr->getArgs();
-  EXPECT_EQ(real, ((*gotArgs)[0])->asOGRealScalar());
-  EXPECT_EQ(complx, ((*gotArgs)[1])->asOGComplexScalar());
+  const ArgContainer& gotArgs = expr->getArgs();
+  EXPECT_EQ(real, (gotArgs[0])->asOGRealScalar());
+  EXPECT_EQ(complx, (gotArgs[1])->asOGComplexScalar());
 
   // Debug string
   expr->debug_print();
@@ -57,8 +57,8 @@ TYPED_TEST_P(UnaryExprTest, Functionality){
   OGRealScalar *real = new OGRealScalar(3.14);
   TypeParam *expr = new TypeParam(real);
   ASSERT_EQ(1, expr->getNArgs());
-  const ArgContainer* gotArgs = expr->getArgs();
-  EXPECT_EQ(real, ((*gotArgs)[0])->asOGRealScalar());
+  const ArgContainer& gotArgs = expr->getArgs();
+  EXPECT_EQ(real, (gotArgs[0])->asOGRealScalar());
 
   // Debug string
   expr->debug_print();
@@ -84,9 +84,9 @@ TEST(OGExprTest, SELECTRESULT){
   OGIntegerScalar *index = new OGIntegerScalar(2);
   OGExpr *selectresult = new SELECTRESULT(real, index);
   ASSERT_EQ(2, selectresult->getNArgs());
-  const ArgContainer* gotArgs = selectresult->getArgs();
-  EXPECT_EQ(real, ((*gotArgs)[0])->asOGRealScalar());
-  EXPECT_EQ(index, ((*gotArgs)[1])->asOGIntegerScalar());
+  const ArgContainer& gotArgs = selectresult->getArgs();
+  EXPECT_EQ(real, (gotArgs[0])->asOGRealScalar());
+  EXPECT_EQ(index, (gotArgs[1])->asOGIntegerScalar());
 
   // Debug string
   selectresult->debug_print();
@@ -221,12 +221,11 @@ TEST(VirtualCopyTest, COPY) {
   COPY *copy1 = new COPY(real);
   COPY const *copy2 = copy1->copy()->asCOPY();
   ASSERT_NE(nullptr, copy2);
-  const ArgContainer* a1 = copy1->getArgs();
-  const ArgContainer* a2 = copy2->getArgs();
-  EXPECT_NE(a1, a2);
-  EXPECT_EQ(a1->size(), a2->size());
-  const OGNumeric* c1arg1 = (*a1)[0];
-  const OGNumeric* c2arg1 = (*a2)[0];
+  const ArgContainer& a1 = copy1->getArgs();
+  const ArgContainer& a2 = copy2->getArgs();
+  EXPECT_EQ(a1.size(), a2.size());
+  const OGNumeric* c1arg1 = a1[0];
+  const OGNumeric* c2arg1 = a2[0];
   EXPECT_NE(c1arg1, c2arg1);
   const OGRealScalar* c1s = c1arg1->asOGRealScalar();
   const OGRealScalar* c2s = c2arg1->asOGRealScalar();
@@ -243,15 +242,14 @@ TEST(VirtualCopyTest, PLUS) {
   PLUS *plus1 = new PLUS(real1, real2);
   const PLUS *plus2 = plus1->copy()->asPLUS();
   ASSERT_NE(nullptr, plus2);
-  const ArgContainer* a1 = plus1->getArgs();
-  const ArgContainer* a2 = plus2->getArgs();
-  EXPECT_NE(a1, a2);
-  EXPECT_EQ(a1->size(), a2->size());
-  const OGNumeric* p1arg1 = (*a1)[0];
-  const OGNumeric* p2arg1 = (*a2)[0];
+  const ArgContainer& a1 = plus1->getArgs();
+  const ArgContainer& a2 = plus2->getArgs();
+  EXPECT_EQ(a1.size(), a2.size());
+  const OGNumeric* p1arg1 = a1[0];
+  const OGNumeric* p2arg1 = a2[0];
   EXPECT_NE(p1arg1, p2arg1);
-  const OGNumeric* p1arg2 = (*a1)[1];
-  const OGNumeric* p2arg2 = (*a2)[1];
+  const OGNumeric* p1arg2 = a1[1];
+  const OGNumeric* p2arg2 = a2[1];
   EXPECT_NE(p1arg2, p2arg2);
   const OGRealScalar* p1s1 = p1arg1->asOGRealScalar();
   const OGRealScalar* p2s1 = p2arg1->asOGRealScalar();
@@ -272,12 +270,11 @@ TEST(VirtualCopyTest, NEGATE) {
   NEGATE *negate1 = new NEGATE(real1);
   const NEGATE *negate2 = negate1->copy()->asNEGATE();
   ASSERT_NE(nullptr, negate2);
-  const ArgContainer* a1 = negate1->getArgs();
-  const ArgContainer* a2 = negate2->getArgs();
-  EXPECT_NE(a1, a2);
-  EXPECT_EQ(a1->size(), a2->size());
-  const OGNumeric* n1arg1 = (*a1)[0];
-  const OGNumeric* n2arg1 = (*a2)[0];
+  const ArgContainer& a1 = negate1->getArgs();
+  const ArgContainer& a2 = negate2->getArgs();
+  EXPECT_EQ(a1.size(), a2.size());
+  const OGNumeric* n1arg1 = a1[0];
+  const OGNumeric* n2arg1 = a2[0];
   EXPECT_NE(n1arg1, n2arg1);
   const OGRealScalar* n1s1 = n1arg1->asOGRealScalar();
   const OGRealScalar* n2s1 = n2arg1->asOGRealScalar();
@@ -294,12 +291,11 @@ TEST(VirtualCopyTest, SVD) {
   SVD *svd1 = new SVD(realMat);
   SVD const *svd2 = svd1->copy()->asSVD();
   ASSERT_NE(nullptr, svd2);
-  const ArgContainer* a1 = svd1->getArgs();
-  const ArgContainer* a2 = svd2->getArgs();
-  EXPECT_NE(a1, a2);
-  EXPECT_EQ(a1->size(), a2->size());
-  const OGNumeric* s1arg1 = (*a1)[0];
-  const OGNumeric* s2arg1 = (*a2)[0];
+  const ArgContainer& a1 = svd1->getArgs();
+  const ArgContainer& a2 = svd2->getArgs();
+  EXPECT_EQ(a1.size(), a2.size());
+  const OGNumeric* s1arg1 = a1[0];
+  const OGNumeric* s2arg1 = a2[0];
   EXPECT_NE(s1arg1, s2arg1);
   const OGRealMatrix* s1m = s1arg1->asOGRealMatrix();
   const OGRealMatrix* s2m = s2arg1->asOGRealMatrix();
@@ -321,15 +317,14 @@ TEST(VirtualCopyTest, SELECTRESULT) {
   SELECTRESULT *sr1 = new SELECTRESULT(svd, i);
   const SELECTRESULT *sr2 = sr1->copy()->asSELECTRESULT();
   ASSERT_NE(nullptr, sr2);
-  const ArgContainer* a1 = sr1->getArgs();
-  const ArgContainer* a2 = sr2->getArgs();
-  EXPECT_NE(a1, a2);
-  EXPECT_EQ(a1->size(), a2->size());
-  const OGNumeric* sr1arg1 = (*a1)[0];
-  const OGNumeric* sr2arg1 = (*a2)[0];
+  const ArgContainer& a1 = sr1->getArgs();
+  const ArgContainer& a2 = sr2->getArgs();
+  EXPECT_EQ(a1.size(), a2.size());
+  const OGNumeric* sr1arg1 = a1[0];
+  const OGNumeric* sr2arg1 = a2[0];
   EXPECT_NE(sr1arg1, sr2arg1);
-  const OGNumeric* sr1arg2 = (*a1)[1];
-  const OGNumeric* sr2arg2 = (*a2)[1];
+  const OGNumeric* sr1arg2 = a1[1];
+  const OGNumeric* sr2arg2 = a2[1];
   EXPECT_NE(sr1arg2, sr2arg2);
   const SVD* sr1svd = sr1arg1->asSVD();
   const SVD* sr2svd = sr2arg1->asSVD();

--- a/src/librdag/test/nodes/check_selectresult.cc
+++ b/src/librdag/test/nodes/check_selectresult.cc
@@ -38,8 +38,7 @@ TEST(SELECTRESULTTests,CheckBehaviour)
   {
     d->dispatch(*it);
   }
-  const RegContainer * regs = s0->getRegs();
-  const OGNumeric * answer = (*regs)[0];
+  const OGNumeric * answer = s0->getRegs()[0];
   EXPECT_TRUE((*one) ==~ (*(answer->asOGTerminal())));
 
   // Check selecting 1 (S)
@@ -49,8 +48,7 @@ TEST(SELECTRESULTTests,CheckBehaviour)
   {
     d->dispatch(*it);
   }
-  regs = s1->getRegs();
-  answer = (*regs)[0];
+  answer = s1->getRegs()[0];
   EXPECT_TRUE((*r0) ==~ (*(answer->asOGTerminal())));
 
   // Check selecting 2 (V)
@@ -60,8 +58,7 @@ TEST(SELECTRESULTTests,CheckBehaviour)
   {
     d->dispatch(*it);
   }
-  regs = s2->getRegs();
-  answer = (*regs)[0];
+  answer = s2->getRegs()[0];
   EXPECT_TRUE((*one) ==~ (*(answer->asOGTerminal())));
 
   // Clean up

--- a/src/librdag/test/nodes/check_svd.cc
+++ b/src/librdag/test/nodes/check_svd.cc
@@ -38,8 +38,7 @@ TEST(SVDTests,CheckScalar)
   {
     d->dispatch(*it);
   }
-  const RegContainer * regs = s0->getRegs();
-  const OGNumeric * answer = (*regs)[0];
+  const OGNumeric * answer = s0->getRegs()[0];
   EXPECT_TRUE((*one) ==~ (*(answer->asOGTerminal())));
 
   // Check selecting 1 (S)
@@ -49,8 +48,7 @@ TEST(SVDTests,CheckScalar)
   {
     d->dispatch(*it);
   }
-  regs = s1->getRegs();
-  answer = (*regs)[0];
+  answer = s1->getRegs()[0];
   EXPECT_TRUE((*r0) ==~ (*(answer->asOGTerminal())));
 
   // Check selecting 2 (V)
@@ -60,8 +58,7 @@ TEST(SVDTests,CheckScalar)
   {
     d->dispatch(*it);
   }
-  regs = s2->getRegs();
-  answer = (*regs)[0];
+  answer = s2->getRegs()[0];
   EXPECT_TRUE((*one) ==~ (*(answer->asOGTerminal())));
 
   // Clean up
@@ -90,8 +87,6 @@ TEST(SVDTests,CheckRealMatrix)
 
   // computed answer pointers
   const OGNumeric * answerU, * answerS, * answerVT, * reconstruct;
-  // computed answer reg containers
-  const RegContainer * regs0, * regs1, * regs2, * regs3;
 
   Dispatcher * d = new Dispatcher();
 
@@ -102,8 +97,7 @@ TEST(SVDTests,CheckRealMatrix)
   {
     d->dispatch(*it);
   }
-  regs0 = s0->getRegs();
-  answerU = (*regs0)[0];
+  answerU = s0->getRegs()[0];
   EXPECT_TRUE((*U) % (*(answerU->asOGTerminal())));
 
   // Check selecting 1 (S)
@@ -113,8 +107,7 @@ TEST(SVDTests,CheckRealMatrix)
   {
     d->dispatch(*it);
   }
-  regs1 = s1->getRegs();
-  answerS = (*regs1)[0];
+  answerS = s1->getRegs()[0];
   EXPECT_TRUE((*S) ==~ (*(answerS->asOGTerminal())));
 
   // Check selecting 2 (V)
@@ -124,8 +117,7 @@ TEST(SVDTests,CheckRealMatrix)
   {
     d->dispatch(*it);
   }
-  regs2 = s2->getRegs();
-  answerVT = (*regs2)[0];
+  answerVT = s2->getRegs()[0];
   EXPECT_TRUE((*VT) % (*(answerVT->asOGTerminal())));
 
   // reconstruction test i.e. recover A from U,S,V**T as A=U*S*V**T
@@ -137,8 +129,7 @@ TEST(SVDTests,CheckRealMatrix)
   {
     d->dispatch(*it);
   }
-  regs3 = m2->getRegs();
-  reconstruct = (*regs3)[0];
+  reconstruct = m2->getRegs()[0];
   EXPECT_TRUE((*M) ==~ (*(reconstruct->asOGTerminal())));
 
   // Clean up
@@ -173,8 +164,6 @@ TEST(SVDTests,CheckComplexMatrix)
 
   // computed answer pointers
   const OGNumeric * answerU, * answerS, * answerVT, * reconstruct;
-  // computed answer reg containers
-  const RegContainer * regs0, * regs1, * regs2, * regs3;
 
   Dispatcher * d = new Dispatcher();
 
@@ -185,8 +174,7 @@ TEST(SVDTests,CheckComplexMatrix)
   {
     d->dispatch(*it);
   }
-  regs0 = s0->getRegs();
-  answerU = (*regs0)[0];
+  answerU = s0->getRegs()[0];
   EXPECT_TRUE((*U) % (*(answerU->asOGTerminal())));
 
   // Check selecting 1 (S)
@@ -196,8 +184,7 @@ TEST(SVDTests,CheckComplexMatrix)
   {
     d->dispatch(*it);
   }
-  regs1 = s1->getRegs();
-  answerS = (*regs1)[0];
+  answerS = s1->getRegs()[0];
   EXPECT_TRUE((*S) ==~ (*(answerS->asOGTerminal())));
 
   // Check selecting 2 (V)
@@ -207,8 +194,7 @@ TEST(SVDTests,CheckComplexMatrix)
   {
     d->dispatch(*it);
   }
-  regs2 = s2->getRegs();
-  answerVT = (*regs2)[0];
+  answerVT = s2->getRegs()[0];
   EXPECT_TRUE((*VT) % (*(answerVT->asOGTerminal())));
 
   // reconstruction test i.e. recover A from U,S,V**T as A=U*S*V**T
@@ -220,8 +206,7 @@ TEST(SVDTests,CheckComplexMatrix)
   {
     d->dispatch(*it);
   }
-  regs3 = m2->getRegs();
-  reconstruct = (*regs3)[0];
+  reconstruct = m2->getRegs()[0];
   // FP fuzz causes grief on reconstruction
   EXPECT_TRUE(ArrayFuzzyEquals(M->asOGComplexMatrix()->getData(),reconstruct->asOGComplexMatrix()->getData(),1e-15,1e-15));
 

--- a/src/librdag/test/nodes/testnodes.cc
+++ b/src/librdag/test/nodes/testnodes.cc
@@ -83,8 +83,8 @@ CheckUnary<T>::execute()
     v->dispatch(*it);
     delete v;
   }
-  const RegContainer * regs = node->getRegs();
-  const OGNumeric * answer = (*regs)[0];
+  const RegContainer& regs = node->getRegs();
+  const OGNumeric * answer = regs[0];
   this->_resultPair = new ResultPair(answer->asOGTerminal()->createOwningCopy(), this->getExpected());
   delete node;
   delete el1;
@@ -149,8 +149,8 @@ CheckBinary<T>::execute()
     v->dispatch(*it);
     delete v;
   }
-  const RegContainer * regs = node->getRegs();
-  const OGNumeric * answer = (*regs)[0];
+  const RegContainer& regs = node->getRegs();
+  const OGNumeric* answer = regs[0];
   this->_resultPair = new ResultPair(answer->asOGTerminal()->createOwningCopy(), this->getExpected());
   delete node;
   delete el1;


### PR DESCRIPTION
This simplifies memory management, as part of the process of avoiding leaks when exceptions are thrown. Since pointers to these members were previously returned, we now return references to them, this also simplifies syntax in a lot of places, reducing the need for explicit dereferences.

Rationale: 
- There is a 1:1 relationship between ArgContainers and Exprs, so we don't need to use pointers to hold ArgContainers.
- There is also a 1:1 relationship between RegContainers and Exprs. This may change in future if we adopt some more advanced allocation scheme - however for now, it is better to have a simpler implementation rather than a future-proof one, especially given the difficulty of testing jshim code.

Buildbot pass: http://devmaths-lx-1:8011/builders/nyqwk2-testing/builds/848
Coverage:
Java: 91%
build/src/jshim: 0.6%
build/src/librdag: 13.5%
src/jshim: 61.3%
src/librdag: 91.3%
src/librdag/runners: 100%

All unchanged except librdag, which is down 0.1% because we don't have code for creating and deleting `_args` and `_regs` anymore
