### PR TITLE
Add GCC runtime libraries into JARs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -79,8 +79,10 @@ cd build
 Next run CMake. It is required that the path to the OG-Lapack exports file is provided ([build OG-Lapack locally first!](https://github.com/OpenGamma/OG-Lapack/)) so that the build can link against the LAPACK libraries and include them in the built JAR. This is done with the `LAPACK_EXPORT` CMake variable. Invocation of CMake:
 
 ```
-cmake .. -DLAPACK_EXPORT=<path_to_og_lapack>/build/LAPACK_EXPORTS.cmake
+cmake .. -DLAPACK_EXPORT=<path_to_og_lapack>/build/LAPACK_EXPORTS.cmake -DGCC_LIB_FOLDER=<path to gcc RTLs>
 ```
+
+The build process includes the GCC runtime libraries, which are copied from `GCC_LIB_FOLDER`. As an alternative to specifying the location as an argument to CMake, the environment variable `GCC_LIB_FOLDER` may also be set to specify the location. Specifying the location on the command line overrides the value stored in the environment variable.
 
 Build with:
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -29,3 +29,16 @@ The file 'include/fake_jni.h' is based on code from Android
 and it is licensed under the Apache Software License v2.0, see
 'licenses/APLv2.0.txt' for license text.
 
+The GNU Compiler Collection:
+Binary distributions of this project include the GCC runtime libraries libgcc_s,
+libgfortran, libstdc++ and libquadmath, which are covered by the GNU General
+Public License (GPL) version 3 with the GCC Runtime Library Exception. Target
+Code is created using an Eligible Compilation Process.  The GNU GPL v3 text is
+in licenses/GCCv3.txt. The GCC Runtime Library Exception is in
+licenses/gcc-exception-3.1.html, retrieved from
+http://www.gnu.org/licenses/gcc-exception-3.1.html on 02/05/2014. The GCC
+Runtime Library Exception FAQ, which clarifies that Target Code produced under
+an Eligible Compilation Process may be distributed in binary form alongside the
+GCC Runtime Libraries is at licenses/gcc-exception-3.1-faq.html, and was
+retrieved from https://www.gnu.org/licenses/gcc-exception-3.1-faq.html on
+02/05/2014.

--- a/cmake/buildutils.py
+++ b/cmake/buildutils.py
@@ -1,0 +1,18 @@
+#
+# Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+#
+# Please see distribution for license.
+#
+
+import platform
+
+def platform_code():
+    """Returns the current platform code, following the usual convention
+    for OG-Maths."""
+    p = platform.system()
+    if p == 'Linux':
+        return 'lnx'
+    elif p == 'Darwin':
+        return 'osx'
+    else:
+        return 'win'

--- a/cmake/modules/NativeLibraryBuilder.cmake
+++ b/cmake/modules/NativeLibraryBuilder.cmake
@@ -5,16 +5,7 @@
 #
 
 include(CMakeParseArguments)
-
-macro(set_platform_folder)
-  if(APPLE)
-    set(native_platform "mac")
-  elseif(WIN32)
-    set(native_platform "win")
-  elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-    set(native_platform "lin")
-  endif()
-endmacro()
+include(NativeLibraryUtils)
 
 set(jar_native_libraries CACHE INTERNAL "Native libraries to be built into the JAR")
 
@@ -24,7 +15,7 @@ macro(jar_native_library lib)
   get_property(_version TARGET ${lib} PROPERTY VERSION)
   get_property(_location TARGET ${lib} PROPERTY LOCATION)
   get_property(_ncfg TARGET ${lib} PROPERTY IMPORTED_SONAME_NOCONFIG)
-  set_platform_folder()
+  set_platform_code(NATIVE_PLATFORM)
 
   # if the lib is imported, we know what it is called!
   if(_ncfg)
@@ -46,7 +37,7 @@ macro(jar_native_library lib)
   endif()
 
   set(_src ${_location})
-  set(_dest ${CMAKE_BINARY_DIR}/lib/${native_platform}/${_output_name})
+  set(_dest ${CMAKE_BINARY_DIR}/lib/${NATIVE_PLATFORM}/${_output_name})
   add_custom_command(OUTPUT  ${_dest}
                      COMMAND cmake -E copy_if_different
                      ARGS    ${_src} ${_dest}

--- a/cmake/modules/NativeLibraryUtils.cmake
+++ b/cmake/modules/NativeLibraryUtils.cmake
@@ -1,0 +1,15 @@
+#
+# Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+#
+# Please see distribution for license.
+#
+
+macro(set_platform_code PC_VAR)
+  if(APPLE)
+    set(${PC_VAR} "mac")
+  elseif(WIN32)
+    set(${PC_VAR} "win")
+  elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+    set(${PC_VAR} "lin")
+  endif()
+endmacro()

--- a/cmake/modules/UseJava.cmake
+++ b/cmake/modules/UseJava.cmake
@@ -393,8 +393,12 @@ function(add_jar _TARGET_NAME)
                         DEPENDS ${jar_native_libraries} ${_add_jar_DEPENDS}
                         COMMENT "Copying native libraries to the build directory")
       set_platform_code(NATIVE_PLATFORM)
+      set(_copyrtl_args)
+      if (GCC_LIB_FOLDER)
+        set(_copyrtl_args "-l ${GCC_LIB_FOLDER}")
+      endif()
       add_custom_target(copyrtl
-                        ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/cmake/syslibs.py -o ${_dest}/${NATIVE_PLATFORM}
+                        ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/cmake/syslibs.py -o ${_dest}/${NATIVE_PLATFORM} ${_copyrtl_args}
                         COMMENT "Copying GCC runtime libraries to the build directory"
                         DEPENDS copylibs)
       list(APPEND _JAVA_NATIVE_FILES lib)

--- a/cmake/modules/UseJava.cmake
+++ b/cmake/modules/UseJava.cmake
@@ -208,6 +208,7 @@
 #  License text for the above reference.)
 
 include(CMakeParseArguments)
+include(NativeLibraryUtils)
 
 # define helper scripts
 set(_JAVA_CLASS_FILELIST_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/UseJavaClassFilelist.cmake)
@@ -391,8 +392,13 @@ function(add_jar _TARGET_NAME)
                         cmake -E copy_directory ${_src} ${_dest}
                         DEPENDS ${jar_native_libraries} ${_add_jar_DEPENDS}
                         COMMENT "Copying native libraries to the build directory")
+      set_platform_code(NATIVE_PLATFORM)
+      add_custom_target(copyrtl
+                        ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/cmake/syslibs.py -o ${_dest}/${NATIVE_PLATFORM}
+                        COMMENT "Copying GCC runtime libraries to the build directory"
+                        DEPENDS copylibs)
       list(APPEND _JAVA_NATIVE_FILES lib)
-      list(APPEND _JAVA_DEPENDS copylibs)
+      list(APPEND _JAVA_DEPENDS copyrtl)
     endif()
 
     # create an empty java_class_filelist

--- a/cmake/syslibs.py
+++ b/cmake/syslibs.py
@@ -1,0 +1,43 @@
+#
+# Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+#
+# Please see distribution for license.
+#
+
+"""Copies the GCC runtime libraries into the jar libraries build folder."""
+
+import argparse, os, shutil, sys
+from buildutils import platform_code
+
+libs = {}
+libs['lnx'] = [ 'libstdc++.so.6', 'libgcc_s.so.1', 'libgfortran.so.3', 'libquadmath.so.0' ]
+libs['osx'] = [ 'libstdc++.6.dylib', 'libgcc_s.1.dylib', 'libgfortran.3.dylib', 'libquadmath.0.dylib' ]
+libs['win'] = [ 'libstdc++-6.dll', 'libgcc_s_seh-1.dll', 'libgfortran-3.dll', 'libquadmath-0.dll' ]
+
+default_gcc_lib_folder = {}
+default_gcc_lib_folder['lnx'] = '/opt/gcc/4.8.2/lib64'
+default_gcc_lib_folder['osx'] = '/opt/local/lib/gcc48'
+default_gcc_lib_folder['win'] = 'C:\\BuildSystem\\mingw-builds\\x64-4.8.1-win32-seh-rev2\\mingw64\\bin'
+
+def get_parser():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('-l', '--lib-location', help='Location of GCC runtime libraries')
+    parser.add_argument('-o', '--output', help='Output folder')
+    return parser
+
+def get_lib_folder(args):
+    p = platform_code()
+    return args.lib_location or os.environ.get('GCC_LIB_FOLDER') or default_gcc_lib_folder[p]
+
+def main(args):
+    gcc_lib_folder = get_lib_folder(args)
+    print "GCC libraries are at %s" % gcc_lib_folder
+    p = platform_code()
+    for lib in libs[p]:
+        src = os.path.join(gcc_lib_folder, lib)
+        dest = os.path.join(args.output, lib)
+        print "Copying %s to %s" % (src, dest)
+        shutil.copyfile(src, dest)
+
+if __name__ == '__main__':
+    sys.exit(main(get_parser().parse_args()))

--- a/cmake/verinfo.py
+++ b/cmake/verinfo.py
@@ -9,7 +9,7 @@ the current platform. Version info is a yaml file containing
 the revision number, build number, version number, project name,
 timestamp/local time, and list of artifacts."""
 
-import platform, sys, subprocess, time
+import sys, subprocess, time
 from buildutils import platform_code
 from yaml import load, dump
 try:

--- a/cmake/verinfo.py
+++ b/cmake/verinfo.py
@@ -7,7 +7,7 @@
 """This tool creates a version info file for an OG-Maths build on
 the current platform. Version info is a yaml file containing
 the revision number, build number, version number, project name,
-and list of artifacts."""
+timestamp/local time, and list of artifacts."""
 
 import platform, sys, subprocess, time
 from yaml import load, dump

--- a/cmake/verinfo.py
+++ b/cmake/verinfo.py
@@ -10,6 +10,7 @@ the revision number, build number, version number, project name,
 timestamp/local time, and list of artifacts."""
 
 import platform, sys, subprocess, time
+from buildutils import platform_code
 from yaml import load, dump
 try:
     from yaml import CLoader as Loader, CDumper as Dumper
@@ -25,17 +26,6 @@ def jarname(version, suffix):
     else:
         suffix = '-%s' % suffix
     return 'jars/og-maths-%s-%s%s.jar' % (platform_code(), version, suffix)
-
-def platform_code():
-    """Returns the current platform code, following the usual convention
-    for OG-Maths."""
-    p = platform.system()
-    if p == 'Linux':
-        return 'lnx'
-    elif p == 'Darwin':
-        return 'osx'
-    else:
-        return 'win'
 
 def get_subprojects(lapack_verinfo_file):
     """Returns a list of verinfo data for the OG-Maths subprojects. At the

--- a/licenses/GPLv3.txt
+++ b/licenses/GPLv3.txt
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<http://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/licenses/gcc-exception-3.1-faq.html
+++ b/licenses/gcc-exception-3.1-faq.html
@@ -1,0 +1,478 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+
+<head>
+<!-- start of server/head-include-1.html -->
+<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<link rev="made" href="mailto:webmasters@gnu.org" />
+<link rel="icon" type="image/png" href="/graphics/gnu-head-mini.png" />
+<meta name="ICBM" content="42.355469,-71.058627" />
+<meta name="DC.title" content="gnu.org" />
+<!-- end of server/head-include-1.html -->
+
+<!-- end of server/header.html -->
+
+<!-- Parent-Version: 1.77 -->
+<title>GCC Runtime Library Exception Rationale and FAQ
+- GNU Project - Free Software Foundation</title>
+<!-- begin translist file -->
+
+
+<!-- end translist file -->
+
+<!-- start of server/banner.html -->
+<!-- start of head-include-2.html -->
+
+<link rel="stylesheet" href="/combo.css" media="screen" />
+<link rel="stylesheet" href="/mini.css" media="handheld" />
+<link rel="stylesheet" href="/layout.css" media="screen" />
+
+<link rel="stylesheet" href="/print.css" media="print" />
+
+<!-- end of head-include-2.html -->
+
+</head>
+<body>
+<div class="inner">
+<!-- start of server/body-include-1.html -->
+
+<div id="toplinks">
+ <a href="#content">Skip to main text</a>
+</div> <!-- /toplinks -->
+
+<div id="searcher">
+ <form method="get" action="//www.gnu.org/cgi-bin/estseek.cgi">
+  <div>
+  <input name="phrase" id="phrase" type="text" size="18" accesskey="s"
+         value="Why GNU/Linux?" onfocus="this.value=''" />
+  <input type="submit" value="Search" />
+  </div>
+ </form>
+</div><!-- /searcher -->
+
+<div id="translations">
+<p>
+<span dir="ltr" class="original"><a lang="en" hreflang="en" href="/licenses/gcc-exception-3.1-faq.en.html">English</a>&nbsp;[en]</span>&nbsp;&nbsp;
+<span dir="ltr"><a lang="de" hreflang="de" href="/licenses/gcc-exception-3.1-faq.de.html">Deutsch</a>&nbsp;[de]</span>&nbsp;&nbsp;
+<span dir="ltr"><a lang="fr" hreflang="fr" href="/licenses/gcc-exception-3.1-faq.fr.html">français</a>&nbsp;[fr]</span>&nbsp;&nbsp;
+<span dir="ltr"><a lang="ja" hreflang="ja" href="/licenses/gcc-exception-3.1-faq.ja.html">日本語</a>&nbsp;[ja]</span>&nbsp;&nbsp;
+<span dir="ltr"><a lang="ru" hreflang="ru" href="/licenses/gcc-exception-3.1-faq.ru.html">русский</a>&nbsp;[ru]</span>&nbsp;&nbsp;
+</p>
+</div>
+
+<!-- end of server/body-include-1.html -->
+
+<!-- start of server/body-include-2 -->
+
+<div id="header">
+<div id="fsf-frame">
+<p id="join-fsf"><a href="https://www.fsf.org/associate/support_freedom?referrer=4052">JOIN&nbsp;THE&nbsp;FSF</a></p><hr />
+<div id="fssbox">
+<p><a href="http://www.fsf.org/fss">GNU/FSF Newsletter</a></p>
+<form action="https://crm.fsf.org/civicrm/profile/create&amp;reset=1&amp;gid=31" method="post">
+ <div>
+  <input name="postURL" type="hidden" value="" />
+  <input type="hidden" name="group[25]" value="1" />
+  <input name="cancelURL" type="hidden" value="https://crm.fsf.org/civicrm/profile?reset=1&amp;gid=31" />
+  <input name="_qf_default" type="hidden" value="Edit:cancel" />
+ </div>
+ <p>
+  <input type="text" id="frmEmail" name="email-Primary" size="18" maxlength="80"
+         value="email address" onfocus="this.value=''"/>
+  <input type="submit" name="_qf_Edit_next" value="Sign up" />
+ </p>
+</form>
+</div><!-- /fssbox -->
+</div><!-- /fsf-frame -->
+
+<div id="gnu-banner">
+ <a href="/">
+ <img src="/graphics/heckert_gnu.small.png" alt=" [A GNU head] " /><strong>GNU</strong> Operating System</a>
+</div><!-- /gnu-banner -->
+<p id="fsf-support">Sponsored by the <a href="#mission-statement">Free Software Foundation</a></p>
+
+</div><!-- /header -->
+
+<div id="navigation">
+
+ <ul>
+  <li id="tabAboutGNU"><a href="/gnu/gnu.html">About&nbsp;GNU</a></li>
+  <li id="tabPhilosophy"><a href="/philosophy/philosophy.html">Philosophy</a></li>
+  <li id="tabLicenses"><a href="/licenses/licenses.html">Licenses</a></li>
+  <li id="tabEducation"><a href="/education/education.html">Education</a></li>
+  <li id="tabSoftware"><a href="/software/software.html">Software</a></li>
+  <li id="tabDoc"><a href="/doc/doc.html">Documentation</a></li>
+  <li id="tabHelp"><a href="/help/help.html">Help&nbsp;GNU</a></li>
+ </ul>
+
+</div><!--  /navigation -->
+<!-- end of server/body-include-2 -->
+
+<div id="content">
+<!-- end of server/banner.html -->
+
+<h2>GCC Runtime Library Exception Rationale and FAQ</h2>
+
+<h3>Introduction</h3>
+
+<p>On June 29th, 2007 the Free Software Foundation released GPLv3.  It
+was immediately adopted by fifteen GNU projects, and more made the
+switch in the following months.  Most of the GCC codebase migrated to
+the new license in the 4.2.2 release, and now we are preparing to
+finish that process.</p>
+
+<p>The licenses for some libraries that accompany GCC have not been
+changed yet.  These libraries are automatically used by the object
+code that GCC produces.  Because of that, if these libraries were
+simply distributed only under the terms of the GPL, all the object
+code that GCC produces would have to be distributed under the same
+terms.  However, the FSF decided long ago to allow developers to use
+GCC's libraries to compile any program, regardless of its license.
+Developing nonfree software is not good for society, and we have no
+obligation to make it easier.  We decided to permit this because
+forbidding it seemed likely to backfire, and because using small
+libraries to limit the use of GCC seemed like the tail wagging the
+dog.</p>
+
+<p>Therefore, these libraries have always had license exceptions that
+allow people to distribute the object code GCC produces under any
+license.  We are now moving these libraries to GPLv3 and updating
+their exceptions.  Our fundamental policy has not changed; the new
+license is meant to permit all the uses of GCC that were permitted
+before.  However, we have decided to use this opportunity to update
+the exception to accomplish three goals:</p>
+
+<ul>
+<li><p>Take advantage of GPLv3's new provisions.  GPLv3 features a number
+of new terms which benefit all software.  These include section 7,
+which establishes a framework for providing license exceptions.  In
+order for GCC to get the most benefit from GPLv3, we need to update
+the exception to take these new terms into account, and work within
+the parameters of section 7.</p></li>
+<li><p>Lay the groundwork for a plugin infrastructure in GCC.  For a while
+now, the GCC developers have considered adding a plugin framework to
+the compiler.  This would make it easier for others to contribute to
+the project, and accelerate the development of new compilation
+techniques for GCC.  However, there have also been concerns that
+unscrupulous developers could write plugins that called out to
+proprietary software to transform the compiled code&mdash;effectively
+creating proprietary extensions to GCC and defeating the purpose of
+the GPL.  The updated exception prevents such abuse, enabling the
+GCC team to look forward to plugin developments.</p></li>
+<li><p>Make exceptions throughout the GCC code base consistent.  Over the
+years, as new files were added to GCC that needed to carry this
+license exception, we reviewed and updated the language to help
+clarify it and address new concerns.  As a result, there are now
+many different exception texts in GCC that provide the same basic
+permissions.  Now all of those files will be able to use the single
+new exception text that we've prepared, making it easier to perform
+legal reviews on the code.</p></li>
+</ul>
+
+<p>As with GPLv3, we worked hard to listen to various users' concerns
+while we drafted this, and address them appropriately.  All told, we
+have spent more than a year on this process.  The Free Software
+Foundation and the GCC Steering Committee would like to thank Richard
+Fontana, Bradley Kuhn, and Karen Sandler at the Software Freedom Law
+Center for all their hard work and assistance with the exception.  The
+changes here will strengthen the GCC community, and we look forward to
+the compiler developments it will enable.</p>
+
+<p>Because GCC is such a crucial part of developers' lives, we're
+expecting lots of questions about these changes, and we want to make
+sure that they're addressed.  Below we've addressed specific concerns
+that we expect users will have.  If you have questions about the new
+exception that aren't mentioned here, please feel free to contact us
+at <a href="mailto:licensing@fsf.org">&lt;licensing@fsf.org&gt;</a>.</p>
+
+<h3>How the Exception Works</h3>
+
+<p>The permission you need&mdash;to convey the object code from these GCC
+libraries under your own project's license&mdash;is primarily contained in
+section 1:</p>
+
+<blockquote>
+  <p>You have permission to propagate a work of Target Code formed by
+  combining the Runtime Library with Independent Modules, even if such
+  propagation would otherwise violate the terms of GPLv3, provided
+  that all Target Code was generated by Eligible Compilation
+  Processes.  You may then convey such a combination under terms of
+  your choice, consistent with the licensing of the Independent
+  Modules.</p>
+</blockquote>
+
+<p>This section uses many defined terms, and their specific meanings are
+integral to how the exception works.  This section looks at how these
+terms relate to common scenarios.</p>
+
+<p>When you write your software, it consists of a set of source code
+files.  Each file is an &ldquo;Independent Module,&rdquo; as long as
+it doesn't contain any source from the GCC libraries.</p>
+
+<p>When you compile those source code files, they usually go through a
+series of steps: source code generation, preprocessing, compilation to
+low-level code, assembling, and linking.  Not all projects follow all
+these steps, depending on what language you're using and how it's
+written, but they'll always go in this order, and everyone using GCC
+will go through the process of compiling high-level code into some
+low-level language such as assembly code or Java bytecode.  This phase
+is when GCC combines or links your own code with code from the GCC
+libraries.  We call it the &ldquo;Compilation Process.&rdquo; The
+output you get from it is called &ldquo;Target Code,&rdquo; as long as
+that output is not used as compiler intermediate representation, or to
+create such an intermediate representation.</p>
+
+<p>In order to take advantage of this permission, the Compilation
+Process that you use to create Target Code has to be
+&ldquo;Eligible,&rdquo; which means that it does not involve both GCC
+and GPL-incompatible software.  It's important to remember that the
+Compilation Process starts when you feed <em>any</em> high-level code
+to GCC, and ends as soon as it generates anything that can be
+considered Target Code.  Because of that, as long as GCC isn't writing
+out intermediate representation, your Compilation Process can still be
+Eligible even if you use GCC in conjunction with GPL-incompatible
+assemblers, linkers, or high-level source generators: those programs
+aren't involved in the Compilation Process as it's defined here.  The
+only place you can't use GPL-incompatible software with GCC is when
+it's performing the core compilation work.</p>
+
+<p>So, if you use GCC, with or without GPL-compatible enhancements, that
+would be an Eligible Compilation Process.  If you only use
+GPL-incompatible compiler tools, that would be an Eligible Compilation
+Process as well.  (It's not uncommon for people who build software for
+GNU/Linux to link against the GCC libraries even if they're using a
+different compiler.)  However, if you used GCC in conjunction with
+GPL-incompatible software during the process of transforming
+high-level code to low-level code, that would <em>not</em> be an Eligible
+Compilation Process.  This would happen if, for example, you used GCC
+with a proprietary plugin.</p>
+
+<p>As long as you use an Eligible Compilation Process, then you have
+permission to take the Target Code that GCC generates and propagate it
+&ldquo;under terms of your choice.&rdquo;</p>
+
+<p>If you did use GPL-incompatible software in conjunction with GCC
+during the Compilation Process, you would not be able to take
+advantage of this permission.  Since all of the object code that GCC
+generates is derived from these GPLed libraries, that means you would
+be required to follow the terms of the GPL when propagating any of
+that object code.  You could not use GCC to develop your own
+GPL-incompatible software.</p>
+
+<h3>Frequently Asked Questions</h3>
+
+<dl>
+<dt>I am using a standard release of GCC (such as one provided by the
+FSF, or with my operating system) to compile GPL-incompatible
+software.  How does this change affect me?</dt>
+
+<dd><p>It should not affect you at all.  Unless you've configured GCC
+to output intermediate representation&mdash;which is rare&mdash;the
+new exception is designed to ensure that you have no license
+obligations when you do this, just as the old exceptions
+were.</p></dd>
+
+<dt>Who does this change affect?</dt>
+
+<dd><p>Nobody who is currently using GCC should be affected by this change.
+The only changes in policy are meant to prevent developers from making
+certain modifications to GCC that <em>will</em> become feasible in the future.
+The FSF has been working closely with GCC developers to learn more about
+the many different ways people use GCC today, and ensure that they will all
+be able to continue those activities under the new exception.</p></dd>
+
+<dt>I use GCC in conjunction with proprietary preprocessors and/or source
+generators to compile my program.  Can I still take advantage of the
+exception?</dt>
+
+<dd><p>Yes.  The Compilation Process can start with any &ldquo;code
+entirely represented in a high-level, non-intermediate
+language.&rdquo; This includes code generated by a preprocessor or
+other proprietary software.  As such, the Compilation Process in this
+case does not involve any proprietary software; it qualifies as
+Eligible, and the exception is available for this program.</p></dd>
+
+<dt>I use GCC in conjunction with proprietary assemblers and/or linkers to
+compile my program.  Can I still take advantage of the exception?</dt>
+
+<dd><p>Yes.  The Compilation Process ends when the compiler generates
+Target Code, which includes output that is &ldquo;suitable for input
+to an assembler, loader, linker and/or execution phase.&rdquo; In
+other words, the Compilation Process in this case is over when you
+have assembly code or unlinked object files from GCC, and so it does
+not involve any proprietary software.  It qualifies as Eligible, and
+the exception is thus available for this program.</p></dd>
+
+<dt>I use GCC to compile parts of my program, and a proprietary
+compiler to compile other parts.  The pieces are combined afterward,
+during assembler or linking phases.  Can I still take advantage of the
+exception?</dt>
+
+<dd><p>Yes.  In this case, each Independent Module is turned into Target Code
+through an Eligible Compilation Process.  Even though different modules
+will go through different processes, the exception is still available
+for this program.</p></dd>
+
+<dt>I use a proprietary compiler toolchain without any parts of GCC to
+compile my program, and link it with libstdc++.  My program itself
+does not include any runtime library code the same way that
+GCC-compiled programs include libgcc.  Can I still take advantage of
+the exception?</dt>
+
+<dd><p>Yes.  While combining libgcc with GCC-compiled object code is
+probably the most common way the exception is used, neither the GPL
+nor the GCC Runtime Library Exception distinguish between static
+linking, dynamic linking, and other methods for combining code in
+their conditions.  The same permissions are available to you, under
+the same terms, no matter which method you use.</p>
+
+<p>Note that if you distribute libstdc++ as an independent library,
+you will need to follow the terms of the GPL when doing so.  For
+example, if you distribute the library itself in object code form, you
+will need to provide source code to your recipients using one of the
+methods listed in section 6 of GPLv3.  But as long as you are eligible
+to take advantage of the GCC Runtime Library Exception's permissions
+for your own program, the GPL's terms do not extend to it.</p></dd>
+
+<dt>Why is compiler intermediate representation excluded from the
+definition of &ldquo;Target Code?&rdquo;</dt>
+
+<dd><p>When we first considered adding a plugin infrastructure to GCC, we
+were deeply concerned about the possibility that someone would write a
+plugin that would merely save GCC's internal, low-level compilation
+data structures to disk.  With that done, other software would be able
+to optimize or otherwise improve that code without being directly
+connected to GCC.  It may have been difficult for us to argue that
+those programs should be subject to the GPL's copyleft, so we wanted
+to discourage these sorts of arrangements.</p>
+
+<p>We do that by excluding such output from the definition of Target
+Code.  Because of this, even if someone writes a plugin that saves
+this information to disk, any programs that change the structures
+before GCC writes out Target Code will be involved in the Compilation
+Process.  If that program is proprietary, the exception will not be
+available to any software compiled with it; the object code that GCC
+ultimately creates will have to be distributed under the terms of the
+GPL.</p></dd>
+
+<dt>If I write some code in assembly language, can I combine that with
+other object code compiled normally, and still take advantage of the
+exception?</dt>
+
+<dd><p>Yes, as long as all of the object code was compiled through an
+Eligible Compilation Process.  The process of running hand-written
+assembly through an assembler is a Compilation Process, since it
+&ldquo;transforms code entirely represented in [a] non-intermediate
+language[] designed for human-written code... into Target
+Code.&rdquo;</p></dd>
+
+<dt>What libraries does the GCC Runtime Library Exception cover?</dt>
+
+<dd><p>The GCC Runtime Library Exception covers any file that has a
+notice in its license headers stating that the exception applies.
+This includes libgcc, libstdc++, libfortran, libgomp, libdecnumber,
+libgcov, and other libraries distributed with GCC.</p></dd>
+
+<dt>Will Classpath use this new exception?</dt>
+
+<dd><p>Even though Classpath's current exception serves a similar purpose,
+we are not updating it at this time.  Because of recent developments
+in the free software Java community, the priorities for Classpath's
+licensing policies are different from other GCC libraries, and we are
+evaluating it separately.</p></dd></dl>
+</div><!-- for id="content", starts in the include above -->
+
+              <!-- begin server/footer-text.html -->
+<div id="fsf-links">
+ <ul>
+  <li><a href="/">GNU&nbsp;home&nbsp;page</a></li>
+  <li><a href="http://www.fsf.org/">FSF&nbsp;home&nbsp;page</a></li>
+  <li><a href="/graphics/graphics.html">GNU&nbsp;Art</a></li>
+  <li><a href="/fun/fun.html">GNU&nbsp;Fun</a></li>
+  <li><a href="/people/people.html">GNU's&nbsp;Who?</a></li>
+  <li><a href="http://directory.fsf.org">Free&nbsp;Software&nbsp;Directory</a></li>
+  <li><a href="/server/sitemap.html">Site&nbsp;map</a></li>
+ </ul>
+</div><!-- /fsf-links -->
+
+<div id="mission-statement">
+
+<blockquote>
+<p><a href="http://www.fsf.org"><img id="fsfbanner"
+src="/graphics/fsf-logo-notext.png" alt=" [FSF logo] "/></a><strong>&ldquo;Our
+mission is to preserve, protect and promote the freedom to use, study,
+copy, modify, and redistribute computer software, and to defend the
+rights of Free Software users.&rdquo;</strong></p>
+</blockquote>
+
+<p>The <a href="http://www.fsf.org">Free Software Foundation</a> is
+the principal organizational sponsor of the GNU Operating System.
+<strong>Support GNU and the FSF</strong> by <a
+href="http://shop.fsf.org/">buying manuals and gear</a>, <a
+href="https://my.fsf.org/associate/support_freedom?referrer=4052">
+<strong>joining the FSF</strong></a> as an associate member, or making
+a <strong>donation</strong>, either <a
+href="http://donate.fsf.org/">directly to the FSF</a> or <a
+href="http://flattr.com/thing/313733/gnuproject-on-Flattr">via
+Flattr</a>.</p>
+
+<p id="backtotop"><a href="#header">back to top</a></p>
+
+</div><!-- /mission-statement -->
+<!-- end server/footer-text.html -->
+
+
+<div id="footer">
+<div class="unprintable">
+
+<p>Please send general FSF &amp; GNU inquiries to <a
+href="mailto:gnu@gnu.org">&lt;gnu@gnu.org&gt;</a>.  There are also <a
+href="/contact/">other ways to contact</a> the FSF.  Broken links and other
+corrections or suggestions can be sent to <a
+href="mailto:webmasters@gnu.org">&lt;webmasters@gnu.org&gt;</a>.</p>
+
+<p><!-- TRANSLATORS: Ignore the original text in this paragraph,
+        replace it with the translation of these two:
+
+        We work hard and do our best to provide accurate, good quality
+        translations.  However, we are not exempt from imperfection.
+        Please send your comments and general suggestions in this regard
+        to <a href="mailto:web-translators@gnu.org">
+        &lt;web-translators@gnu.org&gt;</a>.</p>
+
+        <p>For information on coordinating and submitting translations of
+        our web pages, see <a
+        href="/server/standards/README.translations.html">Translations
+        README</a>. -->
+Please see the <a
+href="/server/standards/README.translations.html">Translations README</a> for
+information on coordinating and submitting translations of this article.</p>
+</div>
+
+<p>Copyright &copy; 2014 Free Software Foundation, Inc.</p>
+
+<p>This page is licensed under a <a rel="license"
+href="http://creativecommons.org/licenses/by-nd/3.0/us/">Creative
+Commons Attribution-NoDerivs 3.0 United States License</a>.</p>
+
+<!-- start of server/bottom-notes.html -->
+<div class="unprintable">
+<p><a href="http://www.fsf.org/about/dmca-notice">Copyright Infringement
+Notification</a>&nbsp;|&nbsp;<a
+href="/accessibility/accessibility.html">Accessibility</a></p>
+
+
+</div>
+<!-- end of server/bottom-notes.html -->
+
+
+<p class="unprintable">Updated:
+<!-- timestamp start -->
+$Date: 2014/04/12 12:39:50 $
+<!-- timestamp end -->
+</p>
+</div>
+</div>
+</body>
+</html>

--- a/licenses/gcc-exception-3.1.html
+++ b/licenses/gcc-exception-3.1.html
@@ -1,0 +1,297 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+
+<head>
+<!-- start of server/head-include-1.html -->
+<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<link rev="made" href="mailto:webmasters@gnu.org" />
+<link rel="icon" type="image/png" href="/graphics/gnu-head-mini.png" />
+<meta name="ICBM" content="42.355469,-71.058627" />
+<meta name="DC.title" content="gnu.org" />
+<!-- end of server/head-include-1.html -->
+
+<!-- end of server/header.html -->
+
+<!-- Parent-Version: 1.77 -->
+<title>GCC Runtime Library Exception
+- GNU Project - Free Software Foundation</title>
+<!-- begin translist file -->
+
+
+<!-- end translist file -->
+
+<!-- start of server/banner.html -->
+<!-- start of head-include-2.html -->
+
+<link rel="stylesheet" href="/combo.css" media="screen" />
+<link rel="stylesheet" href="/mini.css" media="handheld" />
+<link rel="stylesheet" href="/layout.css" media="screen" />
+
+<link rel="stylesheet" href="/print.css" media="print" />
+
+<!-- end of head-include-2.html -->
+
+</head>
+<body>
+<div class="inner">
+<!-- start of server/body-include-1.html -->
+
+<div id="toplinks">
+ <a href="#content">Skip to main text</a>
+</div> <!-- /toplinks -->
+
+<div id="searcher">
+ <form method="get" action="//www.gnu.org/cgi-bin/estseek.cgi">
+  <div>
+  <input name="phrase" id="phrase" type="text" size="18" accesskey="s"
+         value="Why GNU/Linux?" onfocus="this.value=''" />
+  <input type="submit" value="Search" />
+  </div>
+ </form>
+</div><!-- /searcher -->
+
+<div id="translations">
+<p>
+<span dir="ltr" class="original"><a lang="en" hreflang="en" href="/licenses/gcc-exception-3.1.en.html">English</a>&nbsp;[en]</span>&nbsp;&nbsp;
+<span dir="ltr"><a lang="de" hreflang="de" href="/licenses/gcc-exception-3.1.de.html">Deutsch</a>&nbsp;[de]</span>&nbsp;&nbsp;
+<span dir="ltr"><a lang="fr" hreflang="fr" href="/licenses/gcc-exception-3.1.fr.html">français</a>&nbsp;[fr]</span>&nbsp;&nbsp;
+<span dir="ltr"><a lang="ja" hreflang="ja" href="/licenses/gcc-exception-3.1.ja.html">日本語</a>&nbsp;[ja]</span>&nbsp;&nbsp;
+<span dir="ltr"><a lang="ru" hreflang="ru" href="/licenses/gcc-exception-3.1.ru.html">русский</a>&nbsp;[ru]</span>&nbsp;&nbsp;
+<span dir="ltr"><a lang="uk" hreflang="uk" href="/licenses/gcc-exception-3.1.uk.html">українська</a>&nbsp;[uk]</span>&nbsp;&nbsp;
+</p>
+</div>
+
+<!-- end of server/body-include-1.html -->
+
+<!-- start of server/body-include-2 -->
+
+<div id="header">
+<div id="fsf-frame">
+<p id="join-fsf"><a href="https://www.fsf.org/associate/support_freedom?referrer=4052">JOIN&nbsp;THE&nbsp;FSF</a></p><hr />
+<div id="fssbox">
+<p><a href="http://www.fsf.org/fss">GNU/FSF Newsletter</a></p>
+<form action="https://crm.fsf.org/civicrm/profile/create&amp;reset=1&amp;gid=31" method="post">
+ <div>
+  <input name="postURL" type="hidden" value="" />
+  <input type="hidden" name="group[25]" value="1" />
+  <input name="cancelURL" type="hidden" value="https://crm.fsf.org/civicrm/profile?reset=1&amp;gid=31" />
+  <input name="_qf_default" type="hidden" value="Edit:cancel" />
+ </div>
+ <p>
+  <input type="text" id="frmEmail" name="email-Primary" size="18" maxlength="80"
+         value="email address" onfocus="this.value=''"/>
+  <input type="submit" name="_qf_Edit_next" value="Sign up" />
+ </p>
+</form>
+</div><!-- /fssbox -->
+</div><!-- /fsf-frame -->
+
+<div id="gnu-banner">
+ <a href="/">
+ <img src="/graphics/heckert_gnu.small.png" alt=" [A GNU head] " /><strong>GNU</strong> Operating System</a>
+</div><!-- /gnu-banner -->
+<p id="fsf-support">Sponsored by the <a href="#mission-statement">Free Software Foundation</a></p>
+
+</div><!-- /header -->
+
+<div id="navigation">
+
+ <ul>
+  <li id="tabAboutGNU"><a href="/gnu/gnu.html">About&nbsp;GNU</a></li>
+  <li id="tabPhilosophy"><a href="/philosophy/philosophy.html">Philosophy</a></li>
+  <li id="tabLicenses"><a href="/licenses/licenses.html">Licenses</a></li>
+  <li id="tabEducation"><a href="/education/education.html">Education</a></li>
+  <li id="tabSoftware"><a href="/software/software.html">Software</a></li>
+  <li id="tabDoc"><a href="/doc/doc.html">Documentation</a></li>
+  <li id="tabHelp"><a href="/help/help.html">Help&nbsp;GNU</a></li>
+ </ul>
+
+</div><!--  /navigation -->
+<!-- end of server/body-include-2 -->
+
+<div id="content">
+<!-- end of server/banner.html -->
+
+<h2>GCC Runtime Library Exception</h2>
+
+<p>A <a href="/licenses/gcc-exception-3.1-faq.html">rationale document
+and FAQ</a> is available for this exception.</p>
+
+<hr style="clear: both;" />
+
+<!-- The license text is in English and appears broken in RTL as
+     Arabic, Farsi, etc.  Explicitly set the direction to override the
+     one defined in the translation. -->
+<div dir="ltr">
+
+<h3 style="text-align: center;">GCC RUNTIME LIBRARY EXCEPTION</h3>
+
+<p style="text-align: center;">Version 3.1, 31 March 2009</p>
+
+<p>Copyright &copy; 2009 Free Software Foundation, Inc.
+ &lt;<a href="http://fsf.org/">http://fsf.org/</a>&gt;
+ </p><p>Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.</p>
+
+<p>This GCC Runtime Library Exception (&quot;Exception&quot;) is an additional
+permission under section 7 of the GNU General Public License, version
+3 (&quot;GPLv3&quot;).  It applies to a given file (the &quot;Runtime Library&quot;) that
+bears a notice placed by the copyright holder of the file stating that
+the file is governed by GPLv3 along with this Exception.</p>
+
+<p>When you use GCC to compile a program, GCC may combine portions of
+certain GCC header files and runtime libraries with the compiled
+program.  The purpose of this Exception is to allow compilation of
+non-GPL (including proprietary) programs to use, in this way, the
+header files and runtime libraries covered by this Exception.</p>
+
+<h4><a name="section0"></a>0. Definitions.</h4>
+
+<p>A file is an &quot;Independent Module&quot; if it either requires the Runtime
+Library for execution after a Compilation Process, or makes use of an
+interface provided by the Runtime Library, but is not otherwise based on
+the Runtime Library.</p>
+
+<p>&quot;GCC&quot; means a version of the GNU Compiler Collection, with or
+without modifications, governed by version 3 (or a specified later
+version) of the GNU General Public License (GPL) with the option of
+using any subsequent versions published by the FSF.</p>
+
+<p>&quot;GPL-compatible Software&quot; is software whose conditions of
+propagation, modification and use would permit combination with GCC in
+accord with the license of GCC.</p>
+
+<p>&quot;Target Code&quot; refers to output from any compiler for a real or
+virtual target processor architecture, in executable form or suitable
+for input to an assembler, loader, linker and/or execution phase.
+Notwithstanding that, Target Code does not include data in any format
+that is used as a compiler intermediate representation, or used for
+producing a compiler intermediate representation.</p>
+
+<p>The &quot;Compilation Process&quot; transforms code entirely represented in
+non-intermediate languages designed for human-written code, and/or in
+Java Virtual Machine byte code, into Target Code.  Thus, for example,
+use of source code generators and preprocessors need not be considered
+part of the Compilation Process, since the Compilation Process can be
+understood as starting with the output of the generators or
+preprocessors.</p>
+
+<p>A Compilation Process is &quot;Eligible&quot; if it is done using GCC, alone
+or with other GPL-compatible software, or if it is done without using
+any work based on GCC.  For example, using non-GPL-compatible
+Software to optimize any GCC intermediate representations would not
+qualify as an Eligible Compilation Process.</p>
+
+<h4><a name="section1"></a>1. Grant of Additional Permission.</h4>
+
+<p>You have permission to propagate a work of Target Code formed by
+combining the Runtime Library with Independent Modules, even if such
+propagation would otherwise violate the terms of GPLv3, provided that
+all Target Code was generated by Eligible Compilation Processes.  You
+may then convey such a combination under terms of your choice,
+consistent with the licensing of the Independent Modules.</p>
+
+<h4><a name="section2"></a>2. No Weakening of GCC Copyleft.</h4>
+
+<p>The availability of this Exception does not imply any general
+presumption that third-party software is unaffected by the copyleft
+requirements of the license of GCC.</p>
+
+</div>
+
+</div><!-- for id="content", starts in the include above -->
+
+              <!-- begin server/footer-text.html -->
+<div id="fsf-links">
+ <ul>
+  <li><a href="/">GNU&nbsp;home&nbsp;page</a></li>
+  <li><a href="http://www.fsf.org/">FSF&nbsp;home&nbsp;page</a></li>
+  <li><a href="/graphics/graphics.html">GNU&nbsp;Art</a></li>
+  <li><a href="/fun/fun.html">GNU&nbsp;Fun</a></li>
+  <li><a href="/people/people.html">GNU's&nbsp;Who?</a></li>
+  <li><a href="http://directory.fsf.org">Free&nbsp;Software&nbsp;Directory</a></li>
+  <li><a href="/server/sitemap.html">Site&nbsp;map</a></li>
+ </ul>
+</div><!-- /fsf-links -->
+
+<div id="mission-statement">
+
+<blockquote>
+<p><a href="http://www.fsf.org"><img id="fsfbanner"
+src="/graphics/fsf-logo-notext.png" alt=" [FSF logo] "/></a><strong>&ldquo;Our
+mission is to preserve, protect and promote the freedom to use, study,
+copy, modify, and redistribute computer software, and to defend the
+rights of Free Software users.&rdquo;</strong></p>
+</blockquote>
+
+<p>The <a href="http://www.fsf.org">Free Software Foundation</a> is
+the principal organizational sponsor of the GNU Operating System.
+<strong>Support GNU and the FSF</strong> by <a
+href="http://shop.fsf.org/">buying manuals and gear</a>, <a
+href="https://my.fsf.org/associate/support_freedom?referrer=4052">
+<strong>joining the FSF</strong></a> as an associate member, or making
+a <strong>donation</strong>, either <a
+href="http://donate.fsf.org/">directly to the FSF</a> or <a
+href="http://flattr.com/thing/313733/gnuproject-on-Flattr">via
+Flattr</a>.</p>
+
+<p id="backtotop"><a href="#header">back to top</a></p>
+
+</div><!-- /mission-statement -->
+<!-- end server/footer-text.html -->
+
+
+<div id="footer">
+<div class="unprintable">
+
+<p>Please send general FSF &amp; GNU inquiries to
+<a href="mailto:gnu@gnu.org">&lt;gnu@gnu.org&gt;</a>.
+There are also <a href="/contact/">other ways to contact</a>
+the FSF.  Broken links and other corrections or suggestions can be sent
+to <a href="mailto:webmasters@gnu.org">&lt;webmasters@gnu.org&gt;</a>.</p>
+
+<p><!-- TRANSLATORS: Ignore the original text in this paragraph,
+        replace it with the translation of these two:
+
+        We work hard and do our best to provide accurate, good quality
+        translations.  However, we are not exempt from imperfection.
+        Please send your comments and general suggestions in this regard
+        to <a href="mailto:web-translators@gnu.org">
+        &lt;web-translators@gnu.org&gt;</a>.</p>
+
+        <p>For information on coordinating and submitting translations of
+        our web pages, see <a
+        href="/server/standards/README.translations.html">Translations
+        README</a>. -->
+Please see the <a
+href="/server/standards/README.translations.html">Translations
+README</a> for information on coordinating and submitting translations
+of this article.</p>
+</div>
+
+<p>Copyright notice above.</p>
+
+<p>Everyone is permitted to copy and distribute verbatim copies of this license
+document, but changing it is not allowed.</p>
+
+<!-- start of server/bottom-notes.html -->
+<div class="unprintable">
+<p><a href="http://www.fsf.org/about/dmca-notice">Copyright Infringement
+Notification</a>&nbsp;|&nbsp;<a
+href="/accessibility/accessibility.html">Accessibility</a></p>
+
+
+</div>
+<!-- end of server/bottom-notes.html -->
+
+
+<p class="unprintable">Updated:
+<!-- timestamp start -->
+$Date: 2014/04/12 12:39:50 $
+<!-- timestamp end -->
+</p>
+</div>
+</div>
+</body>
+</html>

--- a/src/java/src/main/config/NativeLibraries.properties
+++ b/src/java/src/main/config/NativeLibraries.properties
@@ -5,33 +5,33 @@
 #
 
 NativeLibraries.mac.initialise = libjinitialise.0.dylib
-NativeLibraries.mac.dbg.libraries = libjshim_dbg.0.dylib, librdag_dbg.0.dylib, liboglapack_dbg.3.dylib,libogblas_dbg.3.dylib,libogxerbla_dbg.3.dylib
+NativeLibraries.mac.dbg.libraries = libjshim_dbg.0.dylib, librdag_dbg.0.dylib, liboglapack_dbg.3.dylib,libogblas_dbg.3.dylib,libogxerbla_dbg.3.dylib, libstdc++.6.dylib, libgcc_s.1.dylib, libgfortran.3.dylib, libquadmath.0.dylib
 NativeLibraries.mac.dbg.load = libjshim_dbg.0.dylib
-NativeLibraries.mac.std.libraries = libjshim_std.0.dylib, librdag_std.0.dylib, liboglapack_std.3.dylib,libogblas_std.3.dylib,libogxerbla_std.3.dylib
+NativeLibraries.mac.std.libraries = libjshim_std.0.dylib, librdag_std.0.dylib, liboglapack_std.3.dylib,libogblas_std.3.dylib,libogxerbla_std.3.dylib, libstdc++.6.dylib, libgcc_s.1.dylib, libgfortran.3.dylib, libquadmath.0.dylib
 NativeLibraries.mac.std.load = libjshim_std.0.dylib
-NativeLibraries.mac.sse41.libraries = libjshim_sse41.0.dylib, librdag_sse41.0.dylib, liboglapack_sse41.3.dylib,libogblas_sse41.3.dylib,libogxerbla_sse41.3.dylib
+NativeLibraries.mac.sse41.libraries = libjshim_sse41.0.dylib, librdag_sse41.0.dylib, liboglapack_sse41.3.dylib,libogblas_sse41.3.dylib,libogxerbla_sse41.3.dylib, libstdc++.6.dylib, libgcc_s.1.dylib, libgfortran.3.dylib, libquadmath.0.dylib
 NativeLibraries.mac.sse41.load = libjshim_sse41.0.dylib
-NativeLibraries.mac.avx1.libraries = libjshim_avx1.0.dylib, librdag_avx1.0.dylib, liboglapack_avx1.3.dylib,libogblas_avx1.3.dylib,libogxerbla_avx1.3.dylib
+NativeLibraries.mac.avx1.libraries = libjshim_avx1.0.dylib, librdag_avx1.0.dylib, liboglapack_avx1.3.dylib,libogblas_avx1.3.dylib,libogxerbla_avx1.3.dylib, libstdc++.6.dylib, libgcc_s.1.dylib, libgfortran.3.dylib, libquadmath.0.dylib
 NativeLibraries.mac.avx1.load = libjshim_avx1.0.dylib
 
 
 NativeLibraries.win.initialise = libjinitialise.dll
-NativeLibraries.win.dbg.libraries = libjshim_dbg.dll, librdag_dbg.dll, liboglapack_dbg.dll,libogblas_dbg.dll,libogxerbla_dbg.dll
+NativeLibraries.win.dbg.libraries = libjshim_dbg.dll, librdag_dbg.dll, liboglapack_dbg.dll,libogblas_dbg.dll,libogxerbla_dbg.dll, libstdc++-6.dll, libgcc_s_seh-1.dll, libgfortran-3.dll, libquadmath-0.dll
 NativeLibraries.win.dbg.load = libjshim_dbg.dll
-NativeLibraries.win.std.libraries = libjshim_std.dll, librdag_std.dll, liboglapack_std.dll,libogblas_std.dll,libogxerbla_std.dll
+NativeLibraries.win.std.libraries = libjshim_std.dll, librdag_std.dll, liboglapack_std.dll,libogblas_std.dll,libogxerbla_std.dll, libstdc++-6.dll, libgcc_s_seh-1.dll, libgfortran-3.dll, libquadmath-0.dll
 NativeLibraries.win.std.load = libjshim_std.dll
-NativeLibraries.win.sse41.libraries = libjshim_sse41.dll, librdag_sse41.dll, liboglapack_sse41.dll,libogblas_sse41.dll,libogxerbla_sse41.dll
+NativeLibraries.win.sse41.libraries = libjshim_sse41.dll, librdag_sse41.dll, liboglapack_sse41.dll,libogblas_sse41.dll,libogxerbla_sse41.dll, libstdc++-6.dll, libgcc_s_seh-1.dll, libgfortran-3.dll, libquadmath-0.dll
 NativeLibraries.win.sse41.load = libjshim_sse41.dll
-NativeLibraries.win.avx1.libraries = libjshim_avx1.dll, librdag_avx1.dll, liboglapack_avx1.dll,libogblas_avx1.dll,libogxerbla_avx1.dll
+NativeLibraries.win.avx1.libraries = libjshim_avx1.dll, librdag_avx1.dll, liboglapack_avx1.dll,libogblas_avx1.dll,libogxerbla_avx1.dll, libstdc++-6.dll, libgcc_s_seh-1.dll, libgfortran-3.dll, libquadmath-0.dll
 NativeLibraries.win.avx1.load = libjshim_avx1.dll
 
 
 NativeLibraries.lin.initialise = libjinitialise.so.0
-NativeLibraries.lin.dbg.libraries = libjshim_dbg.so.0, librdag_dbg.so.0,liboglapack_dbg.so.3,libogblas_dbg.so.3,libogxerbla_dbg.so.3
+NativeLibraries.lin.dbg.libraries = libjshim_dbg.so.0, librdag_dbg.so.0,liboglapack_dbg.so.3,libogblas_dbg.so.3,libogxerbla_dbg.so.3, libstdc++.so.6, libgcc_s.so.1, libgfortran.so.3, libquadmath.so.0
 NativeLibraries.lin.dbg.load = libjshim_dbg.so.0
-NativeLibraries.lin.std.libraries = libjshim_std.so.0, librdag_std.so.0,liboglapack_std.so.3,libogblas_std.so.3,libogxerbla_std.so.3
+NativeLibraries.lin.std.libraries = libjshim_std.so.0, librdag_std.so.0,liboglapack_std.so.3,libogblas_std.so.3,libogxerbla_std.so.3, libstdc++.so.6, libgcc_s.so.1, libgfortran.so.3, libquadmath.so.0
 NativeLibraries.lin.std.load = libjshim_std.so.0
-NativeLibraries.lin.sse41.libraries = libjshim_sse41.so.0, librdag_sse41.so.0,liboglapack_sse41.so.3,libogblas_sse41.so.3,libogxerbla_sse41.so.3
+NativeLibraries.lin.sse41.libraries = libjshim_sse41.so.0, librdag_sse41.so.0,liboglapack_sse41.so.3,libogblas_sse41.so.3,libogxerbla_sse41.so.3, libstdc++.so.6, libgcc_s.so.1, libgfortran.so.3, libquadmath.so.0
 NativeLibraries.lin.sse41.load = libjshim_sse41.so.0
-NativeLibraries.lin.avx1.libraries = libjshim_avx1.so.0, librdag_avx1.so.0,liboglapack_avx1.so.3,libogblas_avx1.so.3,libogxerbla_avx1.so.3
+NativeLibraries.lin.avx1.libraries = libjshim_avx1.so.0, librdag_avx1.so.0,liboglapack_avx1.so.3,libogblas_avx1.so.3,libogxerbla_avx1.so.3, libstdc++.so.6, libgcc_s.so.1, libgfortran.so.3, libquadmath.so.0
 NativeLibraries.lin.avx1.load = libjshim_avx1.so.0


### PR DESCRIPTION
This PR provides only the mechanism required to get the GCC runtime libraries into the Jar on each platform. It does not attempt to fix up the linkage of these libraries - this will be done in a future PR.

The library locations are first retrieved from the CMake argument `GCC_LIB_FOLDER`. If this is not specified, the `GCC_LIB_FOLDER` environment variable is checked. If this is also not present, a default library location is assumed (which varies by platform and matches those used on our buildslaves).

Code for computing the platform code is outlined in both the Python and CMake scripts, since it is now required from multiple locations.

Relevant license information is also added.
