### PR TITLE
[MAT-336] Procedural expression convertor

### DIFF
--- a/include/exprfactory.hh
+++ b/include/exprfactory.hh
@@ -13,8 +13,7 @@ using librdag::OGNumeric;
 
 namespace convert {
 
-vector<const OGNumeric*>* generateArgs(jobject obj);
 OGNumeric* createExpression(jobject obj);
-OGNumeric* createExprWithID(jlong ID, jobject obj);
+OGNumeric* translateNode(JNIEnv* env, jobject obj, const OGNumeric* arg0 = nullptr, const OGNumeric* arg1 = nullptr);
 
 } // namespace convert

--- a/src/generator/createexprtemplates.py
+++ b/src/generator/createexprtemplates.py
@@ -25,26 +25,25 @@ namespace convert {
 
 using namespace librdag;
 
-OGNumeric* createExprWithID(jlong ID, jobject obj)
+OGNumeric* translateNode(JNIEnv* env, jobject obj, const OGNumeric* arg0, const OGNumeric* arg1)
 {
   librdag::OGNumeric * _expr = nullptr;
-  vector<const OGNumeric*>* args;
 
-  switch(ID)
+  // Get the type of the node
+  jobject typeobj = env->CallObjectMethod(obj, JVMManager::getOGNumericClazz_getType());
+  checkEx(env);
+  jlong type = env->GetLongField(typeobj, JVMManager::getOGExprEnumClazz__hashdefined());
+
+  switch(type)
   {
 %(switch_cases)s
   default:
   {
     stringstream s;
-    s << "Unknown node type " << ID;
+    s << "Unknown node type " << type;
     throw convert_error(s.str());
   }
   break;
-  }
-
-  if(_expr == nullptr)
-  {
-    throw convert_error("_expr is NULL, and probably hasn't been set by the factory");
   }
 
   return _expr;
@@ -63,11 +62,10 @@ terminal_case = """\
 expr_case = """\
     case %(enumname)s:
       DEBUG_PRINT("%(typename)s function\\n");
-      args = generateArgs(obj);
       _expr = new %(typename)s(%(args)s);
       break;
 """
 
-unary_args = "(*args)[0]"
+unary_args = "arg0"
 
-binary_args = "(*args)[0], (*args)[1]"
+binary_args = "arg0, arg1"

--- a/src/jshim/exprfactory.cc
+++ b/src/jshim/exprfactory.cc
@@ -4,7 +4,7 @@
  * Please see distribution for license.
  */
 
-#include <stdexcept>
+#include <stack>
 #include "numeric.hh"
 #include "exprfactory.hh"
 #include "jvmmanager.hh"
@@ -15,47 +15,224 @@ namespace convert {
 using namespace librdag;
 
 /**
- * Generate the libRDAG expression objects for a given Java object
- * @param obj a Java OGNumeric type
- * @return a pointer to a vector of pointers that point at the arguments. This return type is
- * temporary, and will disappear when the tree generation is converted to the procedural variant.
+ * Represents direction of traversal through a Java expression tree
  */
-vector<const OGNumeric*>* generateArgs(jobject obj)
+enum class Direction { UP, DOWN };
+
+/**
+ * Get the args of a Java expression node
+ * @param env the JNI environment pointer
+ * @param obj the Java expression node
+ * @return the array of args
+ */
+jobjectArray getArgs(JNIEnv* env, jobject obj)
 {
-  // get object array
   jmethodID method = JVMManager::getOGExprClazz_getExprs();
-  JNIEnv *env = nullptr;
-  JVMManager::getEnv((void **)&env);
   jobject dataobj = JVMManager::callObjectMethod(env, obj, method);
-  jobjectArray * args = reinterpret_cast<jobjectArray *>(&dataobj);
-  jsize len = env->GetArrayLength((jarray)*args);
-  DEBUG_PRINT("JOGExpr arg size is %d\n",(int)len);
-  vector<const OGNumeric*>* local_args = new vector<const OGNumeric*>();
-  for(int i=0; i<len; i++)
-  {
-    jobject tmp = (jobject) env->GetObjectArrayElement(*args, i);
-    checkEx(env);
-    local_args->push_back(createExpression(tmp));
-  }
-  return local_args;
+  checkEx(env);
+  return static_cast<jobjectArray>(dataobj);
 }
+
+/**
+ * Get the type of a Java expression node
+ * @param env the JNI environment pointer
+ * @param obj the Java expression node
+ * @return the type ID, which corresponds to the value in the expression type enum
+ */
+jlong getType(JNIEnv* env, jobject obj)
+{
+  jobject typeobj = env->CallObjectMethod(obj, JVMManager::getOGNumericClazz_getType());
+  checkEx(env);
+  return env->GetLongField(typeobj, JVMManager::getOGExprEnumClazz__hashdefined());
+}
+
+/**
+ * A jnode struct is for convenience - when traversing the Java tree, we get
+ * the arguments and number of arguments in order to do the correct traversal.
+ * The arguments are then required in stage 2, where the linearised list of
+ * Java tree nodes are converted to RDAG objects. The jnode is used to cache
+ * a Java expression node with its arguments, so they don't have to be
+ * retrieved a second time in stage 2.
+ */
+struct jnode
+{
+  jobject obj;
+  jobjectArray args;
+  jsize nArgs;
+
+  /**
+   * Construct a jnode from an object for convenience.
+   * @param env the JNI environment pointer (required to get the arguments)
+   * @param o the object from which to construct the jnode
+   */
+  jnode(JNIEnv* env, jobject o): obj{o}
+  {
+    if (!(getType(env, obj) & IS_NODE_MASK))
+    {
+      args = nullptr;
+      nArgs = 0;
+    }
+    else
+    {
+      args = getArgs(env, obj);
+      nArgs = env->GetArrayLength((jarray) args);
+    }
+  }
+};
 
 /**
  * Generates an RDAG expression tree from a java object
  * @param obj a Java OGNumeric type
  * @return the equivalent RDAG expression
  */
-OGNumeric* createExpression(jobject obj)
+OGNumeric* createExpression(jobject jexpr)
 {
-  DEBUG_PRINT("In createExpression\n");
-  JNIEnv *env=nullptr;
-  JVMManager::getEnv((void **)&env);
-  jobject typeobj = env->CallObjectMethod(obj, JVMManager::getOGNumericClazz_getType());
-  checkEx(env);
-  jlong ID = env->GetLongField(typeobj, JVMManager::getOGExprEnumClazz__hashdefined());
-  VAL64BIT_PRINT("Class type", ID);
+  JNIEnv* env = nullptr;
+  JVMManager::getEnv((void **) &env);
 
-  return createExprWithID(ID, obj);
+  // Stage 1: linearise java tree
+
+  // We want to be able to build the Rdag tree by starting with the last node visited
+  // here. So we do a simple depth-first traversal to linearise the tree, then the
+  // Rdag tree construction can work through the stack to get nodes in reverse order.
+
+  // Exceptions: stage 1 uses all stack-allocated variables and only deals with
+  // local references, so no explicit cleanup is required if an exception is thrown.
+
+  // jexprs is the stack containing the Java objects in the order they need to be
+  // translated. We store a jnode, which holds its arguments and number of arguments
+  // as well.
+  vector<jnode> jexprs;
+  // Workjexprs is our working stack of Java expression objects.
+  stack<jnode> workJexprs;
+  // argPos is a temporary state for recording how far we got through getting the args of a
+  // particular node.
+  stack<jsize> argPos;
+
+  // Start by going downwards
+  Direction dir = Direction::DOWN;
+
+  // Initialise stacks with the root node, we're starting at arg position 0
+
+  jnode firstNode{ env, jexpr };
+  workJexprs.push(firstNode);
+  argPos.push(0);
+
+  while (!workJexprs.empty())
+  {
+    // Get the next work item
+    jnode current = workJexprs.top();
+
+    if (!(getType(env, current.obj) & IS_NODE_MASK))
+    {
+      // We've got a terminal, This node is next to execute
+      jexprs.push_back(current);
+      // Go back up to where we came from, by removing this node from the work stacks
+      workJexprs.pop();
+      argPos.pop();
+      dir = Direction::UP;
+    }
+    else
+    {
+      // We've got an expression
+      if (dir == Direction::UP)
+      {
+        // We were on our way up, so we need to find out whether to go down again
+        // through the next arg, or further back up.
+
+        // Get the index of the next argument
+        jint pos = argPos.top() + 1;
+        // Save the new index position back in argPos
+        argPos.pop();
+        argPos.push(pos);
+        // Has our last arg already been traversed?
+        if (pos < current.nArgs)
+        {
+          // No, so go down that child now
+          jobject nextObj = (jobject) env->GetObjectArrayElement(current.args, pos);
+          checkEx(env);
+          jnode nextNode{ env, nextObj };
+          workJexprs.push(nextNode);
+          argPos.push(0);
+          dir = Direction::DOWN;
+        }
+        else
+        {
+          // Yes, so current node is next in execution list and we need to carry on upwards
+
+          // Current node is next in the execution list
+          jexprs.push_back(current);
+          // Go back to the previous node by removing this one from the stack
+          argPos.pop();
+          workJexprs.pop();
+        }
+      }
+      else
+      {
+        // We're on our way down, so we need to push the next node on to the stack
+
+        // Get the first arg and go down to it
+        jobject nextObj = (jobject) env->GetObjectArrayElement(current.args, 0);
+        checkEx(env);
+        jnode nextNode{ env, nextObj };
+        workJexprs.push(nextNode);
+        argPos.push(0);
+      }
+    }
+  }
+
+  // Stage 2: construct Rdag tree
+
+  // We iterate over the list of jexprs and construct the corresponding C++ node. When a
+  // node is constructed, we push it on a stack. When we have construct an expression,
+  // we need to pop the N nodes from the stack where N is the number of args it has.
+  //
+  // At the end of the iteration, there should be a single node left on the stack.
+  // This node is the root of the expression tree.
+
+  // Holds partially-constructed expressions that form part of our arguments.
+  stack<OGNumeric*> exprStack;
+
+  for(auto node: jexprs)
+  {
+    OGNumeric* numeric;
+    const OGNumeric* arg0;
+    const OGNumeric* arg1;
+
+    switch (node.nArgs)
+    {
+    case 0:
+      // This is a terminal, and requires no args
+      numeric = translateNode(env, node.obj);
+      break;
+    case 1:
+      // This is a UnaryExpr
+      numeric = translateNode(env, node.obj, exprStack.top());
+      exprStack.pop();
+      break;
+    case 2:
+      // This is a BinaryExpr
+      arg1 = exprStack.top();
+      exprStack.pop();
+      arg0 = exprStack.top();
+      exprStack.pop();
+      numeric = translateNode(env, node.obj, arg0, arg1);
+      break;
+    default:
+      throw convert_error("Unexpected number of args for expr in stage 2 of conversion");
+    }
+
+    exprStack.push(numeric);
+  }
+
+  if (exprStack.size() != 1)
+  {
+    throw convert_error("Translated expression has multiple roots - "
+                        "something must have gone wrong in createExpression");
+  }
+
+  return exprStack.top();
 }
+
 
 } // namespace convert


### PR DESCRIPTION
Cleaning up when an exception occurs is not yet implemented. However, this is written such that cleaning up is possible. The traversal algorithm is similar to that used by the execution list linearisation, but the implementation is different enough due to all the JNI things that need to be done that I thought it would be counterproductive to try and use a single implementation for both.

The conversion happens in two stages - in the first stage, all the information required to construct the new expression is gathered, and is stored in a `vector` of `jnode` objects. In the second stage, this vector is iterated along to construct the RDAG tree. 

Buildbot pass: http://devmaths-lx-1:8011/builders/nyqwk2-testing/builds/851

Coverage:

Java: 91%
build/src/jshim: 0.8%
build/src/librdag: 13.5%
src/jshim: 57.7%
src/librdag: 91.3%
src/librdag/runners: 100%

All unchanged except for src/jshim, which has dropped because the expression translation is not tested from the C++ side, and the procedural translation in two stages is much longer than the original recursive implementation.
