### PR TITLE
Fix linkage of included libraries on Linux and OS X

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -39,7 +39,7 @@ Generally recent versions of the requirements are preferred:
 * gfortran (we test with GCC 4.8.2)
 * A C++ compiler supporting C++11 (we test with GCC 4.8.2)
 * A C compiler supporting C99 (we test with GCC 4.8.2)
-* Python 2.7 with argparse and yaml modules (we test with Python 2.7)
+* Python 2.6 or 2.7 with argparse and yaml modules (we test with Python 2.6 on Linux and 2.7 on Windows/OS X)
 * JDK 7 (we test with Oracle JDK 1.7.0_51 and 1.7.0_u21)
 * Maven (we test with 3.0.5)
 

--- a/cmake/modules/UseJava.cmake
+++ b/cmake/modules/UseJava.cmake
@@ -395,7 +395,7 @@ function(add_jar _TARGET_NAME)
       set_platform_code(NATIVE_PLATFORM)
       set(_copyrtl_args)
       if (GCC_LIB_FOLDER)
-        set(_copyrtl_args "-l ${GCC_LIB_FOLDER}")
+        set(_copyrtl_args "-l${GCC_LIB_FOLDER}")
       endif()
       add_custom_target(copyrtl
                         ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/cmake/syslibs.py -o ${_dest}/${NATIVE_PLATFORM} ${_copyrtl_args}


### PR DESCRIPTION
This is heavily based on the DOGMA1 implementation of linkage-fixing, in that the operations it performs are identical, but are performed as part of the local build rather than requiring them to be implemented by an external entity like the Buildbot.

This now allows the multiplatform JAR to execute "out of the box" on completely clean Linux, OS X, and Windows machines (assuming that a JRE is present, of course), and I have verified this manually on devmaths-mc-2, devmaths-wn-2 and devmaths-lx-cleantest. Automation of this testing is to be performed in the near future.

Coverage is unchanged, as this is only a build system-related change.

The build of deploy that this was tested with is http://devmaths-lx-1:8012/builders/deploy/builds/33 - the resulting blob can be downloaded and run on any supported machine with no "hacks" required.
