### PR TITLE
Mat 382 - matrix inversion

### DIFF
--- a/include/expressionbase.hh
+++ b/include/expressionbase.hh
@@ -108,6 +108,17 @@ class PINV: public OGUnaryExpr
     virtual ExprType_t getType() const override;
 };
 
+class INV: public OGUnaryExpr
+{
+  public:
+    INV(const OGNumeric* arg);
+    virtual OGNumeric* copy() const override;
+    virtual const INV* asINV() const override;
+    virtual void debug_print() const override;
+    virtual ExprType_t getType() const override;
+};
+
+
 class TRANSPOSE: public OGUnaryExpr
 {
   public:

--- a/include/exprtypeenum.h
+++ b/include/exprtypeenum.h
@@ -49,6 +49,7 @@ typedef enum
   TRANSPOSE_ENUM       = 0x0133L ,
   CTRANSPOSE_ENUM      = 0x0137L ,
   LU_ENUM              = 0x0139L ,
+  INV_ENUM             = 0x013DL ,
 
 #include "exprenum.hh"
 } ExprType_t;

--- a/include/lapack.hh
+++ b/include/lapack.hh
@@ -48,7 +48,7 @@ template<typename T> real16 xlansy(char * NORM, char * UPLO, int * N, T * A, int
 template<typename T> void xpotrf(char * UPLO, int * N, T * A, int * LDA, int * INFO);
 template<typename T> void xtrtrs(char * UPLO, char * TRANS, char * DIAG, int * N, int * NRHS, T * A, int * LDA, T * B, int * LDB, int * INFO);
 template<typename T> void xgetrf(int * M, int * N, T * A, int * LDA, int * IPIV, int *INFO);
-
+template<typename T> void xgetri(int * N, T * A, int * LDA, int * IPIV, T * WORK, int * LWORK, int * INFO );
 }
 
 /**
@@ -205,6 +205,16 @@ template<typename T> void xgesvd(char * JOBU, char * JOBVT, int * M, int * N, T 
  * @param INFO as LAPACK dgetrf INFO
  */
 template<typename T> void xgetrf(int * M, int * N, T * A, int * LDA, int * IPIV, int *INFO);
+
+/**
+ * xgetri() computes the inverse of a matrix via LU decomposition
+ * @param N as LAPACK dgetri N
+ * @param A  data type specific with intent as LAPACK dgetri A
+ * @param LDA as LAPACK dgetri LDA
+ * @param IPIV as LAPACK dgetri IPIV
+ * @param INFO as LAPACK dgetri INFO
+ */
+template<typename T> void xgetri(int * N, T * A, int * LDA, int * IPIV, int * INFO );
 
 /**
  * xtrcon general triangular matrix condition number estimate

--- a/include/lapack_raw.h
+++ b/include/lapack_raw.h
@@ -113,6 +113,15 @@ extern "C"
 #endif
 void F77FUNC(zgetrf)(int * M, int * N, complex16 * A, int * LDA, int * IPIV, int *INFO);
 
+// inverse based on LU
+#ifdef __cplusplus
+extern "C" 
+#endif
+void F77FUNC(dgetri)(int * N, real16 * A, int * LDA, int * IPIV, real16 * WORK, int * LWORK, int * INFO );
+#ifdef __cplusplus
+extern "C" 
+#endif
+void F77FUNC(zgetri)(int * N, complex16 * A, int * LDA, int * IPIV, complex16 * WORK, int * LWORK, int * INFO );
 
 // solves a triangular system of the form : A * X = B  or  A**T * X = B
 #ifdef __cplusplus

--- a/src/generator/enumtemplates.py
+++ b/src/generator/enumtemplates.py
@@ -51,6 +51,7 @@ public enum ExprEnum {
   TRANSPOSE_ENUM    (0x0133L),
   CTRANSPOSE_ENUM   (0x0137L),
   LU_ENUM           (0x0139L),
+  INV_ENUM          (0x013DL),
 
   // Unary expression nodes - start at 175 to leave room for extra non-generated nodes
 %(generated_nodes)s;

--- a/src/generator/exprtemplates.py
+++ b/src/generator/exprtemplates.py
@@ -177,6 +177,7 @@ class COPY;
 class SELECTRESULT;
 class NORM2;
 class PINV;
+class INV;
 class TRANSPOSE;
 class CTRANSPOSE;
 class SVD;
@@ -200,6 +201,7 @@ class OGNumeric: private Uncopyable
     virtual const SELECTRESULT* asSELECTRESULT() const;
     virtual const NORM2* asNORM2() const;
     virtual const PINV* asPINV() const;
+    virtual const INV* asINV() const;
     virtual const TRANSPOSE* asTRANSPOSE() const;
     virtual const CTRANSPOSE* asCTRANSPOSE() const;
     virtual const SVD* asSVD() const;

--- a/src/generator/generator.py
+++ b/src/generator/generator.py
@@ -63,6 +63,7 @@ nodes = [ UnimplementedUnary('ABS'),
 custom_nodes = [
                 UnaryExpressionRunner('NORM2', 'NORM2_ENUM'),
                 UnaryExpressionRunner('PINV', 'PINV_ENUM'),
+                UnaryExpressionRunner('INV', 'INV_ENUM'),
                 UnaryExpressionRunner('SVD', 'SVD_ENUM'),
                 SelectResultRunner('SELECTRESULT', 'SELECTRESULT_ENUM'),
                 BinaryExpressionRunner('MTIMES','MTIMES_ENUM'),

--- a/src/java/src/main/CMakeLists.txt
+++ b/src/java/src/main/CMakeLists.txt
@@ -17,6 +17,7 @@ set(JAVA_FILES
     DOGMA.java
     nodes/COPY.java
     nodes/CTRANSPOSE.java
+    nodes/INV.java
     nodes/LU.java
     nodes/MTIMES.java
     nodes/NEGATE.java

--- a/src/java/src/main/java/com/opengamma/maths/DOGMA.java
+++ b/src/java/src/main/java/com/opengamma/maths/DOGMA.java
@@ -17,6 +17,7 @@ import com.opengamma.maths.exceptions.MathsExceptionIllegalArgument;
 import com.opengamma.maths.materialisers.Materialisers;
 import com.opengamma.maths.nativeloader.NativeLibraries;
 import com.opengamma.maths.nodes.CTRANSPOSE;
+import com.opengamma.maths.nodes.INV;
 import com.opengamma.maths.nodes.LU;
 import com.opengamma.maths.nodes.MTIMES;
 import com.opengamma.maths.nodes.NEGATE;
@@ -70,6 +71,10 @@ public final class DOGMA {
 
   public static OGNumeric pinv(OGNumeric arg0) {
     return new PINV(arg0);
+  }
+
+  public static OGNumeric inv(OGNumeric arg0) {
+    return new INV(arg0);
   }
 
   public static OGNumeric transpose(OGNumeric arg0) {

--- a/src/java/src/main/java/com/opengamma/maths/datacontainers/ExprEnum.java
+++ b/src/java/src/main/java/com/opengamma/maths/datacontainers/ExprEnum.java
@@ -44,6 +44,7 @@ public enum ExprEnum {
   TRANSPOSE_ENUM    (0x0133L),
   CTRANSPOSE_ENUM   (0x0137L),
   LU_ENUM           (0x0139L),
+  INV_ENUM          (0x013DL),
 
   // Unary expression nodes - start at 175 to leave room for extra non-generated nodes
   ABS_ENUM (0X0175L),

--- a/src/java/src/main/java/com/opengamma/maths/nodes/INV.java
+++ b/src/java/src/main/java/com/opengamma/maths/nodes/INV.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+package com.opengamma.maths.nodes;
+
+import com.opengamma.maths.datacontainers.ExprEnum;
+import com.opengamma.maths.datacontainers.OGNumeric;
+import com.opengamma.maths.datacontainers.lazy.OGExpr;
+
+/**
+ * Matrix Inverse class
+ */
+public class INV extends OGExpr {
+
+  @Override
+  public ExprEnum getType() {
+    return ExprEnum.INV_ENUM;
+  }
+
+  public INV(OGNumeric arg) {
+    super(arg);
+  }
+
+
+}

--- a/src/java/src/test/java/com/opengamma/maths/DOGMATest.java
+++ b/src/java/src/test/java/com/opengamma/maths/DOGMATest.java
@@ -10,6 +10,7 @@ import static com.opengamma.maths.DOGMA.C;
 import static com.opengamma.maths.DOGMA.D;
 import static com.opengamma.maths.DOGMA.ctranspose;
 import static com.opengamma.maths.DOGMA.disp;
+import static com.opengamma.maths.DOGMA.inv;
 import static com.opengamma.maths.DOGMA.lu;
 import static com.opengamma.maths.DOGMA.minus;
 import static com.opengamma.maths.DOGMA.mtimes;
@@ -36,6 +37,7 @@ import com.opengamma.maths.datacontainers.other.OGSVDResult;
 import com.opengamma.maths.datacontainers.scalar.OGComplexScalar;
 import com.opengamma.maths.datacontainers.scalar.OGRealScalar;
 import com.opengamma.maths.exceptions.MathsExceptionIllegalArgument;
+import com.opengamma.maths.exceptions.MathsExceptionNativeComputation;
 import com.opengamma.maths.helpers.FuzzyEquals;
 
 /**
@@ -100,6 +102,37 @@ public class DOGMATest {
       0.0059253029550059, 0.0056704512150057, -0.0567045121500567, -0.0042241675905042, 0.0422416759050422, 0.0002970002970003, -0.0029700029700030, 0.0007921968318008, -0.0079219683180079,
       0.0000241128954000, -0.0002411289540002, -0.0004425598485004, 0.0044255984850044, -0.0015300906390015, 0.0153009063900153, 0.0015129371565015, -0.0151293715650151 }, 3, 4)
         .mathsequals(toOGTerminal(pinv(mat))));
+  }
+
+  @Test
+  public void InvTest() {
+    OGTerminal mat;
+    mat = new OGRealDenseMatrix(10);
+    assertTrue(D(1.e0 / 10.e0).mathsequals(toOGTerminal(inv(mat))));
+    mat = new OGRealDenseMatrix(0);
+    assertTrue(D(Double.POSITIVE_INFINITY).mathsequals(toOGTerminal(inv(mat))));
+
+    mat = new OGRealDenseMatrix(new double[][] { { 1, 2, 3 }, { -4, -5, 6 }, { -7, 8, 9 } });
+    assertTrue(new OGRealDenseMatrix(new double[][] { { 0.3039215686274509, -0.0196078431372549, -0.0882352941176471 }, { 0.0196078431372549, -0.0980392156862745, 0.0588235294117647 },
+      { 0.2189542483660130, 0.0718954248366013, -0.0098039215686275 } }).mathsequals(toOGTerminal(inv(mat))));
+
+    mat = new OGRealDenseMatrix(new double[][] { { 1, 2, 3 }, { -4, -5, 6 } });
+    boolean caught = false;
+    try {
+      toOGTerminal(inv(mat));
+    } catch (MathsExceptionNativeComputation e) {
+      caught = true;
+    }
+    assert (caught == true);
+
+    mat = new OGRealDenseMatrix(new double[][] { { 1, 2, 3 }, { 1, 2, 3 }, { -4, -5, 6 } });
+    disp(toOGTerminal(inv(mat)));
+
+    mat = C(10, 20);
+    assertTrue(C(0.02, -0.04).mathsequals(toOGTerminal(inv(mat))));
+    mat = C(0, 0);
+    assertTrue(C(Double.POSITIVE_INFINITY).mathsequals(toOGTerminal(inv(mat))));
+
   }
 
   @Test

--- a/src/java/src/test/java/com/opengamma/maths/DOGMATest.java
+++ b/src/java/src/test/java/com/opengamma/maths/DOGMATest.java
@@ -126,13 +126,23 @@ public class DOGMATest {
     assert (caught == true);
 
     mat = new OGRealDenseMatrix(new double[][] { { 1, 2, 3 }, { 1, 2, 3 }, { -4, -5, 6 } });
-    disp(toOGTerminal(inv(mat)));
+    // TODO: assert warn raised on singular
+    toOGTerminal(inv(mat));
 
     mat = C(10, 20);
     assertTrue(C(0.02, -0.04).mathsequals(toOGTerminal(inv(mat))));
     mat = C(0, 0);
     assertTrue(C(Double.POSITIVE_INFINITY).mathsequals(toOGTerminal(inv(mat))));
 
+    mat = new OGComplexDenseMatrix(new double[] { 1., 10., -4., -40., 7., 70., 2., 20., 2., 20., 9., 90., 3., 30., 1., 10., 11., 11. }, 3, 3);
+    assertTrue(new OGComplexDenseMatrix(new double[] { 0.0015906219620334, -0.0048867825577376, 0.0026942738518561, 0.0088704319348774, 0.0009739401444214, -0.0372879941007054, -0.0019412404140251,
+      0.0183104604339916, 0.0011167112286758, -0.0147484293321016, -0.0000973940144421, 0.0037287994100705, 0.0000779152115537, -0.0029830395280564, 0.0002532244375496, -0.0096948784661834,
+      -0.0001947880288843, 0.0074575988201411 }, 3, 3).mathsequals(toOGTerminal(inv(mat))));
+
+    mat = new OGComplexDenseMatrix(new double[][] { { 1, 2, 3 }, { 1, 2, 3 }, { -4, -5, 6 } }, new double[][] { { 10, 20, 30 }, { 10, 20, 30 }, { -40, -50, 60 } });
+    // TODO: assert warn raised on singular
+    toOGTerminal(inv(mat));
+    
   }
 
   @Test

--- a/src/java/src/test/java/com/opengamma/maths/testnodes/TestInvMaterialise.java
+++ b/src/java/src/test/java/com/opengamma/maths/testnodes/TestInvMaterialise.java
@@ -1,0 +1,192 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+package com.opengamma.maths.testnodes;
+
+import static org.testng.AssertJUnit.assertTrue;
+
+import java.util.Arrays;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.opengamma.maths.datacontainers.OGNumeric;
+import com.opengamma.maths.datacontainers.OGTerminal;
+import com.opengamma.maths.datacontainers.lazy.OGExpr;
+import com.opengamma.maths.datacontainers.matrix.OGComplexDenseMatrix;
+import com.opengamma.maths.datacontainers.matrix.OGRealDenseMatrix;
+import com.opengamma.maths.datacontainers.other.ComplexArrayContainer;
+import com.opengamma.maths.datacontainers.scalar.OGComplexScalar;
+import com.opengamma.maths.datacontainers.scalar.OGRealScalar;
+import com.opengamma.maths.exceptions.MathsException;
+import com.opengamma.maths.exceptions.MathsExceptionIllegalArgument;
+import com.opengamma.maths.exceptions.MathsExceptionNativeComputation;
+import com.opengamma.maths.helpers.FuzzyEquals;
+import com.opengamma.maths.materialisers.Materialisers;
+import com.opengamma.maths.nodes.INV;
+import com.opengamma.maths.nodes.MTIMES;
+
+/**
+ * Tests the INV node
+ */
+public class TestInvMaterialise {
+
+  @DataProvider
+  public Object[][] realDataContainer() {
+    Object[][] obj = new Object[8][2];
+
+    obj[0][0] = new INV(new OGRealScalar(1.0));
+    obj[0][1] = new OGRealScalar(1.0);
+
+    obj[1][0] = new INV(new OGRealScalar(-1.0));
+    obj[1][1] = new OGRealScalar(-1.0);
+
+    obj[2][0] = new INV(new OGRealScalar(0.0));
+    obj[2][1] = new OGRealScalar(Double.POSITIVE_INFINITY);
+
+    obj[3][0] = new INV(new OGRealScalar(10.0));
+    obj[3][1] = new OGRealScalar(0.1);
+
+    obj[4][0] = new INV(new OGRealDenseMatrix(1));
+    obj[4][1] = new OGRealScalar(1);
+
+    obj[5][0] = new INV(new OGRealDenseMatrix(-1));
+    obj[5][1] = new OGRealScalar(-1);
+
+    obj[6][0] = new INV(new OGRealDenseMatrix(0));
+    obj[6][1] = new OGRealScalar(Double.POSITIVE_INFINITY);
+
+    obj[7][0] = new INV(new OGRealDenseMatrix(new double[] { 1, -4, 7, 2, 2, 9, 3, 1, -4 }, 3, 3));
+    obj[7][1] = new OGRealDenseMatrix(new double[] { 0.0918918918918919, 0.0486486486486487, 0.2702702702702703, -0.1891891891891892, 0.1351351351351351, -0.0270270270270270, 0.0216216216216216,
+      0.0702702702702703, -0.0540540540540541 }, 3, 3);
+
+    return obj;
+
+  };
+
+  @DataProvider
+  public Object[][] complexDataContainer() {
+    Object[][] obj = new Object[5][2];
+    obj[0][0] = new INV(new OGComplexScalar(1.0, 0));
+    obj[0][1] = new OGComplexDenseMatrix(1.0);
+
+    obj[1][0] = new INV(new OGComplexScalar(0, 1.0));
+    obj[1][1] = new OGComplexScalar(0, -1.0);
+
+    obj[2][0] = new INV(new OGComplexScalar(0, 0));
+    obj[2][1] = new OGComplexScalar(Double.POSITIVE_INFINITY, 0);
+
+    obj[3][0] = new INV(new OGComplexScalar(1.0, 1.0));
+    obj[3][1] = new OGComplexScalar(0.5, -0.5);
+
+    obj[4][0] = new INV(new OGComplexDenseMatrix(new double[] { 1., 10., -4., -40., 7., 70., 2., 20., 2., 20., 9., 90., 3., 30., 1., 10., 11., 11. }, 3, 3));
+    obj[4][1] = new OGComplexDenseMatrix(new double[] { 0.0015906219620334, -0.0048867825577376, 0.0026942738518561, 0.0088704319348774, 0.0009739401444214, -0.0372879941007054, -0.0019412404140251,
+      0.0183104604339916, 0.0011167112286758, -0.0147484293321016, -0.0000973940144421, 0.0037287994100705, 0.0000779152115537, -0.0029830395280564, 0.0002532244375496, -0.0096948784661834,
+      -0.0001947880288843, 0.0074575988201411 }, 3, 3);
+
+    return obj;
+  };
+
+  @DataProvider
+  public Object[][] jointdataContainer() {
+    Object[][] obj = new Object[13][];
+    int p = 0;
+    for (int k = 0; k < realDataContainer().length; k++) {
+      obj[p++] = realDataContainer()[k];
+    }
+    for (int k = 0; k < complexDataContainer().length; k++) {
+      obj[p++] = complexDataContainer()[k];
+    }
+    return obj;
+  }
+
+  @Test(dataProvider = "realDataContainer")
+  public void materialiseToJDoubleArray(OGNumeric input, OGTerminal expected) {
+    double[][] answer = Materialisers.toDoubleArrayOfArrays(input);
+    if (!FuzzyEquals.ArrayFuzzyEquals(Materialisers.toDoubleArrayOfArrays(expected), answer)) {
+      throw new MathsException("Arrays not equal. Got: " + new OGRealDenseMatrix(answer).toString() + " Expected: " + expected.toString());
+    }
+  }
+
+  @Test(dataProvider = "complexDataContainer")
+  public void materialiseToComplexArrayContainer(OGNumeric input, OGTerminal expected) {
+    ComplexArrayContainer answer = Materialisers.toComplexArrayContainer(input);
+    if (!FuzzyEquals.ArrayFuzzyEquals(Materialisers.toComplexArrayContainer(expected).getReal(), answer.getReal())) {
+      throw new MathsException("Arrays not equal. Got: " + new OGRealDenseMatrix(answer.getReal()).toString() + " Expected: " + Arrays.toString(expected.getData()));
+    }
+    if (!FuzzyEquals.ArrayFuzzyEquals(Materialisers.toComplexArrayContainer(expected).getImag(), answer.getImag())) {
+      throw new MathsException("Arrays not equal. Got: " + new OGRealDenseMatrix(answer.getImag()).toString() + " Expected: " + Arrays.toString(expected.getData()));
+    }
+  }
+
+  @Test(dataProvider = "jointdataContainer")
+  public void materialiseToOGTerminal(OGNumeric input, OGTerminal expected) {
+    OGTerminal answer = Materialisers.toOGTerminal(input);
+    if (!expected.mathsequals(answer)) {
+      throw new MathsException("Terminals not equal. Got: " + answer.toString() + " Expected: " + expected.toString());
+    }
+  }
+
+  @Test(dataProvider = "jointdataContainer", expectedExceptions = MathsExceptionIllegalArgument.class)
+  public void outsideArgBound(OGExpr input, OGTerminal expected) {
+    input.getArg(1);
+  }
+
+  @DataProvider
+  public Object[][] reconstrDataContainer() {
+    OGRealDenseMatrix real = new OGRealDenseMatrix(new double[] { 1, -4, 7, 2, 2, 9, 3, 1, 11 }, 3, 3);
+    OGComplexDenseMatrix complex = new OGComplexDenseMatrix(new double[] { 1, 10, -4, -40, 7, 70, 2, 20, 2, 20, 9, 90, 3, 30, 1, 10, 11, 11 }, 3, 3);
+    Object[][] obj = new Object[2][1];
+    obj[0][0] = real;
+    obj[1][0] = complex;
+    return obj;
+  }
+
+  @Test(dataProvider = "reconstrDataContainer")
+  public void reconstructionTest(OGTerminal A) {
+    OGExpr INV = new INV(A);
+    OGExpr AmtimesINVA = new MTIMES(A, INV);
+    OGRealDenseMatrix expected = new OGRealDenseMatrix(new double[] { 1, 0, 0, 0, 1, 0, 0, 0, 1 }, 3, 3);
+    OGTerminal computed = Materialisers.toOGTerminal(AmtimesINVA);
+    assertTrue(expected.mathsequals(computed, 1e-14, 1e-14));
+  }
+
+  @DataProvider
+  public Object[][] singularDataContainer() {
+    OGRealDenseMatrix real = new OGRealDenseMatrix(new double[] { 1, 10, 1, 2, 20, 2, 3, 30, 3 }, 3, 3);
+    OGComplexDenseMatrix complex = new OGComplexDenseMatrix(new double[] { 1, 10, 10, 100, 1, 10, 2, 20, 20, 200, 2, 20, 3, 30, 30, 300, 3, 30 }, 3, 3);
+    Object[][] obj = new Object[2][1];
+    obj[0][0] = real;
+    obj[1][0] = complex;
+    return obj;
+  }
+
+  @Test(dataProvider = "singularDataContainer")
+  public void warnOnSingularTest(OGTerminal A) {
+    // TODO: This is placeholder code to assert a warning is logged on singular
+    Materialisers.toOGTerminal(new INV(A));
+  }
+
+  @DataProvider
+  public Object[][] nonSquareDataContainer() {
+    OGRealDenseMatrix real0 = new OGRealDenseMatrix(new double[] { 1, 2, 3, 4, 5, 6 }, 2, 3);
+    OGRealDenseMatrix real1 = new OGRealDenseMatrix(new double[] { 1, 2, 3, 4, 5, 6 }, 3, 2);
+    OGComplexDenseMatrix complex0 = new OGComplexDenseMatrix(new double[] { 1, 10, 2, 20, 3, 30, 4, 40, 5, 50, 6, 60 }, 2, 3);
+    OGComplexDenseMatrix complex1 = new OGComplexDenseMatrix(new double[] { 1, 10, 2, 20, 3, 30, 4, 40, 5, 50, 6, 60 }, 3, 2);
+    Object[][] obj = new Object[4][1];
+    obj[0][0] = real0;
+    obj[1][0] = real1;
+    obj[2][0] = complex0;
+    obj[3][0] = complex1;
+    return obj;
+  }
+
+  @Test(dataProvider = "nonSquareDataContainer", expectedExceptions=MathsExceptionNativeComputation.class)
+  public void throwOnNonSquareTest(OGTerminal A) {
+    Materialisers.toOGTerminal(new INV(A));
+  }
+
+}

--- a/src/librdag/CMakeLists.txt
+++ b/src/librdag/CMakeLists.txt
@@ -27,6 +27,7 @@ set(RDAG_SOURCES containers.cc
                  runtree.cc
                  terminal.cc
                  runners/ctransposerunner.cc
+                 runners/invrunner.cc
                  runners/mtimesrunner.cc
                  runners/norm2runner.cc
                  runners/pinvrunner.cc

--- a/src/librdag/expressionbase.cc
+++ b/src/librdag/expressionbase.cc
@@ -244,6 +244,38 @@ PINV::getType() const
 
 
 /**
+ * INV node
+ */
+
+INV::INV(const OGNumeric* arg): OGUnaryExpr{arg} {}
+
+OGNumeric*
+INV::copy() const
+{
+
+  return new INV(_args[0]->copy());
+}
+
+const INV*
+INV::asINV() const
+{
+  return this;
+}
+
+void
+INV::debug_print() const
+{
+        cout << "INV base class" << endl;
+}
+
+ExprType_t
+INV::getType() const
+{
+  return INV_ENUM;
+}
+
+
+/**
  * TRANSPOSE node
  */
 

--- a/src/librdag/numericbase.cc
+++ b/src/librdag/numericbase.cc
@@ -46,6 +46,12 @@ OGNumeric::asPINV() const
   return nullptr;
 }
 
+const INV*
+OGNumeric::asINV() const
+{
+  return nullptr;
+}
+
 const TRANSPOSE*
 OGNumeric::asTRANSPOSE() const
 {

--- a/src/librdag/runners/invrunner.cc
+++ b/src/librdag/runners/invrunner.cc
@@ -1,0 +1,144 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for licence.
+ *
+ */
+
+#include "dispatch.hh"
+#include "runners.hh"
+#include "expression.hh"
+#include "iss.hh"
+#include "terminal.hh"
+#include "execution.hh"
+#include "dispatch.hh"
+#include "uncopyable.hh"
+#include "lapack.hh"
+
+#include <stdio.h>
+#include <complex>
+#include <sstream>
+#include <limits>
+
+/*
+ *  Unit contains code for INV node runners
+ */
+namespace librdag {
+
+void *
+INVRunner::run(RegContainer& reg, OGRealScalar const * arg) const
+{
+  const OGRealScalar* ret;
+  real16 x = arg->getValue();
+  if(x == 0.e0)
+  {
+    cerr << "Warning: singular system detected in matrix inversion" << std::endl;
+    ret = new OGRealScalar(std::numeric_limits<real16>::infinity());
+  }
+  else
+  {
+    ret = new OGRealScalar(1.e0/x);
+  }
+  reg.push_back(ret);
+  return nullptr;
+}
+
+template<typename T>
+void
+inv_dense_runner(RegContainer& reg, OGMatrix<T> const * arg)
+{
+  const OGTerminal* ret = nullptr; // the returned item
+
+  // Matrix in scalar context, i.e. a 1x1 matrix, inv is simply value**-1
+  if(arg->getRows()==1 && arg->getCols()==1)
+  {
+    // NOTE: currently no cutoff grounding is applied to the argument, x;
+    // if x == 0.e0 then inv(x) = inf;
+    // else inv(x) = 1/x;
+    T x = arg->getData()[0];
+    if(x == 0.e0)
+    {
+      cerr << "Warning: singular system detected in matrix inversion." << std::endl;
+      ret = makeConcreteScalar(std::numeric_limits<real16>::infinity());
+    }
+    else
+    {
+      ret = makeConcreteScalar(1.e0/x);
+    }
+  }
+  else
+  {
+    int m = arg->getRows();
+    int n = arg->getCols();
+
+    // require matrix is square.
+    if(m!=n)
+    {
+      stringstream message;
+      message << "Cannot invert a matrix that is not square. Matrix presented has shape: [" << m <<"x"<< n <<"].";
+      throw rdag_error(message.str());
+    }
+
+    // dimensions
+    int size = m;
+    int sizesize = size*size;
+    int lda = size;
+
+    // status
+    int info = 0;
+
+    // copy A else it's destroyed
+    T * A = new T[sizesize];
+    std::memcpy(A, arg->getData(), sizeof(T)*sizesize);
+
+    // create pivot vector
+    int * ipiv = new int[size]();
+
+    // call lapack to get LU decomp
+    try
+    {
+      // LU decomp
+      lapack::xgetrf(&size, &size, A, &lda, ipiv, &info);
+      // Inversion backsolve
+      lapack::xgetri(&size, A, &lda, ipiv, &info);
+    }
+    catch (exception& e)
+    {
+      if(info < 0) // illegal arg
+      {
+        delete[] ipiv;
+        delete[] A;
+        throw ;
+      }
+      else
+      {
+        cerr << "Warning: singular system detected in matrix inversion." << std::endl;
+        cerr << "---> LAPACK details: " << e.what() << std::endl;
+      }
+    }
+
+    // normal return, delete pivot info
+    delete [] ipiv;
+
+    ret = makeConcreteDenseMatrix(A, size, size, OWNER);
+  }
+
+  // shove ret into register
+  reg.push_back(ret);
+}
+
+void *
+INVRunner::run(RegContainer& reg, OGRealMatrix const * arg) const
+{
+  inv_dense_runner(reg, arg);
+  return nullptr;
+}
+
+void *
+INVRunner::run(RegContainer& reg, OGComplexMatrix const * arg) const
+{
+  inv_dense_runner(reg, arg);
+  return nullptr;
+}
+
+} // end namespace

--- a/src/librdag/test/check_lapack.cc
+++ b/src/librdag/test/check_lapack.cc
@@ -486,6 +486,88 @@ TEST(LAPACKTest_xtrtrs, ztrtrs) {
   delete [] A;
 }
 
+
+// Check successful templating of dgetri.
+TEST(LAPACKTest_xgetri, dgetri) {
+  int n = 4;
+  int INFO = 0;
+
+  // this is the decomp of rcondok5x4[1:16] from dgetrf
+  real16 * A = new real16[16]{10,0.5000000000000000,0.9000000000000000,0.8000000000000000,19,-0.5000000000000000,0.2000000000000028,0.4000000000000021,29,-4.5000000000000000,-6.1999999999999886,0.0645161290322571,21,-2.5000000000000000,-3.3999999999999950,12.4193548387096779};
+
+  real16 * expectedA = new real16[16]{4.2701298701298649,-2.2883116883116852,0.0493506493506489,-0.0311688311688309,-2.2883116883116852,1.4519480519480503,-0.1584415584415583,-0.0051948051948053,0.0493506493506489,-0.1584415584415583,0.1532467532467533,-0.0441558441558442,-0.0311688311688309,-0.0051948051948053,-0.0441558441558442,0.0805194805194805};
+
+  // this is the decomp of rsingular3x3 from dgetrf
+  real16 * Asingular = new real16[9] {10., 0.1, 0.10000000000000001, 20., -0., -0., 30.,-0.,-0.};
+
+  int * ipiv = new int[4]{3,3,3,4};
+
+  real16 * Acpy = new real16[16];
+  std::copy(A,A+n*n,Acpy);
+  lapack::xgetri(&n,Acpy,&n,ipiv,&INFO);
+
+  EXPECT_TRUE(ArrayFuzzyEquals(expectedA,Acpy,16,1e-14,1e-14));
+
+  // check throw on bad arg
+  std::copy(A,A+n*n,Acpy);
+  n = -1;
+  EXPECT_THROW(lapack::xgetri(&n,Acpy,&n,ipiv,&INFO), rdag_error);
+
+  // check throw on singular
+  n=3;
+  ipiv[0]=2;ipiv[1]=2;ipiv[2]=3;
+  std::copy(Asingular,Asingular+n*n,Acpy);
+  EXPECT_THROW(lapack::xgetri(&n,Acpy,&n,ipiv,&INFO), rdag_error);
+
+  delete [] ipiv;
+  delete [] A;
+  delete [] Acpy;
+  delete [] expectedA;
+  delete [] Asingular;
+}
+
+// Check successful templating of zgetri.
+TEST(LAPACKTest_xgetri, zgetri) {
+  int n = 4;
+  int INFO = 0;
+
+  // this is the decomp of ccondok5x4[1:16] from zgetrf
+  complex16 * A = new complex16[16]{{10,-20}, {0.5,0}, {0.8999999999999999,0}, {      0.8,0}, {19,-38}, {-0.5,1}, {0.1999999999999957,0}, {0.4000000000000021,0}, {29,-58}, {     -4.5,9}, {     -6.2000000000000171,12.4000000000000341}, {0.0645161290322568,0}, {21,-42}, {-2.5,5}, {     -3.4000000000000092,6.8000000000000185}, {12.4193548387096779,-24.8387096774193559}};
+
+
+  complex16 * expectedA = new complex16[16]{{0.8540259740259719, 1.7080519480519438}, {-0.4576623376623363,-0.9153246753246725}, {0.0098701298701297, 0.0197402597402595}, {-0.0062337662337663,-0.0124675324675326}, {-0.4576623376623364,-0.9153246753246728}, {0.2903896103896096, 0.5807792207792192}, {-0.0316883116883116,-0.0633766233766232}, {-0.0010389610389610,-0.0020779220779220}, {0.0098701298701298, 0.0197402597402595}, {-0.0316883116883116,-0.0633766233766233}, {0.0306493506493506, 0.0612987012987013}, {-0.0088311688311688,-0.0176623376623377}, {-0.0062337662337662,-0.0124675324675325}, {-0.0010389610389610,-0.0020779220779221}, {-0.0088311688311688,-0.0176623376623377}, {0.0161038961038961, 0.0322077922077922}};
+
+  // this is the decomp of csingular3x3 from zgetrf
+  complex16 * Asingular = new complex16[9] {{10.,100.},{0.1,0.1},{20.,200.},{-0.,-0.},{30.,300.}, 0.,0.};
+
+  int * ipiv = new int[4]{3,3,3,4};
+
+  complex16 * Acpy = new complex16[16];
+  std::copy(A,A+n*n,Acpy);
+  lapack::xgetri(&n,Acpy,&n,ipiv,&INFO);
+
+  EXPECT_TRUE(ArrayFuzzyEquals(expectedA,Acpy,16,1e-14,1e-14));
+
+  // check throw on bad arg
+  std::copy(A,A+n*n,Acpy);
+  n = -1;
+  EXPECT_THROW(lapack::xgetri(&n,Acpy,&n,ipiv,&INFO), rdag_error);
+
+  // check throw on singular
+  n=3;
+  ipiv[0]=2;ipiv[1]=2;ipiv[2]=3;
+  std::copy(Asingular,Asingular+n*n,Acpy);
+  EXPECT_THROW(lapack::xgetri(&n,Acpy,&n,ipiv,&INFO), rdag_error);
+
+  delete [] ipiv;
+  delete [] A;
+  delete [] Acpy;
+  delete [] expectedA;
+  delete [] Asingular;
+}
+
+
+
 // Check successful templating of dpotrf.
 TEST(LAPACKTest_xpotrf, dpotrf) {
   int n=4;

--- a/src/librdag/test/nodes/CMakeLists.txt
+++ b/src/librdag/test/nodes/CMakeLists.txt
@@ -23,6 +23,7 @@ add_multitarget_library(testhelper
 
 set(TESTS
     check_ctranspose
+    check_inv
     check_lu
     check_mtimes
     check_norm2

--- a/src/librdag/test/nodes/check_inv.cc
+++ b/src/librdag/test/nodes/check_inv.cc
@@ -128,12 +128,14 @@ TEST(INVTests, WarnOnSingularInput)
   // real space
   mat = new OGRealMatrix(rsingular3x3,3,3,VIEWER);
   inv = new INV(mat);
+  runtree(inv);
   // TODO: assert warn check goes here
   delete inv;
 
   // complex space
   mat = new OGComplexMatrix(csingular3x3,3,3,VIEWER);
   inv = new INV(mat);
+  runtree(inv);
   // TODO: assert warn check goes here
   delete inv;
 

--- a/src/librdag/test/nodes/check_inv.cc
+++ b/src/librdag/test/nodes/check_inv.cc
@@ -1,0 +1,172 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+
+#include "gtest/gtest.h"
+#include "terminal.hh"
+#include "execution.hh"
+#include "dispatch.hh"
+#include "testnodes.hh"
+#include "runtree.hh"
+#include "equals.hh"
+#include <limits>
+
+using namespace std;
+using namespace librdag;
+using namespace testnodes;
+using ::testing::TestWithParam;
+using ::testing::Values;
+
+/*
+ * Check INV node behaves correctly
+ */
+
+UNARY_NODE_TEST_SETUP(INV)
+
+INSTANTIATE_NODE_TEST_CASE_P(INVTests,INV,
+  Values
+  (
+
+  // Test scalar context real space
+
+  // inv(1) = 1
+  new CheckUnary<INV>( new OGRealScalar(1.0), new OGRealScalar(1.0), MATHSEQUAL),
+  // inv(-1) = -1
+  new CheckUnary<INV>( new OGRealScalar(-1.0), new OGRealScalar(-1.0), MATHSEQUAL),
+  // inv(0) = +inf
+  new CheckUnary<INV>( new OGRealScalar(0.0), new OGRealScalar(std::numeric_limits<real16>::infinity()), MATHSEQUAL),
+  // inv(10) = 0.1
+  new CheckUnary<INV>( new OGRealScalar(10.0), new OGRealScalar(0.1), MATHSEQUAL),
+
+  // Test matrix context real space
+
+  // inv(1) = 1
+  new CheckUnary<INV>( new OGRealMatrix(new real16[1]{1},1,1, OWNER), new OGRealScalar(1.0), MATHSEQUAL),
+  // inv(-1) = -1
+  new CheckUnary<INV>( new OGRealMatrix(new real16[1]{-1},1,1, OWNER), new OGRealScalar(-1.0),
+  MATHSEQUAL),
+  // inv(0) = +inf
+  new CheckUnary<INV>( new OGRealMatrix(new real16[1]{0.e0},1,1, OWNER), new OGRealScalar(std::numeric_limits<real16>::infinity()), MATHSEQUAL),
+  // inv(full rank 3x3 system) [condition number ~= 3.7]
+  new CheckUnary<INV>(
+      new OGRealMatrix(new real16[9]{1,-4,7,2,2,9,3,1,-4},3,3, OWNER),
+      new OGRealMatrix(new real16[9] {0.0918918918918919,0.0486486486486487,0.2702702702702703,-0.1891891891891892,0.1351351351351351,-0.0270270270270270,0.0216216216216216,0.0702702702702703,-0.0540540540540541},3,3, OWNER),
+      MATHSEQUAL),
+
+  // Test matrix context complex space
+
+  // inv(1+0i) = 1
+  new CheckUnary<INV>( new OGComplexScalar({1.0,0}), new OGRealScalar(1.0), MATHSEQUAL),
+  // inv(0+1i) = -i
+  new CheckUnary<INV>( new OGComplexScalar({0,1.0}), new OGComplexScalar({0,-1.0}), MATHSEQUAL),
+  // inv(0+0i) = inf
+  new CheckUnary<INV>( new OGComplexScalar({0,0}), new OGComplexScalar({std::numeric_limits<real16>::infinity(),0}), MATHSEQUAL),
+  // inv(1+1i) = 0.5-0.5i
+  new CheckUnary<INV>( new OGComplexScalar({1.0,1.0}), new OGComplexScalar({0.5,-0.5}), MATHSEQUAL),
+  // inv(full rank 3x3 system) [condition number ~= 4.9]
+  new CheckUnary<INV>(  new OGComplexMatrix(new complex16[9]{{1.,10.}, {-4.,-40.}, {7.,70.}, {2.,20.}, {2.,20.}, {9.,90.}, {3.,30.}, {1.,10.}, {11.,11.}},3,3, OWNER),
+      new OGComplexMatrix(new complex16[9] {{0.0015906219620334,-0.0048867825577376}, {0.0026942738518561, 0.0088704319348774}, {0.0009739401444214,-0.0372879941007054}, {-0.0019412404140251, 0.0183104604339916}, {0.0011167112286758,-0.0147484293321016}, {-0.0000973940144421, 0.0037287994100705}, {0.0000779152115537,-0.0029830395280564}, {0.0002532244375496,-0.0096948784661834}, {     -0.0001947880288843, 0.0074575988201411}},3,3, OWNER),
+      MATHSEQUAL)
+  )
+);
+
+// Check invalid/bad input
+
+TEST(INVTests, NonSquareInput)
+{
+  real16 * rdat = new real16[6]{1,2,3,4,5,6};
+  complex16 * cdat = new complex16[6]{{1,10},{2,20},{3,30},{4,40},{5,50},{6,60}};
+  OGTerminal * mat;
+  OGExpr * inv;
+
+  // check throws as matrix must be square
+
+  // real space: try with more rows than cols
+  mat = new OGRealMatrix(rdat,3,2,VIEWER);
+  inv = new INV(mat);
+  ASSERT_THROW(runtree(inv), rdag_error);
+  delete inv;
+
+  // real space: try with more cols than rows
+  mat = new OGRealMatrix(rdat,2,3,VIEWER);
+  inv = new INV(mat);
+  ASSERT_THROW(runtree(inv), rdag_error);
+  delete inv;
+
+  // complex space: try with more rows than cols
+  mat = new OGComplexMatrix(cdat,3,2,VIEWER);
+  inv = new INV(mat);
+  ASSERT_THROW(runtree(inv), rdag_error);
+  delete inv;
+
+  // complex space try with more cols than rows
+  mat = new OGComplexMatrix(cdat,2,3,VIEWER);
+  inv = new INV(mat);
+  ASSERT_THROW(runtree(inv), rdag_error);
+  delete inv;
+
+  // clean up
+  delete [] rdat;
+  delete [] cdat;
+}
+
+// Explicitly test singular systems
+// NOTE: This test is a place holder for asserting that a warning is raised
+
+TEST(INVTests, WarnOnSingularInput)
+{
+  // singular 3x3
+  real16 rsingular3x3[9] = {1,10,1,2,20,2,3,30,3};
+  complex16 csingular3x3[9] = {{1,10},{10,100},{1,10},{2,20},{20,200},{2,20},{3,30},{30,300},{3,30}};
+
+  OGTerminal * mat;
+  OGExpr * inv;
+
+  // real space
+  mat = new OGRealMatrix(rsingular3x3,3,3,VIEWER);
+  inv = new INV(mat);
+  // TODO: assert warn check goes here
+  delete inv;
+
+  // complex space
+  mat = new OGComplexMatrix(csingular3x3,3,3,VIEWER);
+  inv = new INV(mat);
+  // TODO: assert warn check goes here
+  delete inv;
+
+}
+
+// Reconstruction Tests, does A*inv(A) = identity matrix?
+
+namespace testinternal {
+
+using namespace librdag;
+  real16 reals[9] = {1,-4,7,2,2,9,3,1,11};
+  OGRealMatrix * real = new OGRealMatrix(reals,3,3);
+  complex16 complexs[9] = {{1,10},{-4,-40},{7,70},{2,20},{2,20},{9,90},{3,30},{1,10},{11,110}};
+  OGComplexMatrix * complex = new OGComplexMatrix(complexs,3,3);
+}
+
+// Reconstruction Testing
+const librdag::OGTerminal * terminals[] = { testinternal::real,
+                                           testinternal::complex};
+
+class ReconstructInvNodeTest: public ::testing::TestWithParam<const OGTerminal*> {};
+
+TEST_P(ReconstructInvNodeTest, TerminalTypes)
+{
+  const OGTerminal * A = GetParam();
+  OGExpr * inv = new INV(A);
+  OGExpr * AtimesInvA = new MTIMES(A->createOwningCopy(),inv); // use copy else there's two refs to one terminal floating about
+  OGRealMatrix * expected = new OGRealMatrix(new real16[9] {1,0,0,0,1,0,0,0,1},3,3, OWNER);
+  runtree(AtimesInvA);
+  EXPECT_TRUE(AtimesInvA->getRegs()[0]->asOGTerminal()->mathsequals(expected, 1e-14, 1e-14));
+  delete AtimesInvA;
+  delete expected;
+}
+
+INSTANTIATE_TEST_CASE_P(INVTests, ReconstructInvNodeTest, ::testing::ValuesIn(terminals));
+

--- a/src/librdag/test/nodes/check_pinv.cc
+++ b/src/librdag/test/nodes/check_pinv.cc
@@ -69,7 +69,7 @@ INSTANTIATE_NODE_TEST_CASE_P(PINVTests,PINV,
   new CheckUnary<PINV>( new OGComplexScalar({0,1.0}), new OGComplexScalar({0,-1.0}), MATHSEQUAL),
   // pinv(0+0i) = 0
   new CheckUnary<PINV>( new OGComplexScalar({0,0}), new OGComplexScalar({0,0}), MATHSEQUAL),
-  // pinv(1+1i) = 0.5+0.5i
+  // pinv(1+1i) = 0.5-0.5i
   new CheckUnary<PINV>( new OGComplexScalar({1.0,1.0}), new OGComplexScalar({0.5,-0.5}), MATHSEQUAL),
   // pinv(full rank system) [condition number ~= 13]
   new CheckUnary<PINV>(

--- a/src/librdag/test/nodes/testnodes.cc
+++ b/src/librdag/test/nodes/testnodes.cc
@@ -196,6 +196,9 @@ template class UnaryOpTest<NORM2>;
 template class CheckUnary<PINV>;
 template class UnaryOpTest<PINV>;
 
+template class CheckUnary<INV>;
+template class UnaryOpTest<INV>;
+
 template class CheckUnary<TRANSPOSE>;
 template class UnaryOpTest<TRANSPOSE>;
 


### PR DESCRIPTION
The purpose of this PR is to add in the matrix inversion operation. It...
- Adds the INV() node for inverse.
- Adds a load of C++ and Java tests of pure checked input/output pairs AND where applicable reconstruction tests AND tests for throws on invalid input.
- Is missing write-to-logger functionality on singular matrix, currently going to `cerr`. See tickets: [[MAT-358]](http://jira.opengamma.com/browse/MAT-358) and [[MAT-369]](http://jira.opengamma.com/browse/MAT-369).

Coverage:
Java: 91% (no change)
build/src/jshim 0.8% (no change)
build/src/librdag 16.1% (up 0.4%)
src/jshim 57.9% (no change)
src/librdag 91.8% (down 0.3%, need that templated RTTI and copy() testing)
src/librdag/runners 95.7% (down 0.3%, largely due to LAPACK bad-input exception handling not being triggered _again_).
