### PR TITLE
Mat 368 cont.

### DIFF
--- a/include/lapack.hh
+++ b/include/lapack.hh
@@ -155,7 +155,7 @@ template<typename T> void xgemm(char * TRANSA, char * TRANSB, int * M, int * N, 
 /**
  * xnrm2 generalised 2-norm implementation
  * @param N as BLAS dnrm2 N
- * @param A data type specific with intent as BLAS dnrm2 A
+ * @param X data type specific with intent as BLAS dnrm2 X
  * @param INCX as BLAS dnrm2 INCX
  * @return the 2-norm of X
  */
@@ -172,7 +172,6 @@ template<typename T> real16 xnrm2(int * N, T * X, int * INCX);
  * @param A data type specific with intent as LAPACK dgesvd A
  * @param LDA as LAPACK dgesvd LDA
  * @param S as LAPACK dgesvd S
- * @param T as LAPACK dgesvd T
  * @param U as LAPACK dgesvd U
  * @param LDU as LAPACK dgesvd LDU
  * @param VT as LAPACK dgesvd VT

--- a/include/lapack.hh
+++ b/include/lapack.hh
@@ -37,6 +37,33 @@ extern "C" real16 F77FUNC(dznrm2)(int * N, complex16 * X, int * INCX);
 extern "C" void F77FUNC(dgesvd)(char * JOBU, char * JOBVT, int * M, int * N, real16 * A, int * LDA, real16 * S, real16 * U, int * LDU, real16 * VT, int * LDVT, real16 * WORK, int * LWORK, int * INFO);
 extern "C" void F77FUNC(zgesvd)(char * JOBU, char * JOBVT, int * M, int * N, complex16 * A, int * LDA, real16 * S, complex16 * U, int * LDU, complex16 * VT, int * LDVT, complex16 * WORK, int * LWORK, real16 * RWORK, int * INFO);
 
+// Reciprocal condition number estimates
+extern "C" void F77FUNC(dtrcon)(char * NORM, char * UPLO, char * DIAG, int * N, real16 * A, int * LDA, real16 * RCOND, real16 * WORK, int * IWORK, int * INFO);
+extern "C" void F77FUNC(ztrcon)(char * NORM, char * UPLO, char * DIAG, int * N, complex16 * A, int * LDA, real16 * RCOND, complex16 * WORK, real16 * IWORK, int * INFO);
+
+
+// solves a triangular system of the form : A * X = B  or  A**T * X = B
+extern "C" void F77FUNC(dtrtrs)(char * UPLO, char * TRANS, char * DIAG, int * N, int * NRHS, real16 * A, int * LDA, real16 * B, int * LDB, int * INFO);
+extern "C" void F77FUNC(ztrtrs)(char * UPLO, char * TRANS, char * DIAG, int * N, int * NRHS, complex16 * A, int * LDA, complex16 * B, int * LDB, int * INFO);
+
+// Cholesky factorisation for s.p.d matrices
+extern "C" void F77FUNC(dpotrf)(char * UPLO, int * N, real16 * A, int * LDA, int * INFO);
+extern "C" void F77FUNC(zpotrf)(char * UPLO, int * N, complex16 * A, int * LDA, int * INFO);
+
+// Reciprocal condition estimate in the 1-norm of a Cholesky decomposition as computed by xpotrf
+extern "C" void F77FUNC(dpocon)(char * UPLO, int * N, real16 * A, int * LDA, real16 * ANORM, real16 * RCOND, real16 * WORK, int * IWORK, int * INFO);
+extern "C" void F77FUNC(zpocon)(char * UPLO, int * N, complex16 * A, int * LDA, real16 * ANORM, real16 * RCOND, complex16 * WORK, real16 * RWORK, int * INFO);
+
+// Norm calculators for symmetric matrices
+extern "C" real16 F77FUNC(dlansy)(char * NORM, char * UPLO, int * N, real16 * A, int * LDA, real16 * WORK);
+extern "C" real16 F77FUNC(zlansy)(char * NORM, char * UPLO, int * N, complex16 * A, int * LDA, real16 * WORK);
+
+// Cholesky based solvers
+extern "C" void F77FUNC(dpotrs)(char * UPLO, int * N, int * NRHS, real16 * A, int * LDA, real16 * B, int * LDB, int * INFO);
+extern "C" void F77FUNC(zpotrs)(char * UPLO, int * N, int * NRHS, complex16 * A, int * LDA, complex16 * B, int * LDB, int * INFO);
+
+
+
 /**
  * The lapack namespace contains templated variants of functions that vary <real16,complex16> in their signature. In places the <real16,complex16> versions of a function require different
  * parameters effort is made to give a single interface with e.g. workspace handling taken care of.
@@ -50,6 +77,11 @@ namespace detail
 extern char N;
 extern char A;
 extern char T;
+extern char L;
+extern char U;
+extern char D;
+extern char ONE;
+extern char O;
 extern int ione;
 extern real16 rone;
 extern complex16 cone;
@@ -70,6 +102,26 @@ extern char * A;
  * The F77 character 'T'
  */
 extern char * T;
+/**
+ * The F77 character 'L'
+ */
+extern char * L;
+/**
+ * The F77 character 'U'
+ */
+extern char * U;
+/**
+ * The F77 character 'D'
+ */
+extern char * D;
+/**
+ * The F77 character '1'
+ */
+extern char * ONE;
+/**
+ * The F77 character 'O'
+ */
+extern char * O;
 /**
  * The F77 integer '1'
  */
@@ -120,6 +172,86 @@ template<typename T> real16 xnrm2(int * N, T * X, int * INCX);
  * xgesvd general svd implementation that takes care of workspaces
  */
 template<typename T> void xgesvd(char * JOBU, char * JOBVT, int * M, int * N, T * A, int * LDA, real16 * S, T * U, int * LDU, T * VT, int * LDVT, int * INFO);
+
+/**
+ * xtrcon general triangular matrix condition number estimate
+ * @param NORM as LAPACK dtrcon NORM
+ * @param UPLO as LAPACK dtrcon UPLO
+ * @param DIAG as LAPACK dtrcon DIAG
+ * @param N as LAPACK dtrcon N
+ * @param A data type specific with intent as LAPACK dtrcon A
+ * @param LDA as LAPACK dtrcon LDA
+ * @param RCOND as LAPACK dtrcon RCOND
+ * @param INFO as LAPACK dtrcon INFO
+ * @throws rdag_error on illegal input
+ */
+template<typename T> void xtrcon(char * NORM, char * UPLO, char * DIAG, int * N, T * A, int * LDA, real16 * RCOND, int * INFO);
+
+
+/**
+ * Solves a triangular system of the form : A * X = B  or  A**T * X = B
+ * @param UPLO as LAPACK dtrtrs UPLO
+ * @param TRANS as LAPACK dtrtrs TRANS
+ * @param DIAG as LAPACK dtrtrs DIAG
+ * @param N as LAPACK dtrtrs N
+ * @param NRHS as LAPACK dtrtrs NRHS
+ * @param A data type specific with intent as LAPACK dtrtrs A
+ * @param LDA as LAPACK dtrtrs LDA
+ * @param B data type specific with intent as LAPACK dtrtrs B
+ * @param LDB as LAPACK dtrtrs LDB
+ * @param INFO as LAPACK dtrtrs INFO
+ * @throws rdag_error on illegal input
+ */
+template<typename T> void xtrtrs(char * UPLO, char * TRANS, char * DIAG, int * N, int * NRHS, T * A, int * LDA, T * B, int * LDB, int * INFO);
+
+/**
+ * xpotrf() computes the Cholesky factorization of a Hermitian positive definite matrix A.
+ * @param UPLO as LAPACK dpotrf UPLO
+ * @param N as LAPACK dpotrf N
+ * @param A data type specific with intent as LAPACK dpotrf A
+ * @param LDA as LAPACK dpotrf LDA
+ * @param INFO as LAPACK dpotrf INFO
+ * @throws rdag_error on illegal input
+ */
+template<typename T> void  xpotrf(char * UPLO, int * N, T * A, int * LDA, int * INFO);
+
+
+/**
+ * xpocon() computes the reciprocal condition estimate (in the 1-norm) of a s.p.d. matrix using the factorization computed by xpotrf().
+ * @param UPLO as LAPACK dpocon UPLO
+ * @param N as LAPACK dpocon N
+ * @param A data type specific with intent as LAPACK dpocon A
+ * @param LDA as LAPACK dpocon LDA
+ * @param ANORM as LAPACK dpocon ANORM
+ * @param RCOND as LAPACK dpocon RCOND
+ * @param INFO as LAPACK dpocon INFO
+ */
+template<typename T> void xpocon(char * UPLO, int * N, T * A, int * LDA, real16 * ANORM, real16 * RCOND, int * INFO);
+
+/**
+ * xlansy() computes condition numbers for a symmetric matrix.
+ * @param NORM as LAPACK dlansy NORM
+ * @param UPLO as LAPACK dlansy UPLO
+ * @param N as LAPACK dlansy N
+ * @param A data type specific with intent as LAPACK dlansy A
+ * @param LDA as LAPACK dlansy LDA
+ * @return the NORM as indicated by \a NORM.
+ */
+template<typename T> real16 xlansy(char * NORM, char * UPLO, int * N, T * A, int * LDA);
+
+
+/**
+ * xpotrs() solves s.p.d. systems via Cholesky decomposition as computed by xpotrf().
+ * @param UPLO as LAPACK dpotrs UPLO.
+ * @param N as LAPACK dpotrs N.
+ * @param NRHS as LAPACK dpotrs NRHS.
+ * @param A data type specific with intent as LAPACK dpotrs A.
+ * @param LDA as LAPACK dpotrs LDA.
+ * @param B data type specific with intent as LAPACK dpotrs B.
+ * @param LDB as LAPACK dpotrs LDB.
+ * @param INFO as LAPACK dpotrs INFO.
+ */
+template<typename T> void xpotrs(char * UPLO, int * N, int * NRHS, T * A, int * LDA, T * B, int * LDB, int * INFO);
 
 }
 

--- a/include/lapack.hh
+++ b/include/lapack.hh
@@ -58,6 +58,10 @@ extern "C" void F77FUNC(zpocon)(char * UPLO, int * N, complex16 * A, int * LDA, 
 extern "C" real16 F77FUNC(dlansy)(char * NORM, char * UPLO, int * N, real16 * A, int * LDA, real16 * WORK);
 extern "C" real16 F77FUNC(zlansy)(char * NORM, char * UPLO, int * N, complex16 * A, int * LDA, real16 * WORK);
 
+// Norm calculator for Hermitian matrix
+extern "C" real16 F77FUNC(zlanhe)(char * NORM, char * UPLO, int * N, complex16 * A, int * LDA, real16 * WORK);
+
+
 // Cholesky based solvers
 extern "C" void F77FUNC(dpotrs)(char * UPLO, int * N, int * NRHS, real16 * A, int * LDA, real16 * B, int * LDB, int * INFO);
 extern "C" void F77FUNC(zpotrs)(char * UPLO, int * N, int * NRHS, complex16 * A, int * LDA, complex16 * B, int * LDB, int * INFO);
@@ -239,6 +243,16 @@ template<typename T> void xpocon(char * UPLO, int * N, T * A, int * LDA, real16 
  */
 template<typename T> real16 xlansy(char * NORM, char * UPLO, int * N, T * A, int * LDA);
 
+/**
+ * zlanhe() computes condition numbers for a Hermitian matrix.
+ * @param NORM as LAPACK zlanhe NORM
+ * @param UPLO as LAPACK zlanhe UPLO
+ * @param N as LAPACK zlanhe N
+ * @param A a complex Hermitian matrix with intent as given in LAPACK zlanhe A
+ * @param LDA as LAPACK zlanhe LDA
+ * @return the NORM as indicated by \a NORM.
+ */
+real16 zlanhe(char * NORM, char * UPLO, int * N, complex16 * A, int * LDA);
 
 /**
  * xpotrs() solves s.p.d. systems via Cholesky decomposition as computed by xpotrf().

--- a/include/lapack.hh
+++ b/include/lapack.hh
@@ -7,66 +7,8 @@
 #ifndef _LAPACK_HH
 #define _LAPACK_HH
 
+#include "lapack_raw.h"
 #include "numerictypes.hh"
-
-#define F77FUNC(__FUNC) __FUNC##_
-
-// these lurk in global namespace
-
-// BLAS
-// Standard xSCAL
-extern "C" void F77FUNC(dscal)(int * N, real16 * DA, real16* DX, int * INCX);
-extern "C" void F77FUNC(zscal)(int * N, complex16 * DA, complex16* DX, int * INCX);
-
-// Standard xGEMV
-extern "C" void F77FUNC(dgemv)(char * TRANS, int * M, int * N, real16 * ALPHA, real16 * A, int * LDA, real16 * X, int * INCX, real16 * BETA, real16 * Y, int * INCY);
-extern "C" void F77FUNC(zgemv)(char * TRANS, int * M, int * N, complex16 * ALPHA, complex16 * A, int * LDA, complex16 * X, int * INCX, complex16 * BETA, complex16 * Y, int * INCY);
-
-// Standard xGEMM
-extern "C" void F77FUNC(dgemm)(char * TRANSA, char * TRANSB, int * M, int * N, int * K, real16 * ALPHA, real16 * A, int * LDA, real16 * B, int * LDB, real16 * BETA, real16 * C, int * LDC );
-extern "C" void F77FUNC(zgemm)(char * TRANSA, char * TRANSB, int * M, int * N, int * K, complex16 * ALPHA, complex16 * A, int * LDA, complex16 * B, int * LDB, complex16 * BETA, complex16 * C, int * LDC );
-
-// Standard NORM2 implementations.
-extern "C" real16 F77FUNC(dnrm2)(int * N, real16 * X, int * INCX);
-extern "C" real16 F77FUNC(dznrm2)(int * N, complex16 * X, int * INCX);
-
-
-// LAPACK
-
-// Standard SVD implementations.
-extern "C" void F77FUNC(dgesvd)(char * JOBU, char * JOBVT, int * M, int * N, real16 * A, int * LDA, real16 * S, real16 * U, int * LDU, real16 * VT, int * LDVT, real16 * WORK, int * LWORK, int * INFO);
-extern "C" void F77FUNC(zgesvd)(char * JOBU, char * JOBVT, int * M, int * N, complex16 * A, int * LDA, real16 * S, complex16 * U, int * LDU, complex16 * VT, int * LDVT, complex16 * WORK, int * LWORK, real16 * RWORK, int * INFO);
-
-// Reciprocal condition number estimates
-extern "C" void F77FUNC(dtrcon)(char * NORM, char * UPLO, char * DIAG, int * N, real16 * A, int * LDA, real16 * RCOND, real16 * WORK, int * IWORK, int * INFO);
-extern "C" void F77FUNC(ztrcon)(char * NORM, char * UPLO, char * DIAG, int * N, complex16 * A, int * LDA, real16 * RCOND, complex16 * WORK, real16 * IWORK, int * INFO);
-
-
-// solves a triangular system of the form : A * X = B  or  A**T * X = B
-extern "C" void F77FUNC(dtrtrs)(char * UPLO, char * TRANS, char * DIAG, int * N, int * NRHS, real16 * A, int * LDA, real16 * B, int * LDB, int * INFO);
-extern "C" void F77FUNC(ztrtrs)(char * UPLO, char * TRANS, char * DIAG, int * N, int * NRHS, complex16 * A, int * LDA, complex16 * B, int * LDB, int * INFO);
-
-// Cholesky factorisation for s.p.d matrices
-extern "C" void F77FUNC(dpotrf)(char * UPLO, int * N, real16 * A, int * LDA, int * INFO);
-extern "C" void F77FUNC(zpotrf)(char * UPLO, int * N, complex16 * A, int * LDA, int * INFO);
-
-// Reciprocal condition estimate in the 1-norm of a Cholesky decomposition as computed by xpotrf
-extern "C" void F77FUNC(dpocon)(char * UPLO, int * N, real16 * A, int * LDA, real16 * ANORM, real16 * RCOND, real16 * WORK, int * IWORK, int * INFO);
-extern "C" void F77FUNC(zpocon)(char * UPLO, int * N, complex16 * A, int * LDA, real16 * ANORM, real16 * RCOND, complex16 * WORK, real16 * RWORK, int * INFO);
-
-// Norm calculators for symmetric matrices
-extern "C" real16 F77FUNC(dlansy)(char * NORM, char * UPLO, int * N, real16 * A, int * LDA, real16 * WORK);
-extern "C" real16 F77FUNC(zlansy)(char * NORM, char * UPLO, int * N, complex16 * A, int * LDA, real16 * WORK);
-
-// Norm calculator for Hermitian matrix
-extern "C" real16 F77FUNC(zlanhe)(char * NORM, char * UPLO, int * N, complex16 * A, int * LDA, real16 * WORK);
-
-
-// Cholesky based solvers
-extern "C" void F77FUNC(dpotrs)(char * UPLO, int * N, int * NRHS, real16 * A, int * LDA, real16 * B, int * LDB, int * INFO);
-extern "C" void F77FUNC(zpotrs)(char * UPLO, int * N, int * NRHS, complex16 * A, int * LDA, complex16 * B, int * LDB, int * INFO);
-
-
 
 /**
  * The lapack namespace contains templated variants of functions that vary <real16,complex16> in their signature. In places the <real16,complex16> versions of a function require different
@@ -87,6 +29,7 @@ extern char D;
 extern char ONE;
 extern char O;
 extern int ione;
+extern int izero;
 extern real16 rone;
 extern complex16 cone;
 extern real16 rzero;
@@ -130,6 +73,10 @@ extern char * O;
  * The F77 integer '1'
  */
 extern int * ione;
+/**
+ * The F77 integer '0'
+ */
+extern int * izero;
 /**
  * The F77 double precision '1.d0'
  */

--- a/include/lapack.hh
+++ b/include/lapack.hh
@@ -35,6 +35,17 @@ extern complex16 cone;
 extern real16 rzero;
 extern complex16 czero;
 
+template<typename T>char charmagic();
+
+template<typename T> void xscal(int * N, T * DA, T * DX, int * INCX);
+template<typename T> void xgemv(char * TRANS, int * M, int * N, T * ALPHA, T * A, int * LDA, T * X, int * INCX, T * BETA, T * Y, int * INCY );
+template<typename T> void xgemm(char * TRANSA, char * TRANSB, int * M, int * N, int * K, T * ALPHA, T * A, int * LDA, T * B, int * LDB, T * BETA, T * C, int * LDC );
+template<typename T> real16 xnrm2(int * N, T * X, int * INCX);
+template<typename T> void xpotrs(char * UPLO, int * N, int * NRHS, T * A, int * LDA, T * B, int * LDB, int * INFO);
+template<typename T> real16 xlansy(char * NORM, char * UPLO, int * N, T * A, int * LDA, real16 * WORK);
+template<typename T> void xpotrf(char * UPLO, int * N, T * A, int * LDA, int * INFO);
+template<typename T> void xtrtrs(char * UPLO, char * TRANS, char * DIAG, int * N, int * NRHS, T * A, int * LDA, T * B, int * LDB, int * INFO);
+
 }
 
 /**
@@ -98,29 +109,76 @@ extern complex16 * czero;
 // BLAS
 
 /**
- * xscal general vector scaling
+ * xscal generalised vector scaling
+ * @param N as BLAS dscal N
+ * @param DA data type specific with intent as BLAS dscal DA
+ * @param DX data type specific with intent as BLAS dscal DX
+ * @param INCX as BLAS dscal INCX
  */
 template<typename T> void xscal(int * N, T * DA, T * DX, int * INCX);
 
 /**
- * xgemv general matrix vector multiplication.
+ * xgemv generalised matrix vector multiplication.
+ * @param TRANS as BLAS dgemv TRANS
+ * @param M as BLAS dgemv M
+ * @param N as BLAS dgemv N
+ * @param ALPHA data type specific with intent as BLAS dgemv ALPHA
+ * @param A data type specific with intent as BLAS dgemv A
+ * @param LDA as BLAS dgemv LDA
+ * @param X data type specific with intent as BLAS dgemv X
+ * @param INCX as BLAS dgemv INCX
+ * @param BETA data type specific with intent as BLAS dgemv BETA
+ * @param Y data type specific with intent as BLAS dgemv Y
+ * @param INCY as BLAS dgemv INCY
  */
 template<typename T> void xgemv(char * TRANS, int * M, int * N, T * ALPHA, T * A, int * LDA, T * X, int * INCX, T * BETA, T * Y, int * INCY );
 
 /**
- * xgemm general matrix matrix multiplication.
+ * xgemm generalised matrix matrix multiplication.
+ * @param TRANSA as BLAS dgemm TRANSA
+ * @param TRANSB as BLAS dgemm TRANSB
+ * @param M as BLAS dgemm M
+ * @param N as BLAS dgemm N
+ * @param K as BLAS dgemm K
+ * @param ALPHA data type specific with intent as BLAS dgemm ALPHA
+ * @param A data type specific with intent as BLAS dgemm A
+ * @param LDA as BLAS dgemm LDA
+ * @param B data type specific with intent as BLAS dgemm B
+ * @param LDB as BLAS dgemm LDB
+ * @param BETA data type specific with intent as BLAS dgemm BETA
+ * @param C data type specific with intent as BLAS dgemm C
+ * @param LDC as BLAS dgemm LDC
+
  */
 template<typename T> void xgemm(char * TRANSA, char * TRANSB, int * M, int * N, int * K, T * ALPHA, T * A, int * LDA, T * B, int * LDB, T * BETA, T * C, int * LDC );
 
 /**
- * xnrm2 general norm2 implementation
+ * xnrm2 generalised 2-norm implementation
+ * @param N as BLAS dnrm2 N
+ * @param A data type specific with intent as BLAS dnrm2 A
+ * @param INCX as BLAS dnrm2 INCX
+ * @return the 2-norm of X
  */
 template<typename T> real16 xnrm2(int * N, T * X, int * INCX);
 
 // LAPACK
 
 /**
- * xgesvd general svd implementation that takes care of workspaces
+ * xgesvd is a generalised svd implementation that takes care of workspaces
+ * @param JOBU as LAPACK dgesvd JOBU
+ * @param JOBVT as LAPACK dgesvd JOBVT
+ * @param M as LAPACK dgesvd M
+ * @param N as LAPACK dgesvd N
+ * @param A data type specific with intent as LAPACK dgesvd A
+ * @param LDA as LAPACK dgesvd LDA
+ * @param S as LAPACK dgesvd S
+ * @param T as LAPACK dgesvd T
+ * @param U as LAPACK dgesvd U
+ * @param LDU as LAPACK dgesvd LDU
+ * @param VT as LAPACK dgesvd VT
+ * @param LDVT as LAPACK dgesvd LDVT
+ * @param INFO as LAPACK dgesvd INFO
+ * @throws rdag_error on illegal input OR non-convergence
  */
 template<typename T> void xgesvd(char * JOBU, char * JOBVT, int * M, int * N, T * A, int * LDA, real16 * S, T * U, int * LDU, T * VT, int * LDVT, int * INFO);
 

--- a/include/lapack_raw.h
+++ b/include/lapack_raw.h
@@ -1,0 +1,153 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+/**
+ * Raw "C" style LAPACK bindings
+ */
+
+#ifndef _LAPACK_RAW_H
+#define _LAPACK_RAW_H
+
+#include "numerictypes.hh"
+
+#define F77FUNC(__FUNC) __FUNC##_
+
+// these lurk in global namespace
+
+// Xerbla handing, these are ISO C bound so no name mangling required
+#ifdef __cplusplus
+extern "C" 
+#endif
+void set_xerbla_death_switch(int * value);
+
+#ifdef __cplusplus
+extern "C" 
+#endif
+int get_xerbla_death_switch();
+
+// BLAS
+// Standard xSCAL
+#ifdef __cplusplus
+extern "C" 
+#endif
+void F77FUNC(dscal)(int * N, real16 * DA, real16* DX, int * INCX);
+#ifdef __cplusplus
+extern "C" 
+#endif
+void F77FUNC(zscal)(int * N, complex16 * DA, complex16* DX, int * INCX);
+
+// Standard xGEMV
+#ifdef __cplusplus
+extern "C" 
+#endif
+void F77FUNC(dgemv)(char * TRANS, int * M, int * N, real16 * ALPHA, real16 * A, int * LDA, real16 * X, int * INCX, real16 * BETA, real16 * Y, int * INCY);
+#ifdef __cplusplus
+extern "C" 
+#endif
+void F77FUNC(zgemv)(char * TRANS, int * M, int * N, complex16 * ALPHA, complex16 * A, int * LDA, complex16 * X, int * INCX, complex16 * BETA, complex16 * Y, int * INCY);
+
+// Standard xGEMM
+#ifdef __cplusplus
+extern "C" 
+#endif
+void F77FUNC(dgemm)(char * TRANSA, char * TRANSB, int * M, int * N, int * K, real16 * ALPHA, real16 * A, int * LDA, real16 * B, int * LDB, real16 * BETA, real16 * C, int * LDC );
+#ifdef __cplusplus
+extern "C" 
+#endif
+void F77FUNC(zgemm)(char * TRANSA, char * TRANSB, int * M, int * N, int * K, complex16 * ALPHA, complex16 * A, int * LDA, complex16 * B, int * LDB, complex16 * BETA, complex16 * C, int * LDC );
+
+// Standard NORM2 implementations.
+#ifdef __cplusplus
+extern "C" 
+#endif
+real16 F77FUNC(dnrm2)(int * N, real16 * X, int * INCX);
+#ifdef __cplusplus
+extern "C" 
+#endif
+real16 F77FUNC(dznrm2)(int * N, complex16 * X, int * INCX);
+
+
+// LAPACK
+
+// Standard SVD implementations.
+#ifdef __cplusplus
+extern "C" 
+#endif
+void F77FUNC(dgesvd)(char * JOBU, char * JOBVT, int * M, int * N, real16 * A, int * LDA, real16 * S, real16 * U, int * LDU, real16 * VT, int * LDVT, real16 * WORK, int * LWORK, int * INFO);
+#ifdef __cplusplus
+extern "C" 
+#endif
+void F77FUNC(zgesvd)(char * JOBU, char * JOBVT, int * M, int * N, complex16 * A, int * LDA, real16 * S, complex16 * U, int * LDU, complex16 * VT, int * LDVT, complex16 * WORK, int * LWORK, real16 * RWORK, int * INFO);
+
+// Reciprocal condition number estimates
+#ifdef __cplusplus
+extern "C" 
+#endif
+void F77FUNC(dtrcon)(char * NORM, char * UPLO, char * DIAG, int * N, real16 * A, int * LDA, real16 * RCOND, real16 * WORK, int * IWORK, int * INFO);
+#ifdef __cplusplus
+extern "C" 
+#endif
+void F77FUNC(ztrcon)(char * NORM, char * UPLO, char * DIAG, int * N, complex16 * A, int * LDA, real16 * RCOND, complex16 * WORK, real16 * IWORK, int * INFO);
+
+
+// solves a triangular system of the form : A * X = B  or  A**T * X = B
+#ifdef __cplusplus
+extern "C" 
+#endif
+void F77FUNC(dtrtrs)(char * UPLO, char * TRANS, char * DIAG, int * N, int * NRHS, real16 * A, int * LDA, real16 * B, int * LDB, int * INFO);
+#ifdef __cplusplus
+extern "C" 
+#endif
+void F77FUNC(ztrtrs)(char * UPLO, char * TRANS, char * DIAG, int * N, int * NRHS, complex16 * A, int * LDA, complex16 * B, int * LDB, int * INFO);
+
+// Cholesky factorisation for s.p.d matrices
+#ifdef __cplusplus
+extern "C" 
+#endif
+void F77FUNC(dpotrf)(char * UPLO, int * N, real16 * A, int * LDA, int * INFO);
+#ifdef __cplusplus
+extern "C" 
+#endif
+void F77FUNC(zpotrf)(char * UPLO, int * N, complex16 * A, int * LDA, int * INFO);
+
+// Reciprocal condition estimate in the 1-norm of a Cholesky decomposition as computed by xpotrf
+#ifdef __cplusplus
+extern "C" 
+#endif
+void F77FUNC(dpocon)(char * UPLO, int * N, real16 * A, int * LDA, real16 * ANORM, real16 * RCOND, real16 * WORK, int * IWORK, int * INFO);
+#ifdef __cplusplus
+extern "C" 
+#endif
+void F77FUNC(zpocon)(char * UPLO, int * N, complex16 * A, int * LDA, real16 * ANORM, real16 * RCOND, complex16 * WORK, real16 * RWORK, int * INFO);
+
+// Norm calculators for symmetric matrices
+#ifdef __cplusplus
+extern "C" 
+#endif
+real16 F77FUNC(dlansy)(char * NORM, char * UPLO, int * N, real16 * A, int * LDA, real16 * WORK);
+#ifdef __cplusplus
+extern "C" 
+#endif
+real16 F77FUNC(zlansy)(char * NORM, char * UPLO, int * N, complex16 * A, int * LDA, real16 * WORK);
+
+// Norm calculator for Hermitian matrix
+#ifdef __cplusplus
+extern "C" 
+#endif
+real16 F77FUNC(zlanhe)(char * NORM, char * UPLO, int * N, complex16 * A, int * LDA, real16 * WORK);
+
+
+// Cholesky based solvers
+#ifdef __cplusplus
+extern "C" 
+#endif
+void F77FUNC(dpotrs)(char * UPLO, int * N, int * NRHS, real16 * A, int * LDA, real16 * B, int * LDB, int * INFO);
+#ifdef __cplusplus
+extern "C" 
+#endif
+void F77FUNC(zpotrs)(char * UPLO, int * N, int * NRHS, complex16 * A, int * LDA, complex16 * B, int * LDB, int * INFO);
+
+#endif //_LAPACK_RAW_H

--- a/include/numerictypes.hh
+++ b/include/numerictypes.hh
@@ -7,15 +7,29 @@
 #ifndef _NUMERICTYPES_HH
 #define _NUMERICTYPES_HH
 
+#ifdef __cplusplus
 #include <complex>
+#else
+#include <complex.h>
+#endif
 
+#ifdef __cplusplus
 using namespace std;
+#endif
 
+#ifdef __cplusplus
 typedef complex<double> complex16;
 typedef complex<float> complex8;
 typedef double real16;
 typedef float real8;
+#else
+typedef double complex complex16;
+typedef float complex complex8;
+typedef double real16;
+typedef float real8;
+#endif
 
+#ifdef __cplusplus
 namespace librdag {
 
 real16 getNaN();
@@ -29,6 +43,6 @@ complex16 getNegPosComplexInf();
 complex16 getNegNegComplexInf();
 
 }
-
+#endif
 
 #endif /* NUMERICTYPES_HH_ */

--- a/src/librdag/entrypt.cc
+++ b/src/librdag/entrypt.cc
@@ -14,6 +14,7 @@
 #include "exprtypeenum.h"
 #include <typeinfo>
 #include <iostream>
+#include "lapack_raw.h"
 
 using namespace std;
 
@@ -134,6 +135,10 @@ void Walker::talkandwalk(librdag::OGNumeric const * numeric_expr_types)
 const OGTerminal*
 entrypt(const OGNumeric* expr)
 {
+  // Sort out LAPACK so xerbla calls don't kill the processes.
+  int zero = 0;
+  set_xerbla_death_switch(&zero);
+
   const OGTerminal* asTerminal = expr->asOGTerminal();
   if (asTerminal!=nullptr)
   {

--- a/src/librdag/lapack.cc
+++ b/src/librdag/lapack.cc
@@ -164,6 +164,12 @@ template<>  void xgesvd(char * JOBU, char * JOBVT, int * M, int * N, complex16 *
 
 template<> void xtrcon(char * NORM, char * UPLO, char * DIAG, int * N, real16 * A, int * LDA, real16 * RCOND, int * INFO)
 {
+  if(*N<0)
+  {
+    stringstream message;
+    message << "Input to LAPACK::dtrcon call incorrect at arg: " << 4;
+    throw rdag_error(message.str());
+  }
   real16 * WORK = new real16[ 3 * *N];
   int * IWORK = new int[*N];
   F77FUNC(dtrcon)(NORM, UPLO, DIAG, N, A, LDA, RCOND, WORK, IWORK, INFO);
@@ -180,6 +186,12 @@ template<> void xtrcon(char * NORM, char * UPLO, char * DIAG, int * N, real16 * 
 
 template<> void xtrcon(char * NORM, char * UPLO, char * DIAG, int * N, complex16 * A, int * LDA, real16 * RCOND, int * INFO)
 {
+  if(*N<0)
+  {
+    stringstream message;
+    message << "Input to LAPACK::ztrcon call incorrect at arg: " << 4;
+    throw rdag_error(message.str());
+  }
   complex16 * WORK = new complex16[ 2 * *N];
   real16 * RWORK = new real16[*N];
   F77FUNC(ztrcon)(NORM, UPLO, DIAG, N, A, LDA, RCOND, WORK, RWORK, INFO);
@@ -306,6 +318,12 @@ template<> void xpocon(char * UPLO, int * N, complex16 * A, int * LDA, real16 * 
 
 template<>real16 xlansy(char * NORM, char * UPLO, int * N, real16 * A, int * LDA)
 {
+  if(*N<0)
+  {
+    stringstream message;
+    message << "Input to LAPACK::dlansy call incorrect at arg: " << 3;
+    throw rdag_error(message.str());
+  }
   real16 * WORK = new real16[*N]; // allocate regardless of *NORM
   real16 ret = F77FUNC(dlansy)(NORM, UPLO, N, A, LDA, WORK);
   delete [] WORK;
@@ -314,6 +332,12 @@ template<>real16 xlansy(char * NORM, char * UPLO, int * N, real16 * A, int * LDA
 
 template<>real16 xlansy(char * NORM, char * UPLO, int * N, complex16 * A, int * LDA)
 {
+  if(*N<0)
+  {
+    stringstream message;
+    message << "Input to LAPACK::zlansy call incorrect at arg: " << 3;
+    throw rdag_error(message.str());
+  }
   real16 * WORK = new real16[*N]; // allocate regardless of *NORM
   real16 ret = F77FUNC(zlansy)(NORM, UPLO, N, A, LDA, WORK);
   delete [] WORK;

--- a/src/librdag/lapack.cc
+++ b/src/librdag/lapack.cc
@@ -196,7 +196,13 @@ template<> void xtrcon(char * NORM, char * UPLO, char * DIAG, int * N, complex16
 template<> void xtrtrs(char * UPLO, char * TRANS, char * DIAG, int * N, int * NRHS, real16 * A, int * LDA, real16 * B, int * LDB, int * INFO)
 {
   F77FUNC(dtrtrs)(UPLO, TRANS, DIAG, N, NRHS, A, LDA, B, LDB, INFO);
-  if(*INFO!=0)
+  if(*INFO>0)
+  {
+    stringstream message;
+    message << "LAPACK::dtrtrs matrix is reported as being singular, the " << *INFO << "th diagonal is zero. No solutions have been computed.";
+    throw rdag_error(message.str());
+  }
+  if(*INFO<0)
   {
     stringstream message;
     message << "Input to LAPACK::dtrtrs call incorrect at arg: " << *INFO;
@@ -207,6 +213,12 @@ template<> void xtrtrs(char * UPLO, char * TRANS, char * DIAG, int * N, int * NR
 template<> void xtrtrs(char * UPLO, char * TRANS, char * DIAG, int * N, int * NRHS, complex16 * A, int * LDA, complex16 * B, int * LDB, int * INFO)
 {
   F77FUNC(ztrtrs)(UPLO, TRANS, DIAG, N, NRHS, A, LDA, B, LDB, INFO);
+  if(*INFO>0)
+  {
+    stringstream message;
+    message << "LAPACK::dtrtrs matrix is reported as being singular, the " << *INFO << "th diagonal is zero. No solutions have been computed.";
+    throw rdag_error(message.str());
+  }
   if(*INFO!=0)
   {
     stringstream message;
@@ -219,6 +231,12 @@ template<> void xtrtrs(char * UPLO, char * TRANS, char * DIAG, int * N, int * NR
 template<> void xpotrf(char * UPLO, int * N, real16 * A, int * LDA, int * INFO)
 {
   F77FUNC(dpotrf)(UPLO, N, A, LDA, INFO);
+  if(*INFO>0)
+  {
+    stringstream message;
+    message << "LAPACK::dpotrf matrix is reported as being non s.p.d OR the factorisation failed. The " << *INFO << "th leading minor is not positive definite.";
+    throw rdag_error(message.str());
+  }
   if(*INFO<0)
   {
     stringstream message;
@@ -230,6 +248,12 @@ template<> void xpotrf(char * UPLO, int * N, real16 * A, int * LDA, int * INFO)
 template<> void xpotrf(char * UPLO, int * N, complex16 * A, int * LDA, int * INFO)
 {
   F77FUNC(zpotrf)(UPLO, N, A, LDA, INFO);
+  if(*INFO>0)
+  {
+    stringstream message;
+    message << "LAPACK::zpotrf matrix is reported as being non s.p.d OR the factorisation failed. The " << *INFO << "th leading minor is not positive definite.";
+    throw rdag_error(message.str());
+  }
   if(*INFO<0)
   {
     stringstream message;
@@ -240,8 +264,14 @@ template<> void xpotrf(char * UPLO, int * N, complex16 * A, int * LDA, int * INF
 
 template<> void xpocon(char * UPLO, int * N, real16 * A, int * LDA, real16 * ANORM, real16 * RCOND, int * INFO)
 {
-  real16 * WORK = new real16[3 * *N];
-  int * IWORK = new int[*N];
+  if(*N<0)
+  {
+    stringstream message;
+    message << "Input to LAPACK::dpocon call incorrect at arg: " << 2;
+    throw rdag_error(message.str());
+  }
+  real16 * WORK = new real16[3 * (*N)];
+  int * IWORK = new int[(*N)];
   F77FUNC(dpocon)(UPLO, N, A, LDA, ANORM, RCOND, WORK, IWORK, INFO);
   delete [] WORK;
   delete [] IWORK;
@@ -255,6 +285,12 @@ template<> void xpocon(char * UPLO, int * N, real16 * A, int * LDA, real16 * ANO
 
 template<> void xpocon(char * UPLO, int * N, complex16 * A, int * LDA, real16 * ANORM, real16 * RCOND, int * INFO)
 {
+  if(*N<0)
+  {
+    stringstream message;
+    message << "Input to LAPACK::zpocon call incorrect at arg: " << 2;
+    throw rdag_error(message.str());
+  }
   complex16 * WORK = new complex16[2 * *N];
   real16 * RWORK = new real16[*N];
   F77FUNC(zpocon)(UPLO, N, A, LDA, ANORM, RCOND, WORK, RWORK, INFO);
@@ -280,6 +316,15 @@ template<>real16 xlansy(char * NORM, char * UPLO, int * N, complex16 * A, int * 
 {
   real16 * WORK = new real16[*N]; // allocate regardless of *NORM
   real16 ret = F77FUNC(zlansy)(NORM, UPLO, N, A, LDA, WORK);
+  delete [] WORK;
+  return ret;
+}
+
+
+real16 zlanhe(char * NORM, char * UPLO, int * N, complex16 * A, int * LDA)
+{
+  real16 * WORK = new real16[*N]; // allocate regardless of *NORM
+  real16 ret = F77FUNC(zlanhe)(NORM, UPLO, N, A, LDA, WORK);
   delete [] WORK;
   return ret;
 }

--- a/src/librdag/lapack.cc
+++ b/src/librdag/lapack.cc
@@ -22,6 +22,7 @@ namespace detail
   char O = 'O';
   char ONE = '1';
   int ione = 1;
+  int izero = 0;
   real16 rone = 1.e0;
   complex16 cone = {1.e0, 0.e0};
   real16 rzero = 0.e0;
@@ -35,9 +36,10 @@ char *      T     = &detail::T;
 char *      L     = &detail::L;
 char *      U     = &detail::U;
 char *      D     = &detail::D;
-char * 	    O     = &detail::O;
+char *      O     = &detail::O;
 char *      ONE   = &detail::ONE;
 int *       ione  = &detail::ione;
+int *       izero  = &detail::izero;
 real16 *    rone  = &detail::rone;
 complex16 * cone  = &detail::cone;
 real16 *    rzero = &detail::rzero;
@@ -46,22 +48,26 @@ complex16 * czero = &detail::czero;
 // xSCAL specialisations
 template<> void xscal(int * N, real16 * DA, real16 * DX, int * INCX)
 {
+  set_xerbla_death_switch(lapack::izero);
   F77FUNC(dscal)(N, DA, DX, INCX);
 }
 
 template<> void xscal(int * N, complex16 * DA, complex16 * DX, int * INCX)
 {
+  set_xerbla_death_switch(lapack::izero);
   F77FUNC(zscal)(N, DA, DX, INCX);
 }
 
 // xGEMV specialisations
 template<> void xgemv(char * TRANS, int * M, int * N, real16 * ALPHA, real16 * A, int * LDA, real16 * X, int * INCX, real16 * BETA, real16 * Y, int * INCY )
 {
+  set_xerbla_death_switch(lapack::izero);
   F77FUNC(dgemv)(TRANS, M, N, ALPHA, A, LDA, X, INCX, BETA, Y, INCY);
 }
 
 template<> void xgemv(char * TRANS, int * M, int * N, complex16 * ALPHA, complex16 * A, int * LDA, complex16 * X, int * INCX, complex16 * BETA, complex16 * Y, int * INCY )
 {
+  set_xerbla_death_switch(lapack::izero);
   F77FUNC(zgemv)(TRANS, M, N, ALPHA, A, LDA, X, INCX, BETA, Y, INCY);
 }
 
@@ -69,12 +75,14 @@ template<> void xgemv(char * TRANS, int * M, int * N, complex16 * ALPHA, complex
 template<> void
 xgemm(char * TRANSA, char * TRANSB, int * M, int * N, int * K, real16 * ALPHA, real16 * A, int * LDA, real16 * B, int * LDB, real16 * BETA, real16 * C, int * LDC )
 {
+  set_xerbla_death_switch(lapack::izero);
   F77FUNC(dgemm)(TRANSA, TRANSB, M, N, K, ALPHA, A, LDA, B, LDB, BETA, C, LDC );
 }
 
 template<> void
 xgemm(char * TRANSA, char * TRANSB, int * M, int * N, int * K, complex16 * ALPHA, complex16 * A, int * LDA, complex16 * B, int * LDB, complex16 * BETA, complex16 * C, int * LDC )
 {
+  set_xerbla_death_switch(lapack::izero);
   F77FUNC(zgemm)(TRANSA, TRANSB, M, N, K, ALPHA, A, LDA, B, LDB, BETA, C, LDC );
 }
 
@@ -82,17 +90,20 @@ xgemm(char * TRANSA, char * TRANSB, int * M, int * N, int * K, complex16 * ALPHA
 // xNORM2 specialisations
 template<> real16 xnrm2(int * N, real16 * X, int * INCX)
 {
+  set_xerbla_death_switch(lapack::izero);
   return F77FUNC(dnrm2)(N, X, INCX);
 }
 
 template<> real16 xnrm2(int * N, complex16 * X, int * INCX)
 {
+  set_xerbla_death_switch(lapack::izero);
   return F77FUNC(dznrm2)(N, X, INCX);
 }
 
 // xGESVD specialisations
 template<>  void xgesvd(char * JOBU, char * JOBVT, int * M, int * N, real16 * A, int * LDA, real16 * S, real16 * U, int * LDU, real16 * VT, int * LDVT, int * INFO)
 {
+  set_xerbla_death_switch(lapack::izero);
   real16 * tmp = new real16[1]; // buffer, alloc slot of 1 needed as the work space dimension is written here.
   int lwork = -1; // set for query
   real16 * WORK = tmp; // set properly after query
@@ -127,6 +138,7 @@ template<>  void xgesvd(char * JOBU, char * JOBVT, int * M, int * N, real16 * A,
 
 template<>  void xgesvd(char * JOBU, char * JOBVT, int * M, int * N, complex16 * A, int * LDA, real16 * S, complex16 * U, int * LDU, complex16 * VT, int * LDVT, int * INFO)
 {
+  set_xerbla_death_switch(lapack::izero);
   int minmn = *M > *N ? *N : *M; // compute scale for RWORK
   complex16 * tmp = new complex16[1]; // buffer, alloc slot of 1 needed as the work space dimension is written here.
   int lwork = -1; // set for query
@@ -164,6 +176,7 @@ template<>  void xgesvd(char * JOBU, char * JOBVT, int * M, int * N, complex16 *
 
 template<> void xtrcon(char * NORM, char * UPLO, char * DIAG, int * N, real16 * A, int * LDA, real16 * RCOND, int * INFO)
 {
+  set_xerbla_death_switch(lapack::izero);
   if(*N<0)
   {
     stringstream message;
@@ -186,6 +199,7 @@ template<> void xtrcon(char * NORM, char * UPLO, char * DIAG, int * N, real16 * 
 
 template<> void xtrcon(char * NORM, char * UPLO, char * DIAG, int * N, complex16 * A, int * LDA, real16 * RCOND, int * INFO)
 {
+  set_xerbla_death_switch(lapack::izero);
   if(*N<0)
   {
     stringstream message;
@@ -207,6 +221,7 @@ template<> void xtrcon(char * NORM, char * UPLO, char * DIAG, int * N, complex16
 
 template<> void xtrtrs(char * UPLO, char * TRANS, char * DIAG, int * N, int * NRHS, real16 * A, int * LDA, real16 * B, int * LDB, int * INFO)
 {
+  set_xerbla_death_switch(lapack::izero);
   F77FUNC(dtrtrs)(UPLO, TRANS, DIAG, N, NRHS, A, LDA, B, LDB, INFO);
   if(*INFO>0)
   {
@@ -224,6 +239,7 @@ template<> void xtrtrs(char * UPLO, char * TRANS, char * DIAG, int * N, int * NR
 
 template<> void xtrtrs(char * UPLO, char * TRANS, char * DIAG, int * N, int * NRHS, complex16 * A, int * LDA, complex16 * B, int * LDB, int * INFO)
 {
+  set_xerbla_death_switch(lapack::izero);
   F77FUNC(ztrtrs)(UPLO, TRANS, DIAG, N, NRHS, A, LDA, B, LDB, INFO);
   if(*INFO>0)
   {
@@ -242,6 +258,7 @@ template<> void xtrtrs(char * UPLO, char * TRANS, char * DIAG, int * N, int * NR
 
 template<> void xpotrf(char * UPLO, int * N, real16 * A, int * LDA, int * INFO)
 {
+  set_xerbla_death_switch(lapack::izero);
   F77FUNC(dpotrf)(UPLO, N, A, LDA, INFO);
   if(*INFO>0)
   {
@@ -259,6 +276,7 @@ template<> void xpotrf(char * UPLO, int * N, real16 * A, int * LDA, int * INFO)
 
 template<> void xpotrf(char * UPLO, int * N, complex16 * A, int * LDA, int * INFO)
 {
+  set_xerbla_death_switch(lapack::izero);
   F77FUNC(zpotrf)(UPLO, N, A, LDA, INFO);
   if(*INFO>0)
   {
@@ -276,6 +294,7 @@ template<> void xpotrf(char * UPLO, int * N, complex16 * A, int * LDA, int * INF
 
 template<> void xpocon(char * UPLO, int * N, real16 * A, int * LDA, real16 * ANORM, real16 * RCOND, int * INFO)
 {
+  set_xerbla_death_switch(lapack::izero);
   if(*N<0)
   {
     stringstream message;
@@ -297,6 +316,7 @@ template<> void xpocon(char * UPLO, int * N, real16 * A, int * LDA, real16 * ANO
 
 template<> void xpocon(char * UPLO, int * N, complex16 * A, int * LDA, real16 * ANORM, real16 * RCOND, int * INFO)
 {
+  set_xerbla_death_switch(lapack::izero);
   if(*N<0)
   {
     stringstream message;
@@ -318,6 +338,7 @@ template<> void xpocon(char * UPLO, int * N, complex16 * A, int * LDA, real16 * 
 
 template<>real16 xlansy(char * NORM, char * UPLO, int * N, real16 * A, int * LDA)
 {
+  set_xerbla_death_switch(lapack::izero);
   if(*N<0)
   {
     stringstream message;
@@ -332,6 +353,7 @@ template<>real16 xlansy(char * NORM, char * UPLO, int * N, real16 * A, int * LDA
 
 template<>real16 xlansy(char * NORM, char * UPLO, int * N, complex16 * A, int * LDA)
 {
+  set_xerbla_death_switch(lapack::izero);
   if(*N<0)
   {
     stringstream message;
@@ -347,6 +369,7 @@ template<>real16 xlansy(char * NORM, char * UPLO, int * N, complex16 * A, int * 
 
 real16 zlanhe(char * NORM, char * UPLO, int * N, complex16 * A, int * LDA)
 {
+  set_xerbla_death_switch(lapack::izero);
   real16 * WORK = new real16[*N]; // allocate regardless of *NORM
   real16 ret = F77FUNC(zlanhe)(NORM, UPLO, N, A, LDA, WORK);
   delete [] WORK;
@@ -356,6 +379,7 @@ real16 zlanhe(char * NORM, char * UPLO, int * N, complex16 * A, int * LDA)
 
 template<> void xpotrs(char * UPLO, int * N, int * NRHS, real16 * A, int * LDA, real16 * B, int * LDB, int * INFO)
 {
+  set_xerbla_death_switch(lapack::izero);
   F77FUNC(dpotrs)(UPLO, N, NRHS, A, LDA, B, LDB, INFO);
   if(*INFO<0)
   {
@@ -367,6 +391,7 @@ template<> void xpotrs(char * UPLO, int * N, int * NRHS, real16 * A, int * LDA, 
 
 template<> void xpotrs(char * UPLO, int * N, int * NRHS, complex16 * A, int * LDA, complex16 * B, int * LDB, int * INFO)
 {
+  set_xerbla_death_switch(lapack::izero);
   F77FUNC(zpotrs)(UPLO, N, NRHS, A, LDA, B, LDB, INFO);
   if(*INFO<0)
   {

--- a/src/librdag/lapack.cc
+++ b/src/librdag/lapack.cc
@@ -27,6 +27,103 @@ namespace detail
   complex16 cone = {1.e0, 0.e0};
   real16 rzero = 0.e0;
   complex16 czero = {0.e0, 0.e0};
+
+  // charmagic specialisation
+  template<>char charmagic<real16>()
+  {
+    return 'd';
+  }
+  template<>char charmagic<complex16>()
+  {
+    return 'z';
+  }
+
+  // xSCAL specialisations
+  template<> void xscal(int * N, real16 * DA, real16 * DX, int * INCX)
+  {
+    F77FUNC(dscal)(N, DA, DX, INCX);
+  }
+
+  template<> void xscal(int * N, complex16 * DA, complex16 * DX, int * INCX)
+  {
+    F77FUNC(zscal)(N, DA, DX, INCX);
+  }
+
+  // xGEMV specialisations
+  template<> void xgemv(char * TRANS, int * M, int * N, real16 * ALPHA, real16 * A, int * LDA, real16 * X, int * INCX, real16 * BETA, real16 * Y, int * INCY )
+  {
+    F77FUNC(dgemv)(TRANS, M, N, ALPHA, A, LDA, X, INCX, BETA, Y, INCY);
+  }
+
+  template<> void xgemv(char * TRANS, int * M, int * N, complex16 * ALPHA, complex16 * A, int * LDA, complex16 * X, int * INCX, complex16 * BETA, complex16 * Y, int * INCY )
+  {
+    F77FUNC(zgemv)(TRANS, M, N, ALPHA, A, LDA, X, INCX, BETA, Y, INCY);
+  }
+
+  // xGEMM specialisations
+  template<> void
+  xgemm(char * TRANSA, char * TRANSB, int * M, int * N, int * K, real16 * ALPHA, real16 * A, int * LDA, real16 * B, int * LDB, real16 * BETA, real16 * C, int * LDC )
+  {
+    F77FUNC(dgemm)(TRANSA, TRANSB, M, N, K, ALPHA, A, LDA, B, LDB, BETA, C, LDC );
+  }
+
+  template<> void
+  xgemm(char * TRANSA, char * TRANSB, int * M, int * N, int * K, complex16 * ALPHA, complex16 * A, int * LDA, complex16 * B, int * LDB, complex16 * BETA, complex16 * C, int * LDC )
+  {
+    F77FUNC(zgemm)(TRANSA, TRANSB, M, N, K, ALPHA, A, LDA, B, LDB, BETA, C, LDC );
+  }
+
+  // xNORM2 specialisations
+  template<> real16 xnrm2(int * N, real16 * X, int * INCX)
+  {
+    return F77FUNC(dnrm2)(N, X, INCX);
+  }
+
+  template<> real16 xnrm2(int * N, complex16 * X, int * INCX)
+  {
+    return F77FUNC(dznrm2)(N, X, INCX);
+  }
+
+  // xPOTRS specialisations
+  template<> void xpotrs(char * UPLO, int * N, int * NRHS, real16 * A, int * LDA, real16 * B, int * LDB, int * INFO)
+  {
+    F77FUNC(dpotrs)(UPLO, N, NRHS, A, LDA, B, LDB, INFO);
+  }
+
+  template<> void xpotrs(char * UPLO, int * N, int * NRHS, complex16 * A, int * LDA, complex16 * B, int * LDB, int * INFO)
+  {
+    F77FUNC(zpotrs)(UPLO, N, NRHS, A, LDA, B, LDB, INFO);
+  }
+
+  // xLANSY specialisations
+  template<>real16 xlansy(char * NORM, char * UPLO, int * N, real16 * A, int * LDA, real16 * WORK)
+  {
+    return F77FUNC(dlansy)(NORM, UPLO, N, A, LDA, WORK);
+  }
+  template<>real16 xlansy(char * NORM, char * UPLO, int * N, complex16 * A, int * LDA, real16 * WORK)
+  {
+    return  F77FUNC(zlansy)(NORM, UPLO, N, A, LDA, WORK);
+  }
+
+  // xPOTRF specialisations
+  template<> void xpotrf(char * UPLO, int * N, real16 * A, int * LDA, int * INFO)
+  {
+    F77FUNC(dpotrf)(UPLO, N, A, LDA, INFO);
+  }
+  template<> void xpotrf(char * UPLO, int * N, complex16 * A, int * LDA, int * INFO)
+  {
+    F77FUNC(zpotrf)(UPLO, N, A, LDA, INFO);
+  }
+
+  //xTRTRS specialisations
+  template<> void xtrtrs(char * UPLO, char * TRANS, char * DIAG, int * N, int * NRHS, real16 * A, int * LDA, real16 * B, int * LDB, int * INFO)
+  {
+    F77FUNC(dtrtrs)(UPLO, TRANS, DIAG, N, NRHS, A, LDA, B, LDB, INFO);
+  }
+  template<> void xtrtrs(char * UPLO, char * TRANS, char * DIAG, int * N, int * NRHS, complex16 * A, int * LDA, complex16 * B, int * LDB, int * INFO)
+  {
+    F77FUNC(ztrtrs)(UPLO, TRANS, DIAG, N, NRHS, A, LDA, B, LDB, INFO);
+  }
 }
 
 // f77 constants
@@ -45,60 +142,44 @@ complex16 * cone  = &detail::cone;
 real16 *    rzero = &detail::rzero;
 complex16 * czero = &detail::czero;
 
-// xSCAL specialisations
-template<> void xscal(int * N, real16 * DA, real16 * DX, int * INCX)
+// xSCAL
+template<typename T> void xscal(int * N, T * DA, T * DX, int * INCX)
 {
   set_xerbla_death_switch(lapack::izero);
-  F77FUNC(dscal)(N, DA, DX, INCX);
+  detail::xscal(N, DA, DX, INCX);
 }
+template void xscal<real16>(int * N, real16 * DA, real16 * DX, int * INCX);
+template void xscal<complex16>(int * N, complex16 * DA, complex16 * DX, int * INCX);
 
-template<> void xscal(int * N, complex16 * DA, complex16 * DX, int * INCX)
+// xGEMV
+template<typename T> void
+xgemv(char * TRANS, int * M, int * N, T * ALPHA, T * A, int * LDA, T * X, int * INCX, T * BETA, T * Y, int * INCY )
 {
   set_xerbla_death_switch(lapack::izero);
-  F77FUNC(zscal)(N, DA, DX, INCX);
+  detail::xgemv(TRANS, M, N, ALPHA, A, LDA, X, INCX, BETA, Y, INCY);
 }
+template void xgemv<real16>(char * TRANS, int * M, int * N, real16 * ALPHA, real16 * A, int * LDA, real16 * X, int * INCX, real16 * BETA, real16 * Y, int * INCY);
+template void xgemv<complex16>(char * TRANS, int * M, int * N, complex16 * ALPHA, complex16 * A, int * LDA, complex16 * X, int * INCX, complex16 * BETA, complex16 * Y, int * INCY);
 
-// xGEMV specialisations
-template<> void xgemv(char * TRANS, int * M, int * N, real16 * ALPHA, real16 * A, int * LDA, real16 * X, int * INCX, real16 * BETA, real16 * Y, int * INCY )
+// xGEMM
+template<typename T> void
+xgemm(char * TRANSA, char * TRANSB, int * M, int * N, int * K, T * ALPHA, T * A, int * LDA, T * B, int * LDB, T * BETA, T * C, int * LDC )
 {
   set_xerbla_death_switch(lapack::izero);
-  F77FUNC(dgemv)(TRANS, M, N, ALPHA, A, LDA, X, INCX, BETA, Y, INCY);
+  detail::xgemm(TRANSA, TRANSB, M, N, K, ALPHA, A, LDA, B, LDB, BETA, C, LDC );
 }
+template void xgemm<real16>(char * TRANSA, char * TRANSB, int * M, int * N, int * K, real16 * ALPHA, real16 * A, int * LDA, real16 * B, int * LDB, real16 * BETA, real16 * C, int * LDC );
+template void xgemm<complex16>(char * TRANSA, char * TRANSB, int * M, int * N, int * K, complex16 * ALPHA, complex16 * A, int * LDA, complex16 * B, int * LDB, complex16 * BETA, complex16 * C, int * LDC );
 
-template<> void xgemv(char * TRANS, int * M, int * N, complex16 * ALPHA, complex16 * A, int * LDA, complex16 * X, int * INCX, complex16 * BETA, complex16 * Y, int * INCY )
+// xNORM2
+template<typename T> real16
+xnrm2(int * N, T * X, int * INCX)
 {
   set_xerbla_death_switch(lapack::izero);
-  F77FUNC(zgemv)(TRANS, M, N, ALPHA, A, LDA, X, INCX, BETA, Y, INCY);
+  return detail::xnrm2(N, X, INCX);
 }
-
-// xGEMM specialisations
-template<> void
-xgemm(char * TRANSA, char * TRANSB, int * M, int * N, int * K, real16 * ALPHA, real16 * A, int * LDA, real16 * B, int * LDB, real16 * BETA, real16 * C, int * LDC )
-{
-  set_xerbla_death_switch(lapack::izero);
-  F77FUNC(dgemm)(TRANSA, TRANSB, M, N, K, ALPHA, A, LDA, B, LDB, BETA, C, LDC );
-}
-
-template<> void
-xgemm(char * TRANSA, char * TRANSB, int * M, int * N, int * K, complex16 * ALPHA, complex16 * A, int * LDA, complex16 * B, int * LDB, complex16 * BETA, complex16 * C, int * LDC )
-{
-  set_xerbla_death_switch(lapack::izero);
-  F77FUNC(zgemm)(TRANSA, TRANSB, M, N, K, ALPHA, A, LDA, B, LDB, BETA, C, LDC );
-}
-
-
-// xNORM2 specialisations
-template<> real16 xnrm2(int * N, real16 * X, int * INCX)
-{
-  set_xerbla_death_switch(lapack::izero);
-  return F77FUNC(dnrm2)(N, X, INCX);
-}
-
-template<> real16 xnrm2(int * N, complex16 * X, int * INCX)
-{
-  set_xerbla_death_switch(lapack::izero);
-  return F77FUNC(dznrm2)(N, X, INCX);
-}
+template real16 xnrm2<real16>(int * N, real16 * X, int * INCX);
+template real16 xnrm2<complex16>(int * N, complex16 * X, int * INCX);
 
 // xGESVD specialisations
 template<>  void xgesvd(char * JOBU, char * JOBVT, int * M, int * N, real16 * A, int * LDA, real16 * S, real16 * U, int * LDU, real16 * VT, int * LDVT, int * INFO)
@@ -219,78 +300,47 @@ template<> void xtrcon(char * NORM, char * UPLO, char * DIAG, int * N, complex16
   }
 }
 
-template<> void xtrtrs(char * UPLO, char * TRANS, char * DIAG, int * N, int * NRHS, real16 * A, int * LDA, real16 * B, int * LDB, int * INFO)
+template<typename T> void xtrtrs(char * UPLO, char * TRANS, char * DIAG, int * N, int * NRHS, T * A, int * LDA, T * B, int * LDB, int * INFO)
 {
   set_xerbla_death_switch(lapack::izero);
-  F77FUNC(dtrtrs)(UPLO, TRANS, DIAG, N, NRHS, A, LDA, B, LDB, INFO);
+  detail::xtrtrs(UPLO, TRANS, DIAG, N, NRHS, A, LDA, B, LDB, INFO);
   if(*INFO>0)
   {
     stringstream message;
-    message << "LAPACK::dtrtrs matrix is reported as being singular, the " << *INFO << "th diagonal is zero. No solutions have been computed.";
-    throw rdag_error(message.str());
-  }
-  if(*INFO<0)
-  {
-    stringstream message;
-    message << "Input to LAPACK::dtrtrs call incorrect at arg: " << *INFO;
-    throw rdag_error(message.str());
-  }
-}
-
-template<> void xtrtrs(char * UPLO, char * TRANS, char * DIAG, int * N, int * NRHS, complex16 * A, int * LDA, complex16 * B, int * LDB, int * INFO)
-{
-  set_xerbla_death_switch(lapack::izero);
-  F77FUNC(ztrtrs)(UPLO, TRANS, DIAG, N, NRHS, A, LDA, B, LDB, INFO);
-  if(*INFO>0)
-  {
-    stringstream message;
-    message << "LAPACK::dtrtrs matrix is reported as being singular, the " << *INFO << "th diagonal is zero. No solutions have been computed.";
+    message << "LAPACK::"<<detail::charmagic<T>()<<"trtrs matrix is reported as being singular, the " << *INFO << "th diagonal is zero. No solutions have been computed.";
     throw rdag_error(message.str());
   }
   if(*INFO!=0)
   {
     stringstream message;
-    message << "Input to LAPACK::ztrtrs call incorrect at arg: " << *INFO;
+    message << "Input to LAPACK::"<<detail::charmagic<T>()<<"trtrs call incorrect at arg: " << *INFO;
     throw rdag_error(message.str());
   }
 }
+template void xtrtrs<real16>(char * UPLO, char * TRANS, char * DIAG, int * N, int * NRHS, real16 * A, int * LDA, real16 * B, int * LDB, int * INFO);
+template void xtrtrs<complex16>(char * UPLO, char * TRANS, char * DIAG, int * N, int * NRHS, complex16 * A, int * LDA, complex16 * B, int * LDB, int * INFO);
 
 
-template<> void xpotrf(char * UPLO, int * N, real16 * A, int * LDA, int * INFO)
+template<typename T> void xpotrf(char * UPLO, int * N, T * A, int * LDA, int * INFO)
 {
   set_xerbla_death_switch(lapack::izero);
-  F77FUNC(dpotrf)(UPLO, N, A, LDA, INFO);
+  detail::xpotrf(UPLO, N, A, LDA, INFO);
   if(*INFO>0)
   {
     stringstream message;
-    message << "LAPACK::dpotrf matrix is reported as being non s.p.d OR the factorisation failed. The " << *INFO << "th leading minor is not positive definite.";
+    message << "LAPACK::"<<detail::charmagic<T>()<<"potrf matrix is reported as being non s.p.d OR the factorisation failed. The " << *INFO << "th leading minor is not positive definite.";
     throw rdag_error(message.str());
   }
   if(*INFO<0)
   {
     stringstream message;
-    message << "Input to LAPACK::dpotrf call incorrect at arg: " << *INFO;
+    message << "Input to LAPACK::"<<detail::charmagic<T>()<<"potrf call incorrect at arg: " << *INFO;
     throw rdag_error(message.str());
   }
 }
+template void xpotrf<real16>(char * UPLO, int * N, real16 * A, int * LDA, int * INFO);
+template void xpotrf<complex16>(char * UPLO, int * N, complex16 * A, int * LDA, int * INFO);
 
-template<> void xpotrf(char * UPLO, int * N, complex16 * A, int * LDA, int * INFO)
-{
-  set_xerbla_death_switch(lapack::izero);
-  F77FUNC(zpotrf)(UPLO, N, A, LDA, INFO);
-  if(*INFO>0)
-  {
-    stringstream message;
-    message << "LAPACK::zpotrf matrix is reported as being non s.p.d OR the factorisation failed. The " << *INFO << "th leading minor is not positive definite.";
-    throw rdag_error(message.str());
-  }
-  if(*INFO<0)
-  {
-    stringstream message;
-    message << "Input to LAPACK::zpotrf call incorrect at arg: " << *INFO;
-    throw rdag_error(message.str());
-  }
-}
 
 template<> void xpocon(char * UPLO, int * N, real16 * A, int * LDA, real16 * ANORM, real16 * RCOND, int * INFO)
 {
@@ -336,36 +386,22 @@ template<> void xpocon(char * UPLO, int * N, complex16 * A, int * LDA, real16 * 
   }
 }
 
-template<>real16 xlansy(char * NORM, char * UPLO, int * N, real16 * A, int * LDA)
+template<typename T>real16 xlansy(char * NORM, char * UPLO, int * N, T * A, int * LDA)
 {
   set_xerbla_death_switch(lapack::izero);
   if(*N<0)
   {
     stringstream message;
-    message << "Input to LAPACK::dlansy call incorrect at arg: " << 3;
+    message << "Input to LAPACK::"<<detail::charmagic<T>()<<"lansy call incorrect at arg: " << 3;
     throw rdag_error(message.str());
   }
   real16 * WORK = new real16[*N]; // allocate regardless of *NORM
-  real16 ret = F77FUNC(dlansy)(NORM, UPLO, N, A, LDA, WORK);
+  real16 ret = detail::xlansy(NORM, UPLO, N, A, LDA, WORK);
   delete [] WORK;
   return ret;
 }
-
-template<>real16 xlansy(char * NORM, char * UPLO, int * N, complex16 * A, int * LDA)
-{
-  set_xerbla_death_switch(lapack::izero);
-  if(*N<0)
-  {
-    stringstream message;
-    message << "Input to LAPACK::zlansy call incorrect at arg: " << 3;
-    throw rdag_error(message.str());
-  }
-  real16 * WORK = new real16[*N]; // allocate regardless of *NORM
-  real16 ret = F77FUNC(zlansy)(NORM, UPLO, N, A, LDA, WORK);
-  delete [] WORK;
-  return ret;
-}
-
+template real16 xlansy<real16>(char * NORM, char * UPLO, int * N, real16 * A, int * LDA);
+template real16  xlansy<complex16>(char * NORM, char * UPLO, int * N, complex16 * A, int * LDA);
 
 real16 zlanhe(char * NORM, char * UPLO, int * N, complex16 * A, int * LDA)
 {
@@ -377,29 +413,19 @@ real16 zlanhe(char * NORM, char * UPLO, int * N, complex16 * A, int * LDA)
 }
 
 
-template<> void xpotrs(char * UPLO, int * N, int * NRHS, real16 * A, int * LDA, real16 * B, int * LDB, int * INFO)
+template<typename T> void xpotrs(char * UPLO, int * N, int * NRHS, T * A, int * LDA, T * B, int * LDB, int * INFO)
 {
   set_xerbla_death_switch(lapack::izero);
-  F77FUNC(dpotrs)(UPLO, N, NRHS, A, LDA, B, LDB, INFO);
+  detail::xpotrs(UPLO, N, NRHS, A, LDA, B, LDB, INFO);
   if(*INFO<0)
   {
     stringstream message;
-    message << "Input to LAPACK::dpotrs call incorrect at arg: " << *INFO;
+    message << "Input to LAPACK::"<<detail::charmagic<T>()<<"potrs call incorrect at arg: " << *INFO;
     throw rdag_error(message.str());
   }
 }
-
-template<> void xpotrs(char * UPLO, int * N, int * NRHS, complex16 * A, int * LDA, complex16 * B, int * LDB, int * INFO)
-{
-  set_xerbla_death_switch(lapack::izero);
-  F77FUNC(zpotrs)(UPLO, N, NRHS, A, LDA, B, LDB, INFO);
-  if(*INFO<0)
-  {
-    stringstream message;
-    message << "Input to LAPACK::zpotrs call incorrect at arg: " << *INFO;
-    throw rdag_error(message.str());
-  }
-}
+template void xpotrs<real16>(char * UPLO, int * N, int * NRHS, real16 * A, int * LDA, real16 * B, int * LDB, int * INFO);
+template void xpotrs<complex16>(char * UPLO, int * N, int * NRHS, complex16 * A, int * LDA, complex16 * B, int * LDB, int * INFO);
 
 
 } // end namespace lapack

--- a/src/librdag/runners/svdrunner.cc
+++ b/src/librdag/runners/svdrunner.cc
@@ -48,6 +48,9 @@ template<typename T> void svd_dense_runner(RegContainer& reg, const OGMatrix<T>*
     if(info < 0) // illegal arg
     {
       delete[] A;
+      delete[] U;
+      delete[] VT;
+      delete[] S;
       throw e;
     }
     else // failed convergence TODO: this will end up in logs (MAT-369) and userland (MAT-370).

--- a/src/librdag/runners/svdrunner.cc
+++ b/src/librdag/runners/svdrunner.cc
@@ -39,12 +39,27 @@ template<typename T> void svd_dense_runner(RegContainer& reg, const OGMatrix<T>*
   std::memcpy(A, arg->getData(), sizeof(T)*m*n);
 
   // call lapack
-  lapack::xgesvd(lapack::A, lapack::A, &m, &n, A, &lda, S, U, &ldu, VT, &ldvt, &info);
+  try
+  {
+    lapack::xgesvd(lapack::A, lapack::A, &m, &n, A, &lda, S, U, &ldu, VT, &ldvt, &info);
+  }
+  catch (exception& e)
+  {
+    if(info < 0) // illegal arg
+    {
+      delete[] A;
+      throw e;
+    }
+    else // failed convergence TODO: this will end up in logs (MAT-369) and userland (MAT-370).
+    {
+      cerr << e.what() << std::endl;
+    }
+  }
+  delete[] A;
 
   reg.push_back(makeConcreteDenseMatrix(U, m, m, OWNER));
   reg.push_back(new OGRealDiagonalMatrix(S, m, n, OWNER));
   reg.push_back(makeConcreteDenseMatrix(VT, n, n, OWNER));
-  delete[] A;
 }
 
 void *

--- a/src/librdag/test/CMakeLists.txt
+++ b/src/librdag/test/CMakeLists.txt
@@ -18,6 +18,7 @@ set(TESTS
   check_execution
   check_expressions
   check_iss
+  check_lapack
   check_numerictypes
   check_rtti
   check_terminals

--- a/src/librdag/test/check_lapack.cc
+++ b/src/librdag/test/check_lapack.cc
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+#include "gtest/gtest.h"
+#include "warningmacros.h"
+#include "equals.hh"
+#include "lapack.hh"
+#include "exceptions.hh"
+
+using namespace std;
+using namespace librdag;
+
+
+// Check successful templating of dgesvd.
+TEST(LAPACKTest, dgesvd) {
+  int m = 3;
+  int n = 2;
+  int INFO;
+
+  real16* expectedU = new real16[9] {-0.2298476964000714,-0.5247448187602936,-0.8196419411205156,0.8834610176985253,0.2407824921325463,-0.4018960334334317,0.4082482904638627,-0.8164965809277263,0.4082482904638631};
+  real16* expectedS = new real16[2] {9.525518091565107,  0.514300580658644};
+  real16 * expectedVT = new real16[4]{-0.6196294838293402,-0.7848944532670524,-0.7848944532670524,0.6196294838293402};
+
+  real16* U  = new real16[9]();
+  real16* S  = new real16[2]();
+  real16* VT = new real16[4]();
+
+  real16 * A = new real16[6] {1,3,5,2,4,6};
+  real16 * Acpy = new real16[6];
+  std::copy(A,A+m*n,Acpy);
+
+  lapack::xgesvd<real16>(lapack::A, lapack::A, &m, &n, Acpy, &m, S, U, &m, VT, &n, &INFO);
+
+  EXPECT_TRUE(ArrayFuzzyEquals(expectedU,U,9,1e-14,1e-14));
+  EXPECT_TRUE(ArrayFuzzyEquals(expectedS,S,2,1e-14,1e-14));
+  EXPECT_TRUE(ArrayFuzzyEquals(expectedVT,VT,4,1e-14,1e-14));
+
+  // check throw on bad arg
+  std::copy(A,A+m*n,Acpy);
+  m = -1;
+  EXPECT_THROW(lapack::xgesvd<real16>(lapack::A, lapack::A, &m, &n, Acpy, &m, S, U, &m, VT, &n, &INFO), rdag_error);
+
+  delete[] U;
+  delete[] S;
+  delete[] VT;
+  delete[] expectedU;
+  delete[] expectedS;
+  delete[] expectedVT;
+  delete[] A;
+  delete[] Acpy;
+}

--- a/src/librdag/test/check_lapack.cc
+++ b/src/librdag/test/check_lapack.cc
@@ -27,6 +27,14 @@ complex16 c4x2[8] = {{2.,20.}, {5.,50.}, {11.,110.}, {17.,170.}, {3.,30.}, {7.,7
 real16 r4x1[4] = {1,2,3,4};
 complex16 c4x1[4] = {{1,10},{2,20},{3,30},{4,40}};
 
+// tri upper
+real16 rutri4[16] = {1.,0.,0.,0.,2.,6.,0.,0.,3.,7.,11.,0.,4.,8.,12.,16.};
+complex16 cutri4[16] = {{1,10}, 0,0,0,{2,20}, {6,60}, 0,0,{3,30}, {7,70}, {11,110}, 0,{4,40}, {8,80}, {12,120}, {16,160}};
+
+// SPD
+real16 rspd[16] =  {5,9,10,8,9,17,19,15,10,19,29,21,8,15,21,28};
+complex16 cspd[16] = {{ 50,   0}, { 90,  -9}, {100, -10}, { 80,  -8}, { 90,   9}, {170,   0}, {190, -19}, {150, -15}, {100,  10}, {190,  19}, {290,   0}, {210, -21}, { 80,   8}, {150,  15}, {210,  21}, {280,   0}};
+
 
 // Check successful templating of dscal.
 TEST(LAPACKTest_xscal, dscal) {
@@ -182,6 +190,25 @@ TEST(LAPACKTest_xgemm, zgemm) {
   delete[] expected;
 }
 
+// Check successful templating of dnrm2
+TEST(LAPACKTest_xnrm2, dnrm2) {
+
+  int n = 4;
+  real16 answer = lapack::xnrm2(&n, r4x1, lapack::ione);
+  real16 expected = 5.4772255750516612e0;
+  EXPECT_TRUE(SingleValueFuzzyEquals(expected,answer));
+}
+
+// Check successful templating of znrm2
+TEST(LAPACKTest_xnrm2, znrm2) {
+
+  int n = 4;
+  real16 answer = lapack::xnrm2(&n, c4x1, lapack::ione);
+  real16 expected = 55.0454357780915302e0;
+  EXPECT_TRUE(SingleValueFuzzyEquals(expected,answer));
+}
+
+
 // Check successful templating of dgesvd.
 TEST(LAPACKTest_xgesvd, dgesvd) {
   int m = 3;
@@ -200,7 +227,7 @@ TEST(LAPACKTest_xgesvd, dgesvd) {
   real16 * Acpy = new real16[6];
   std::copy(A,A+m*n,Acpy);
 
-  lapack::xgesvd<real16>(lapack::A, lapack::A, &m, &n, Acpy, &m, S, U, &m, VT, &n, &INFO);
+  lapack::xgesvd(lapack::A, lapack::A, &m, &n, Acpy, &m, S, U, &m, VT, &n, &INFO);
 
   EXPECT_TRUE(ArrayFuzzyEquals(expectedU,U,9,1e-14,1e-14));
   EXPECT_TRUE(ArrayFuzzyEquals(expectedS,S,2,1e-14,1e-14));
@@ -209,7 +236,7 @@ TEST(LAPACKTest_xgesvd, dgesvd) {
   // check throw on bad arg
   std::copy(A,A+m*n,Acpy);
   m = -1;
-  EXPECT_THROW(lapack::xgesvd<real16>(lapack::A, lapack::A, &m, &n, Acpy, &m, S, U, &m, VT, &n, &INFO), rdag_error);
+  EXPECT_THROW(lapack::xgesvd(lapack::A, lapack::A, &m, &n, Acpy, &m, S, U, &m, VT, &n, &INFO), rdag_error);
 
   delete[] U;
   delete[] S;
@@ -220,7 +247,6 @@ TEST(LAPACKTest_xgesvd, dgesvd) {
   delete[] A;
   delete[] Acpy;
 }
-
 
 // Check successful templating of zgesvd.
 TEST(LAPACKTest_xgesvd, zgesvd) {
@@ -240,7 +266,7 @@ TEST(LAPACKTest_xgesvd, zgesvd) {
   complex16 * Acpy = new complex16[6];
   std::copy(A,A+m*n,Acpy);
 
-  lapack::xgesvd<complex16>(lapack::A, lapack::A, &m, &n, Acpy, &m, S, U, &m, VT, &n, &INFO);
+  lapack::xgesvd(lapack::A, lapack::A, &m, &n, Acpy, &m, S, U, &m, VT, &n, &INFO);
 
   EXPECT_TRUE(ArrayFuzzyEquals(expectedU,U,9,1e-14,1e-14));
   EXPECT_TRUE(ArrayFuzzyEquals(expectedS,S,2,1e-14,1e-14));
@@ -249,7 +275,7 @@ TEST(LAPACKTest_xgesvd, zgesvd) {
   // check throw on bad arg
   std::copy(A,A+m*n,Acpy);
   m = -1;
-  EXPECT_THROW(lapack::xgesvd<complex16>(lapack::A, lapack::A, &m, &n, Acpy, &m, S, U, &m, VT, &n, &INFO), rdag_error);
+  EXPECT_THROW(lapack::xgesvd(lapack::A, lapack::A, &m, &n, Acpy, &m, S, U, &m, VT, &n, &INFO), rdag_error);
 
   delete[] U;
   delete[] S;
@@ -259,4 +285,169 @@ TEST(LAPACKTest_xgesvd, zgesvd) {
   delete[] expectedVT;
   delete[] A;
   delete[] Acpy;
+}
+
+// Check successful templating of dtrcon.
+TEST(LAPACKTest_xtrcon, dtrcon) {
+  int n = 4;
+  real16 rcond = 0;
+  int INFO = 0;
+  lapack::xtrcon(lapack::ONE, lapack::U, lapack::N, &n, rutri4, &n, &rcond, &INFO );
+  real16 expected = 0.025e0;
+  EXPECT_TRUE(SingleValueFuzzyEquals(expected,rcond));
+}
+
+// Check successful templating of ztrcon.
+TEST(LAPACKTest_xtrcon, ztrcon) {
+  int n = 4;
+  real16 rcond = 0;
+  int INFO = 0;
+  lapack::xtrcon(lapack::ONE, lapack::U, lapack::N, &n, cutri4, &n, &rcond, &INFO );
+  real16 expected = 0.025e0;
+  EXPECT_TRUE(SingleValueFuzzyEquals(expected,rcond));
+}
+
+// Check successful templating of dtrtrs.
+TEST(LAPACKTest_xtrtrs, dtrtrs) {
+  int n = 4;
+  real16 * RHS = new real16[4]{10,8,2,-1};
+  int INFO = 0;
+  lapack::xtrtrs(lapack::U, lapack::N, lapack::N, &n, lapack::ione, rutri4, &n, RHS, &n, &INFO );
+  real16 expected[4] = {7.25,1.125,0.25,-0.0625};
+  EXPECT_TRUE(ArrayFuzzyEquals(expected,RHS,n));
+
+  // check throw on singluar matrix
+  real16 * A = new real16[16];
+  std::copy(rutri4,rutri4+n*n,A);
+  A[5] = 0.e0; // 2nd diagonal
+  EXPECT_THROW(lapack::xtrtrs(lapack::U, lapack::N, lapack::N, &n, lapack::ione, A, &n, RHS, &n, &INFO ), rdag_error);
+
+  // check throw on bad arg
+  n=-1;
+  EXPECT_THROW(lapack::xtrtrs(lapack::U, lapack::N, lapack::N, &n, lapack::ione, rutri4, &n, RHS, &n, &INFO ), rdag_error);
+  delete [] RHS;
+  delete [] A;
+}
+
+// Check successful templating of ztrtrs.
+TEST(LAPACKTest_xtrtrs, ztrtrs) {
+  int n = 4;
+  complex16 * RHS = new complex16[4]{{10.,-2.}, {-7.,3.}, {3.,-6.}, {-2.,-5.}};
+  int INFO = 0;
+  lapack::xtrtrs(lapack::U, lapack::N, lapack::N, &n, lapack::ione, cutri4, &n, RHS, &n, &INFO );
+  complex16 expected[4] = {{-0.1212121212121212,-1.2348484848484849}, {0.0997599759975998, 0.1577032703270327}, {-0.0162016201620162,-0.0425292529252925}, {-0.0321782178217822, 0.0092821782178218}};
+  EXPECT_TRUE(ArrayFuzzyEquals(expected,RHS,n));
+
+  // check throw on singluar matrix
+  complex16 * A = new complex16[16];
+  std::copy(cutri4,cutri4+n*n,A);
+  A[5] = 0.e0; // 2nd diagonal
+  EXPECT_THROW(lapack::xtrtrs(lapack::U, lapack::N, lapack::N, &n, lapack::ione, A, &n, RHS, &n, &INFO ), rdag_error);
+
+  // check throw on bad arg
+  n=-1;
+  EXPECT_THROW(lapack::xtrtrs(lapack::U, lapack::N, lapack::N, &n, lapack::ione, cutri4, &n, RHS, &n, &INFO ), rdag_error);
+  delete [] RHS;
+  delete [] A;
+}
+
+// Check successful templating of dpotrf.
+TEST(LAPACKTest_xpotrf, dpotrf) {
+  int n=4;
+  int INFO = 0;
+  real16 * A = new real16[16];
+
+  std::copy(rspd,rspd+n*n,A);
+  lapack::xpotrf(lapack::U, &n, A, &n, &INFO);
+
+  real16 * expected = new real16[16]{2.2360679774997898,9,10,8,4.0249223594996213,0.8944271909999163,19,15,4.4721359549995796,1.1180339887498942,2.7838821814150103,21,3.5777087639996634,0.6708203932499381,1.5266450672275866,3.5241105031922135};
+  EXPECT_TRUE(ArrayFuzzyEquals(expected,A,n*n));
+
+  // check throw on non SPD
+  std::copy(rspd,rspd+n*n,A);
+  A[9] = 400;
+  EXPECT_THROW(lapack::xpotrf(lapack::U, &n, A, &n, &INFO), rdag_error);
+  EXPECT_TRUE(INFO==3);
+
+  // check throw on bad arg
+  std::copy(rspd,rspd+n*n,A);
+  n = -1;
+  EXPECT_THROW(lapack::xpotrf(lapack::U, &n, A, &n, &INFO), rdag_error);
+
+
+  delete[] A;
+  delete[] expected;
+}
+
+// Check successful templating of zpotrf.
+TEST(LAPACKTest_xpotrf, zpotrf) {
+  int n=4;
+  int INFO = 0;
+  complex16 * A = new complex16[16];
+
+  std::copy(cspd,cspd+n*n,A);
+  lapack::xpotrf(lapack::U, &n, A, &n, &INFO);
+
+  complex16 * expected = new complex16[16]{{  7.0710678118654755,   0}, { 90,   -9}, {100,  -10}, { 80,   -8}, { 12.7279220613578552,   1.2727922061357855}, {  2.5258661880630169,   0}, {190,  -19}, {150,  -15}, { 14.1421356237309492,   1.4142135623730949}, {  3.2464110881060808,   7.5221720334165125}, {  4.5692168854967257,   0}, {210,  -21}, { 11.3137084989847594,   1.1313708498984760}, {  1.8053212880199752,   5.9385568684867200}, { -0.4665266489696448,   3.3487008435600085}, { 10.0380731673420662,   0}};
+  EXPECT_TRUE(ArrayFuzzyEquals(expected,A,n*n,1e-14,1e-14));
+
+  // check throw on non SPD
+  std::copy(cspd,cspd+n*n,A);
+  A[9] = 400;
+  EXPECT_THROW(lapack::xpotrf(lapack::U, &n, A, &n, &INFO), rdag_error);
+  EXPECT_TRUE(INFO==3);
+
+  // check throw on bad arg
+  std::copy(cspd,cspd+n*n,A);
+  n = -1;
+  EXPECT_THROW(lapack::xpotrf(lapack::U, &n, A, &n, &INFO), rdag_error);
+
+
+  delete[] A;
+  delete[] expected;
+}
+
+// Check successful templating of dpocon.
+TEST(LAPACKTest_xpocon, dpocon) {
+  int n = 4;
+  int INFO = 0;
+  real16 * A = new real16[16];
+  std::copy(rspd,rspd+n*n,A);
+  real16 ANORM = lapack::xlansy(lapack::ONE, lapack::U, &n, A, &n);
+  lapack::xpotrf(lapack::U, &n, A, &n, &INFO);
+  real16 RCOND = 0;
+  lapack::xpocon(lapack::U, &n, A, &n, &ANORM, &RCOND, &INFO);
+  real16 anorm_expected = 79e0;
+  EXPECT_TRUE(ANORM==anorm_expected);
+  real16 rcond_expected = 0.00190665795051604e0;
+  EXPECT_TRUE(SingleValueFuzzyEquals(rcond_expected, RCOND));
+
+  // check throw on bad arg
+  n = -1;
+  EXPECT_THROW(lapack::xpocon(lapack::U, &n, A, &n, &ANORM, &RCOND, &INFO), rdag_error);
+
+  delete [] A;
+}
+
+
+// Check successful templating of zpocon.
+TEST(LAPACKTest_xpocon, zpocon) {
+  int n = 4;
+  int INFO = 0;
+  complex16 * A = new complex16[16];
+  std::copy(cspd,cspd+n*n,A);
+  real16 ANORM = lapack::zlanhe(lapack::ONE, lapack::U, &n, A, &n);
+  lapack::xpotrf(lapack::U, &n, A, &n, &INFO);
+  real16 RCOND = 0;
+  lapack::xpocon(lapack::U, &n, A, &n, &ANORM, &RCOND, &INFO);
+  real16 anorm_expected = 792.493781056045;
+  EXPECT_TRUE(SingleValueFuzzyEquals(ANORM,anorm_expected));
+  real16 rcond_expected = 3.21351909155511e-04;
+  EXPECT_TRUE(SingleValueFuzzyEquals(rcond_expected, RCOND));
+
+  // check throw on bad arg
+  n = -1;
+  EXPECT_THROW(lapack::xpocon(lapack::U, &n, A, &n, &ANORM, &RCOND, &INFO), rdag_error);
+
+  delete [] A;
 }

--- a/src/librdag/test/check_lapack.cc
+++ b/src/librdag/test/check_lapack.cc
@@ -13,9 +13,177 @@
 using namespace std;
 using namespace librdag;
 
+/**
+ * These tests are present to loosly check the *wiring* of LAPACK not LAPACK itself.
+ * Our bindings are templated so the tests where applicable will check one real and
+ * one complex variant of a routine.
+ */
+
+// Some general matrices for input.
+real16 r5x4[20] = {1,5,9,13,17,2,6,10,14,18,3,7,11,15,19,4,8,12,16,20};
+complex16 c5x4[20] =  {{1,10}, {5,50}, {9,90}, {13,130}, {17,170}, {2,20}, {6,60}, {10,100}, {14,140}, {18,180}, {3,30}, {7,70}, {11,110}, {15,150}, {19,190}, {4,40}, {8,80}, {12,120}, {16,160}, {20,200}};
+real16 r4x2[8] = {2,5,11,17,3,7,13,19};
+complex16 c4x2[8] = {{2.,20.}, {5.,50.}, {11.,110.}, {17.,170.}, {3.,30.}, {7.,70.}, {13.,130.}, {19.,190.}};
+real16 r4x1[4] = {1,2,3,4};
+complex16 c4x1[4] = {{1,10},{2,20},{3,30},{4,40}};
+
+
+// Check successful templating of dscal.
+TEST(LAPACKTest_xscal, dscal) {
+  int N = 4;
+  real16 alpha = 10.e0;
+  real16 * x = new real16[4]{1,2,3,4};
+  real16 * expected = new real16[4]{10,20,30,40};
+  lapack::xscal(&N, &alpha, x, lapack::ione);
+  EXPECT_TRUE(ArrayFuzzyEquals(expected,x,4));
+
+  delete[] x;
+  delete[] expected;
+}
+
+// Check successful templating of zscal.
+TEST(LAPACKTest_xscal, zscal) {
+  int N = 4;
+  complex16 alpha = {2,10};
+  complex16 * x = new complex16[4]{{1,10},{2,20},{3,30},{4,40}};
+  complex16 * expected = new complex16[4]{{-98.,30.}, {-196.,60.}, {-294.,90.}, {-392.,120.}};
+  lapack::xscal(&N, &alpha, x, lapack::ione);
+  EXPECT_TRUE(ArrayFuzzyEquals(expected,x,4));
+
+  delete[] x;
+  delete[] expected;
+}
+
+// Check successful templating of dgemv
+TEST(LAPACKTest_xgemv, dgemv) {
+
+  int m = 5;
+  int n = 4;
+
+  // copy in A
+  real16 * A = new real16[20];
+  std::copy(r5x4,r5x4+m*n,A);
+
+  real16 alpha = 2.e0;
+
+  // copy in x
+  real16 * x = new real16[4];
+  std::copy(r4x1,r4x1+n,x);
+
+  real16 beta = 3.e0;
+
+  real16 y[5] = {-1,-1,-1,-1,-1};
+
+  real16 * expected = new real16[5]{57.,137.,217.,297.,377.};
+
+  //check call
+  lapack::xgemv(lapack::N, &m, &n, &alpha, A, &m, x, lapack::ione, &beta, y, lapack::ione);
+  EXPECT_TRUE(ArrayFuzzyEquals(expected,y,m));
+
+  delete[] A;
+  delete[] x;
+  delete[] expected;
+}
+
+// Check successful templating of zgemv
+TEST(LAPACKTest_xgemv, zgemv) {
+
+  int m = 5;
+  int n = 4;
+
+  // copy in A
+  complex16 * A = new complex16[20];
+  std::copy(c5x4,c5x4+m*n,A);
+
+  complex16 alpha = {2.e0,3.e0};
+
+  // copy in x
+  complex16 * x = new complex16[4];
+  std::copy(c4x1,c4x1+n,x);
+
+  complex16 beta = {3.e0,4.e0};
+
+  complex16 y[5] = {{-1,-2},{-1,-2},{-1,-2},{-1,-2},{-1,-2}};
+
+  complex16 * expected = new complex16[5] {{  -7735.,-7720.}, { -18055.,  -18000.}, { -28375.,  -28280.}, { -38695.,  -38560.}, { -49015.,  -48840.}};
+
+  //check call
+  lapack::xgemv(lapack::N, &m, &n, &alpha, A, &m, x, lapack::ione, &beta, y, lapack::ione);
+  EXPECT_TRUE(ArrayFuzzyEquals(expected,y,m));
+
+  delete[] A;
+  delete[] x;
+  delete[] expected;
+}
+
+// Check successful templating of dgemm
+TEST(LAPACKTest_xgemm, dgemm) {
+
+  int m = 5;
+  int k = 4;
+  int n = 2;
+
+  // copy in A
+  real16 * A = new real16[20];
+  std::copy(r5x4,r5x4+m*k,A);
+
+  // copy in B
+  real16 * B = new real16[8];
+  std::copy(r4x2,r4x2+n*k,B);
+
+  real16 alpha = 2.e0;
+
+  real16 beta = 3.e0;
+
+  // create C
+  real16 C[10] = {-1,-1,-1,-1,-1,-1,-1,-1,-1,-1};
+
+  real16 * expected = new real16[10]{223.,503.,783.,1063.,1343.,261.,597.,933.,1269.,1605.};
+
+  //check call
+  lapack::xgemm(lapack::N,lapack::N, &m, &n, &k, &alpha, A, &m, B, &k, &beta, C, &m);
+  EXPECT_TRUE(ArrayFuzzyEquals(expected,C,m*n));
+
+  delete[] A;
+  delete[] B;
+  delete[] expected;
+}
+
+// Check successful templating of dgemm
+TEST(LAPACKTest_xgemm, zgemm) {
+
+  int m = 5;
+  int k = 4;
+  int n = 2;
+
+  // copy in A
+  complex16 * A = new complex16[20];
+  std::copy(c5x4,c5x4+m*k,A);
+
+  // copy in B
+  complex16 * B = new complex16[8];
+  std::copy(c4x2,c4x2+n*k,B);
+
+  complex16 alpha = {2.e0,3.e0};
+
+  complex16 beta = {3.e0,4.e0};
+
+  // create C
+  complex16 C[10] = {{-1,-2},{-1,-2},{-1,-2},{-1,-2},{-1,-2},{-1,-2},{-1,-2},{-1,-2},{-1,-2},{-1,-2}};
+
+  complex16 * expected = new complex16[10]{{ -29149,  -29051}, { -65269,  -65031}, {-101389, -101011}, {-137509, -136991}, {-173629, -172971}, { -34051,  -33934}, { -77395,  -77110}, {-120739, -120286}, {-164083, -163462}, {-207427, -206638}};
+
+  //check call
+  lapack::xgemm(lapack::N,lapack::N, &m, &n, &k, &alpha, A, &m, B, &k, &beta, C, &m);
+  EXPECT_TRUE(ArrayFuzzyEquals(expected,C,m*n));
+
+  delete[] A;
+  delete[] B;
+  delete[] expected;
+}
 
 // Check successful templating of dgesvd.
-TEST(LAPACKTest, dgesvd) {
+TEST(LAPACKTest_xgesvd, dgesvd) {
   int m = 3;
   int n = 2;
   int INFO;
@@ -42,6 +210,46 @@ TEST(LAPACKTest, dgesvd) {
   std::copy(A,A+m*n,Acpy);
   m = -1;
   EXPECT_THROW(lapack::xgesvd<real16>(lapack::A, lapack::A, &m, &n, Acpy, &m, S, U, &m, VT, &n, &INFO), rdag_error);
+
+  delete[] U;
+  delete[] S;
+  delete[] VT;
+  delete[] expectedU;
+  delete[] expectedS;
+  delete[] expectedVT;
+  delete[] A;
+  delete[] Acpy;
+}
+
+
+// Check successful templating of zgesvd.
+TEST(LAPACKTest_xgesvd, zgesvd) {
+  int m = 3;
+  int n = 2;
+  int INFO;
+
+  complex16* expectedU = new complex16[9] {{-0.0228707006002169,-0.2287070060021659}, {-0.0522140610036492,-0.5221406100364927}, {-0.0815574214070819,-0.8155742140708198}, {-0.0879076568710847,-0.8790765687107978}, {-0.0239587534423321,-0.2395875344233279}, {0.0399901499864153, 0.3999014998641418}, {0.3147401422050641, 0.2600102104752862}, {-0.6294802844101258,-0.5200204209505755}, {0.3147401422050625, 0.2600102104752883}};
+  real16* expectedS = new real16[2] {95.7302720469661779,5.1686568674896343};
+  complex16 * expectedVT = new complex16[4]{{-0.6196294838293402,0},{0.7848944532670524,-0.e0},{-0.7848944532670524,0},{-0.6196294838293402,0}};
+
+  complex16* U  = new complex16[9]();
+  real16* S  = new real16[2]();
+  complex16* VT = new complex16[4]();
+
+  complex16 * A = new complex16[6]{{1,10}, {3,30}, {5,50}, {2,20}, {4,40}, {6,60}};
+  complex16 * Acpy = new complex16[6];
+  std::copy(A,A+m*n,Acpy);
+
+  lapack::xgesvd<complex16>(lapack::A, lapack::A, &m, &n, Acpy, &m, S, U, &m, VT, &n, &INFO);
+
+  EXPECT_TRUE(ArrayFuzzyEquals(expectedU,U,9,1e-14,1e-14));
+  EXPECT_TRUE(ArrayFuzzyEquals(expectedS,S,2,1e-14,1e-14));
+  EXPECT_TRUE(ArrayFuzzyEquals(expectedVT,VT,4,1e-14,1e-14));
+
+  // check throw on bad arg
+  std::copy(A,A+m*n,Acpy);
+  m = -1;
+  EXPECT_THROW(lapack::xgesvd<complex16>(lapack::A, lapack::A, &m, &n, Acpy, &m, S, U, &m, VT, &n, &INFO), rdag_error);
 
   delete[] U;
   delete[] S;


### PR DESCRIPTION
This PR:
- Adds in a number of functions from LAPACK/BLAS via templates. The purpose of doing this is so that we can write methods in terms of templates that will use LAPACK/BLAS for the lifting without worrying about
  - what the data type is
  - F77 calling conventions 
  - computing the workspace requirements/memory management
- Also included are patches to make the LAPACK frames exception safe in terms of memory management.

Coverage:
Java: 91%
build/src/jshim 0.8% (no change)
build/src/librdag 13.5% (no change)
src/jshim 57.7% (no change)
src/librdag 92.9% (up 1.6%)
src/librdag/runners 96.3% (down 3.6%, exception catches not covered in SVD runner)
