### PR TITLE
[MAT-378] Version info in JAR, fix rebuilding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,6 +197,20 @@ endif()
 # Where the generated include files live
 set(BIN_INCLUDE_DIR ${CMAKE_BINARY_DIR}/include)
 
+# Add version info file
+if(WIN32)
+  set(PLATFORM_CODE win)
+else()
+  if(APPLE)
+    set(PLATFORM_CODE osx)
+  else()
+    set(PLATFORM_CODE lnx)
+  endif()
+endif()
+add_custom_target(verinfo
+                  ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/cmake/verinfo.py ${CMAKE_BINARY_DIR}/lib/og-maths-${PLATFORM_CODE}-sha1.txt
+                  COMMENT "Generating version info")
+
 add_subdirectory(src)
 
 add_gtest_report()

--- a/cmake/verinfo.py
+++ b/cmake/verinfo.py
@@ -1,0 +1,24 @@
+#
+# Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+#
+# Please see distribution for license.
+#
+
+import sys, subprocess
+
+def main():
+    if len(sys.argv) != 2:
+        print "Usage: verinfo.py <output_file>"
+        return 1
+
+    process = subprocess.Popen(['git', 'rev-parse', 'HEAD'], stdout=subprocess.PIPE)
+    rev, unused_err = process.communicate()
+    retcode = process.poll()
+    if retcode:
+        raise RuntimeError('Error getting SHA1 of git HEAD')
+    with open(sys.argv[1],'w') as f:
+        f.write(rev)
+    return 0
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/src/java/src/main/CMakeLists.txt
+++ b/src/java/src/main/CMakeLists.txt
@@ -69,7 +69,7 @@ endforeach()
 add_jar(${JAR_NAME_NO_EXTN} ${JAR_SOURCES}
         RESOURCES ${CMAKE_CURRENT_SOURCE_DIR}/config
         INCLUDE_NATIVE TRUE
-        DEPENDS ${jar_native_libraries}
+        DEPENDS verinfo
         ENTRY_POINT com/opengamma/maths/nativeloader/NativeLibrariesSelfTest
         OUTPUT_DIR ${JARDIR})
 


### PR DESCRIPTION
Rebuilding of the JAR after some a non-java file that is included
in it changes should now be fixed. This is achieved by always
rebuilding a JAR containing native code, by using a custom target
to build the JAR instead of a custom command.

Also, handling of the DEPENDS argument to add_jar() is implemented
- a DEPENDS argument was specified in the main JAR's add_jar, but
  DEPENDS was not actually being handled by add_jar.

A small script to generate a text file containing the SHA1 of the
commit for inclusion into the JAR is added. The correct updating
of this file every time the JAR is built is handled by using the
new DEPENDS argument.

Coverage is unchanged - this is a build system change only.
