### PR TITLE
[MAT-399] patch to deal with unprelinking RTLs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -45,7 +45,7 @@ Generally recent versions of the requirements are preferred:
 
 * Platform specific tools:
   * Linux users will need the 'readelf' and 'patchelf' tools.
-  * OS X users will need the 'otool' tool.
+  * OS X users will need the 'otool' and 'install_name_tool' tools.
 
 #### Operating Systems
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -43,6 +43,10 @@ Generally recent versions of the requirements are preferred:
 * JDK 7 (we test with Oracle JDK 1.7.0_51 and 1.7.0_u21)
 * Maven (we test with 3.0.5)
 
+* Platform specific tools:
+  * Linux users will need the 'readelf' and 'patchelf' tools.
+  * OS X users will need the 'otool' tool.
+
 #### Operating Systems
 
 * Windows 7/8 (we test on Windows 7)


### PR DESCRIPTION
This is a bit of a weird PR. The bug this code patches is only present in Linuxes that run `prelink` across a variety of system level libraries (notifying culprit is Fedora!). This affects the built jar as the included GCC RTLs have `prelink`ed addresses and offsets, which, when extracted and run during execution of code in the jar, causes `mmap` havoc due to invalid sizes etc. To fix this I've added a step in the build to `readelf` the dynamic section of the RTLs and look for the string `GNU_PRELINKED` which indicates the library has been prelinked. If found then an un-prelinking command is run on the library. On my local machine (one of the offenders) output is:

```
[ 96%] Copying native libraries to the build directory
[ 96%] Built target copylibs
[ 96%] Copying GCC runtime libraries to the build directory
GCC libraries are at /usr/lib64
Copying /usr/lib64/libstdc++.so.6 to [redacated]/build/jars/CMakeFiles/og-maths-lnx-0.1.0-SNAPSHOT.dir/lib/lin/libstdc++.so.6
Copying /usr/lib64/libgcc_s.so.1 to[redacated]/build/jars/CMakeFiles/og-maths-lnx-0.1.0-SNAPSHOT.dir/lib/lin/libgcc_s.so.1
Copying /usr/lib64/libgfortran.so.3 to [redacated]/build/jars/CMakeFiles/og-maths-lnx-0.1.0-SNAPSHOT.dir/lib/lin/libgfortran.so.3
Copying /usr/lib64/libquadmath.so.0 to[redacated]/build/jars/CMakeFiles/og-maths-lnx-0.1.0-SNAPSHOT.dir/lib/lin/libquadmath.so.0
Un-prelinking library: libstdc++.so.6
Patching RUNPATH to $ORIGIN for: libstdc++.so.6
Un-prelinking library: libgcc_s.so.1
Patching RUNPATH to $ORIGIN for: libgcc_s.so.1
Patching RUNPATH to $ORIGIN for: librdag_sse41.so.0
Un-prelinking library: libquadmath.so.0
Patching RUNPATH to $ORIGIN for: libquadmath.so.0
Patching RUNPATH to $ORIGIN for: libogblas_dbg.so.3
Patching RUNPATH to $ORIGIN for: libjshim_std.so.0
Un-prelinking library: libgfortran.so.3
Patching RUNPATH to $ORIGIN for: libgfortran.so.3
...
```

To test this, I've built a jar locally and have `scp`'d it to a shared location, if you would be so kind as to give it a manual test on a couple of random linux boxes that'd be most helpful in terms of ensuring this patch is valid, thanks.

The changes present are build system related so coverage has not changed.
