### PR TITLE
Add documentation of JAR and blob combining

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -33,7 +33,8 @@ That's literally it! The jar has all the code included necessary to work out whi
 
 Note: To get a JAR like the one we distribute you'll need to build on all of
 Linux, OSX and Windows and then combine the jars produced into a single JAR. If
-you just want a JAR for a single platform, this step can be omitted.
+you just want a JAR for a single platform, then combining the JARs can be
+omitted.
 
 ### Requirements ####
 
@@ -117,6 +118,49 @@ Test with:
 ```
 export NPROCS=4
 make test ARGS=-j${NPROCS}
+```
+
+Combining the JARs
+------------------
+
+This step is optional, and only required if you intend to make a single
+multiplatform OG-Maths JAR file.
+
+In order to combine all the relevant build artifacts into a single blob for
+combination, run the following on each platform in the `build` directory:
+
+```
+python ../cmake/makeblob.py verinfo.yaml 1
+```
+
+The final argument specifies the build number - this is usually filled in by our
+build system, but you can use 1 as a placeholder. `makeblob.py` will output the
+name of the generated blob.
+
+Copy the resulting blob zips from each platform into the `combine` folder on the
+Linux machine. Then created a combined blob by running:
+
+```
+python combine.py 1 lnx.zip osx.zip win.zip
+```
+
+where `lnx.zip`, `osx.zip` and `win.zip` are the names of the blobs from each
+platform. This will generate a combined blob (a zip file) which contains:
+
+* The main JAR, which will run on all three platforms,
+* The tests JAR,
+* The source JAR,
+* The javadoc JAR,
+* and a `verinfo.yaml` file that contains information about the revisions that
+  the blob was built from.
+
+These can all be found by unzipping the blob, the name of which is specified in
+the output of `combine.py`. If you wish, you can test the combined main JAR on
+each platform by copying it and the tests JAR across, and then running:
+
+```
+export CLASSPATH=$CLASSPATH:<path to combined main jar>
+java org.testng.TestNG -testjar <path to tests jar> -listener com.opengamma.maths.fuzzer.TransformAnnotationFuzzOnly
 ```
 
 #### Troubleshooting native library extraction

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,7 +1,10 @@
 OpenGamma Maths Installation
 ========
 
-This document is split into two sections: the first describes "installing" OpenGamma Maths (OG-Maths) as a user, the second describes "installing" OG-Maths as an OG-Maths developer. Most people will want to install from the user perspective.
+This document is split into two sections: the first describes "installing"
+OpenGamma Maths (OG-Maths) as a user, the second describes "installing"
+OG-Maths as an OG-Maths developer. Most people will want to install from the
+user perspective.
 
 [![OpenGamma](http://developers.opengamma.com/res/display/default/chrome/masthead_logo.png "OpenGamma")](http://developers.opengamma.com)
 
@@ -10,7 +13,8 @@ Installation as a User
 
 ## For Java Users
 
-To use OG-Maths in a Java project, assuming you are using Maven as your package manager, include OG-Maths in the `pom.xml` as you would any other dependency:
+To use OG-Maths in a Java project, assuming you are using Maven as your package
+manager, include OG-Maths in the `pom.xml` as you would any other dependency:
 
 ```
 <dependencies>
@@ -27,7 +31,9 @@ That's literally it! The jar has all the code included necessary to work out whi
 
 ## For Developers/C++ Users
 
-Note: To get a JAR like the one we distribute you'll need to build on all of Linux, OSX and Windows and then combine the jars produced into a single JAR. If you just want a JAR for a single platform, this step can be omitted.
+Note: To get a JAR like the one we distribute you'll need to build on all of
+Linux, OSX and Windows and then combine the jars produced into a single JAR. If
+you just want a JAR for a single platform, this step can be omitted.
 
 ### Requirements ####
 
@@ -39,7 +45,8 @@ Generally recent versions of the requirements are preferred:
 * gfortran (we test with GCC 4.8.2)
 * A C++ compiler supporting C++11 (we test with GCC 4.8.2)
 * A C compiler supporting C99 (we test with GCC 4.8.2)
-* Python 2.6 or 2.7 with argparse and yaml modules (we test with Python 2.6 on Linux and 2.7 on Windows/OS X)
+* Python 2.6 or 2.7 with argparse and yaml modules 
+  (we test with Python 2.6 on Linux and 2.7 on Windows/OS X)
 * JDK 7 (we test with Oracle JDK 1.7.0_51 and 1.7.0_u21)
 * Maven (we test with 3.0.5)
 
@@ -69,24 +76,32 @@ git clone https://github.com/OpenGamma/OG-Maths.git
 Building
 --------
 
-The code uses the CMake toolchain to build. First, create an out-of-tree build dir:
+The code uses the CMake toolchain to build. First, create an out-of-tree build
+dir:
 
 ```
 mkdir build
 cd build
 ```
 
-****
-**Before going any further, make sure your build environment `CLASSPATH` variable contains the paths to your `jcommander` and `TestNG` jars.**
-****
+** Before going any further, make sure your build environment `CLASSPATH`
+variable contains the paths to your `jcommander` and `TestNG` jars. **
 
-Next run CMake. It is required that the path to the OG-Lapack exports file is provided ([build OG-Lapack locally first!](https://github.com/OpenGamma/OG-Lapack/)) so that the build can link against the LAPACK libraries and include them in the built JAR. This is done with the `LAPACK_EXPORT` CMake variable. Invocation of CMake:
+Next run CMake. It is required that the path to the OG-Lapack exports file is
+provided ([build OG-Lapack locally first!](https://github.com/OpenGamma/OG-Lapack/))
+so that the build can link against the LAPACK libraries and include them in the
+built JAR. This is done with the `LAPACK_EXPORT` CMake variable. Invocation of
+CMake:
 
 ```
 cmake .. -DLAPACK_EXPORT=<path_to_og_lapack>/build/LAPACK_EXPORTS.cmake -DGCC_LIB_FOLDER=<path to gcc RTLs>
 ```
 
-The build process includes the GCC runtime libraries, which are copied from `GCC_LIB_FOLDER`. As an alternative to specifying the location as an argument to CMake, the environment variable `GCC_LIB_FOLDER` may also be set to specify the location. Specifying the location on the command line overrides the value stored in the environment variable.
+The build process includes the GCC runtime libraries, which are copied from
+`GCC_LIB_FOLDER`. As an alternative to specifying the location as an argument
+to CMake, the environment variable `GCC_LIB_FOLDER` may also be set to specify
+the location. Specifying the location on the command line overrides the value
+stored in the environment variable.
 
 Build with:
 
@@ -94,7 +109,10 @@ Build with:
 make -j
 ```
 
-We strongly recommend that you test your build, since different platforms, compilers, or system math libraries may have an effect on computed results. Test with:
+We strongly recommend that you test your build, since different platforms,
+compilers, or system math libraries may have an effect on computed results.
+
+Test with:
 
 ```
 export NPROCS=4
@@ -103,21 +121,33 @@ make test ARGS=-j${NPROCS}
 
 #### Troubleshooting native library extraction
 
-The JAR's main class runs an extremely simple test that forces the extraction and linking of native code. If you encounter problems with the native code tests passing (those prefixed `check_`) and the TestNG tests failing due to UnsatisfiedLinkError, you can use the main class as a test of linking whilst working through the issue:
+The JAR's main class runs an extremely simple test that forces the extraction
+and linking of native code. If you encounter problems with the native code
+tests passing (those prefixed `check_`) and the TestNG tests failing due to
+UnsatisfiedLinkError, you can use the main class as a test of linking whilst
+working through the issue:
 
 ```
 java -jar jars/og-maths-0.1.0-SNAPSHOT.jar
 ```
 
 Should this test succeed, the final line of the output will be:
+
 ```
 Native library linkage appears to be working correctly.
 ```
 
-If there are link errors, these will be uncaught and therefore printed to standard output. It can be easier to tell what the problem is this way than using the TestNG tests.
+If there are link errors, these will be uncaught and therefore printed to
+standard output. It can be easier to tell what the problem is this way than
+using the TestNG tests.
 
 #### Working with the Java side in Eclipse
-The project can be imported into Eclipse, but this is not necessary unless you intend to develop the actual Java library itself - most people will just want the pre-built JAR. If you are sure you want to work on the Java part of the library, first ensure your Eclipse install has the Maven toolchain installed and then:
+
+The project can be imported into Eclipse, but this is not necessary unless you
+intend to develop the actual Java library itself - most people will just want
+the pre-built JAR. If you are sure you want to work on the Java part of the
+library, first ensure your Eclipse install has the Maven toolchain installed
+and then:
 
 1. Go to `"File -> Import"`.
 2. Select the `"Maven -> Existing Maven Projects"` option.
@@ -127,9 +157,9 @@ The project can be imported into Eclipse, but this is not necessary unless you i
 
 #### Refreshing the expression enum
 
-Since it is difficult to work with generated Java code in eclipse, we generate and then
-commit the expression enum for the Java side. In order to regenerate it, use the
-`exprenum_java` target:
+Since it is difficult to work with generated Java code in eclipse, we generate
+and then commit the expression enum for the Java side. In order to regenerate
+it, use the `exprenum_java` target:
 
 ```
 $ make exprenum_java


### PR DESCRIPTION
This PR adds documentation of the making and combination of blobs to create a multiplatform JAR.

Additionally, the text of INSTALL.md is wrapped at 80 characters to make it easier to work with in a text editor.

Coverage: unchanged.
