### PR TITLE
[MAT-379] patch javadoc bug, this is a PR demo, deliberate mistake\!

### DIFF
--- a/src/java/src/main/java/com/opengamma/maths/datacontainers/matrix/OGComplexDenseMatrix.java
+++ b/src/java/src/main/java/com/opengamma/maths/datacontainers/matrix/OGComplexDenseMatrix.java
@@ -59,7 +59,7 @@ public class OGComplexDenseMatrix extends OGDenseMatrix {
    * Takes a column major double[] and turns it into an OGComplexArray
    * The length of dataIn must be either:
    * a) rows*columns in which case it is assumed the double[] provided is the real part of the data (imaginary part assumed zero)
-   * c) 2*rows*columns in which case it is assumed the double[] provided is formed of interleaved real and imaginary values
+   * b) 2*rows*columns in which case it is assumed the double[] provided is formed of interleaved real and imaginary values
    * @param dataIn the real part data backing data
    * @param rows number of rows
    * @param columns number of columns

--- a/src/java/src/main/java/com/opengamma/maths/datacontainers/matrix/OGComplexDenseMatrix.java
+++ b/src/java/src/main/java/com/opengamma/maths/datacontainers/matrix/OGComplexDenseMatrix.java
@@ -58,8 +58,8 @@ public class OGComplexDenseMatrix extends OGDenseMatrix {
   /**
    * Takes a column major double[] and turns it into an OGComplexArray
    * The length of dataIn must be either:
-   * <li>rows*columns in which case it is assumed the double[] provided is the real part of the data (imaginary part assumed zero)
-   * <li>2*rows*columns in which case it is assumed the double[] provided is formed of interleaved real and imaginary values
+   * a) rows*columns in which case it is assumed the double[] provided is the real part of the data (imaginary part assumed zero)
+   * c) 2*rows*columns in which case it is assumed the double[] provided is formed of interleaved real and imaginary values
    * @param dataIn the real part data backing data
    * @param rows number of rows
    * @param columns number of columns


### PR DESCRIPTION
This PR is a minor bugfix for javadoc not building with `<li>` tags.
This is a demo PR!

Coverage: No change as textual changes only.
