### PR TITLE
Fix FuzzyCompareOGTerminalContainer and ConvertTo interfaces in OGTerminal

### DIFF
--- a/include/convertto.hh
+++ b/include/convertto.hh
@@ -6,7 +6,8 @@
 
 #ifndef _CONVERTTO_HH
 #define _CONVERTTO_HH
-#include "terminal.hh"
+
+#include <memory>
 
 // defines permissable type conversions
 
@@ -25,6 +26,17 @@
 
 
 namespace librdag {
+
+class OGRealScalar;
+class OGComplexScalar;
+class OGIntegerScalar;
+class OGRealMatrix;
+class OGComplexMatrix;
+class OGLogicalMatrix;
+class OGRealDiagonalMatrix;
+class OGComplexDiagonalMatrix;
+class OGRealSparseMatrix;
+class OGComplexSparseMatrix;
 
 // conversion class, it need not be a class
 class ConvertTo

--- a/include/terminal.hh
+++ b/include/terminal.hh
@@ -31,7 +31,7 @@ class FuzzyCompareOGTerminalContainer
     const weak_ptr<const OGTerminal> _terminal;
 };
 
-}
+} // end namespace detail
 
 
 /**
@@ -147,7 +147,7 @@ class OGTerminal: public OGNumeric
     virtual bool operator==(const OGTerminal::Ptr&) const;
     virtual bool operator!=(const OGTerminal::Ptr&) const;
     virtual bool operator%(const OGTerminal::Ptr&) const;
-    virtual detail::FuzzyCompareOGTerminalContainer& operator~(void) const;
+    virtual detail::FuzzyCompareOGTerminalContainer operator~(void) const;
     virtual bool operator==(const detail::FuzzyCompareOGTerminalContainer&) const;
     virtual bool operator!=(const detail::FuzzyCompareOGTerminalContainer&) const;
     OGTerminal();
@@ -157,11 +157,6 @@ class OGTerminal: public OGNumeric
      */
     const ConvertTo * getConvertTo() const;
   private:
-    detail::FuzzyCompareOGTerminalContainer& getFuzzyContainer() const;
-    // We need _fuzzyref to be mutable so that we can set it later on. We can't set
-    // it on construction, since we need to use shared_from_this() to build the
-    // _fuzzyref.
-    mutable detail::FuzzyCompareOGTerminalContainer * _fuzzyref = nullptr;
     const ConvertTo * _converter = nullptr;
 };
 

--- a/include/terminal.hh
+++ b/include/terminal.hh
@@ -23,12 +23,9 @@ class FuzzyCompareOGTerminalContainer
   public:
     FuzzyCompareOGTerminalContainer(const shared_ptr<const OGTerminal>& terminal);
     ~FuzzyCompareOGTerminalContainer();
-    const weak_ptr<const OGTerminal> getTerminal() const;
+    const shared_ptr<const OGTerminal> getTerminal() const;
   private:
-    // We use a weak_ptr to refer to the terminal because the terminal would
-    // always be holding a shared_ptr reference to itself through its
-    // FuzzyCompareOGTerminalContainer, which would prevent it ever getting deleted.
-    const weak_ptr<const OGTerminal> _terminal;
+    const shared_ptr<const OGTerminal> _terminal;
 };
 
 } // end namespace detail

--- a/include/terminal.hh
+++ b/include/terminal.hh
@@ -149,12 +149,8 @@ class OGTerminal: public OGNumeric
     virtual bool operator!=(const detail::FuzzyCompareOGTerminalContainer&) const;
     OGTerminal();
     virtual ~OGTerminal();
-    /**
-     * Gets the converter
-     */
-    const ConvertTo * getConvertTo() const;
-  private:
-    const ConvertTo * _converter = nullptr;
+  protected:
+    ConvertTo _converter;
 };
 
 /**

--- a/src/librdag/terminal.cc
+++ b/src/librdag/terminal.cc
@@ -65,10 +65,10 @@ OGTerminal::operator!=(const OGTerminal::Ptr& other) const
   return !(this->equals(other));
 }
 
-detail::FuzzyCompareOGTerminalContainer&
+detail::FuzzyCompareOGTerminalContainer
 OGTerminal::operator~(void) const
 {
-  return this->getFuzzyContainer();
+  return detail::FuzzyCompareOGTerminalContainer(asOGTerminal());
 }
 
 bool OGTerminal::operator==(const detail::FuzzyCompareOGTerminalContainer& thing) const
@@ -88,20 +88,7 @@ OGTerminal::OGTerminal()
 
 OGTerminal::~OGTerminal()
 {
-  if (_fuzzyref != nullptr)
-  {
-    delete _fuzzyref;
-  }
   delete _converter;
-}
-
-detail::FuzzyCompareOGTerminalContainer&
-OGTerminal::getFuzzyContainer() const{
-  if (_fuzzyref == nullptr)
-  {
-    _fuzzyref = new detail::FuzzyCompareOGTerminalContainer(asOGTerminal());
-  }
-  return *_fuzzyref;
 }
 
 const ConvertTo *

--- a/src/librdag/terminal.cc
+++ b/src/librdag/terminal.cc
@@ -145,7 +145,7 @@ detail::FuzzyCompareOGTerminalContainer::FuzzyCompareOGTerminalContainer(const O
 
 detail::FuzzyCompareOGTerminalContainer::~FuzzyCompareOGTerminalContainer(){}
 
-const weak_ptr<const OGTerminal>
+const shared_ptr<const OGTerminal>
 detail::FuzzyCompareOGTerminalContainer::getTerminal() const
 {
   return _terminal;

--- a/src/librdag/terminal.cc
+++ b/src/librdag/terminal.cc
@@ -81,21 +81,9 @@ bool OGTerminal::operator!=(const detail::FuzzyCompareOGTerminalContainer& thing
   return !(this->fuzzyequals(OGTerminal::Ptr{thing.getTerminal()}));
 }
 
-OGTerminal::OGTerminal()
-{
-  _converter = new ConvertTo();
-}
+OGTerminal::OGTerminal() {}
 
-OGTerminal::~OGTerminal()
-{
-  delete _converter;
-}
-
-const ConvertTo *
-OGTerminal::getConvertTo() const
-{
-  return this->_converter;
-}
+OGTerminal::~OGTerminal() {}
 
 bool
 OGTerminal::mathsequals(const OGTerminal::Ptr& other) const
@@ -352,13 +340,13 @@ OGRealScalar::getType() const
 OGRealMatrix::Ptr
 OGRealScalar::asFullOGRealMatrix() const
 {
-  return getConvertTo()->convertToOGRealMatrix(asOGRealScalar());
+  return _converter.convertToOGRealMatrix(asOGRealScalar());
 }
 
 OGComplexMatrix::Ptr
 OGRealScalar::asFullOGComplexMatrix() const
 {
-  return getConvertTo()->convertToOGComplexMatrix(asOGRealScalar());
+  return _converter.convertToOGComplexMatrix(asOGRealScalar());
 }
 
 OGTerminal::Ptr
@@ -424,7 +412,7 @@ OGComplexScalar::asFullOGRealMatrix() const
 OGComplexMatrix::Ptr
 OGComplexScalar::asFullOGComplexMatrix() const
 {
-  return getConvertTo()->convertToOGComplexMatrix(asOGComplexScalar());
+  return _converter.convertToOGComplexMatrix(asOGComplexScalar());
 }
 
 OGTerminal::Ptr
@@ -479,13 +467,13 @@ OGIntegerScalar::getType() const
 OGRealMatrix::Ptr
 OGIntegerScalar::asFullOGRealMatrix() const
 {
-  return getConvertTo()->convertToOGRealMatrix(asOGIntegerScalar());
+  return _converter.convertToOGRealMatrix(asOGIntegerScalar());
 }
 
 OGComplexMatrix::Ptr
 OGIntegerScalar::asFullOGComplexMatrix() const
 {
-  return getConvertTo()->convertToOGComplexMatrix(asOGIntegerScalar());
+  return _converter.convertToOGComplexMatrix(asOGIntegerScalar());
 }
 
 OGTerminal::Ptr
@@ -936,7 +924,7 @@ OGRealMatrix::asFullOGRealMatrix() const
 OGComplexMatrix::Ptr
 OGRealMatrix::asFullOGComplexMatrix() const
 {
-  return getConvertTo()->convertToOGComplexMatrix(asOGRealMatrix());
+  return _converter.convertToOGComplexMatrix(asOGRealMatrix());
 }
 
 OGTerminal::Ptr
@@ -1170,13 +1158,13 @@ OGRealDiagonalMatrix::getType() const
 OGRealMatrix::Ptr
 OGRealDiagonalMatrix::asFullOGRealMatrix() const
 {
-    return getConvertTo()->convertToOGRealMatrix(asOGRealDiagonalMatrix());
+    return _converter.convertToOGRealMatrix(asOGRealDiagonalMatrix());
 }
 
 OGComplexMatrix::Ptr
 OGRealDiagonalMatrix::asFullOGComplexMatrix() const
 {
-  return getConvertTo()->convertToOGComplexMatrix(asOGRealDiagonalMatrix());
+  return _converter.convertToOGComplexMatrix(asOGRealDiagonalMatrix());
 }
 
 OGTerminal::Ptr
@@ -1277,7 +1265,7 @@ OGComplexDiagonalMatrix::asFullOGRealMatrix() const
 OGComplexMatrix::Ptr
 OGComplexDiagonalMatrix::asFullOGComplexMatrix() const
 {
-  return getConvertTo()->convertToOGComplexMatrix(asOGComplexDiagonalMatrix());
+  return _converter.convertToOGComplexMatrix(asOGComplexDiagonalMatrix());
 }
 
 
@@ -1511,13 +1499,13 @@ OGRealSparseMatrix::getType() const
 OGRealMatrix::Ptr
 OGRealSparseMatrix::asFullOGRealMatrix() const
 {
-  return getConvertTo()->convertToOGRealMatrix(asOGRealSparseMatrix());
+  return _converter.convertToOGRealMatrix(asOGRealSparseMatrix());
 }
 
 OGComplexMatrix::Ptr
 OGRealSparseMatrix::asFullOGComplexMatrix() const
 {
-  return getConvertTo()->convertToOGComplexMatrix(asOGRealSparseMatrix());
+  return _converter.convertToOGComplexMatrix(asOGRealSparseMatrix());
 }
 
 OGTerminal::Ptr
@@ -1610,7 +1598,7 @@ OGComplexSparseMatrix::asFullOGRealMatrix() const
 OGComplexMatrix::Ptr
 OGComplexSparseMatrix::asFullOGComplexMatrix() const
 {
-  return getConvertTo()->convertToOGComplexMatrix(asOGComplexSparseMatrix());
+  return _converter.convertToOGComplexMatrix(asOGComplexSparseMatrix());
 }
 
 OGTerminal::Ptr


### PR DESCRIPTION
This PR involves:
- Changing the interface of `FuzzyCompareOGTerminalContainer` in `OGTerminal` so that no dangling references can be exposed, and `OGTerminal` no longer holds a reference to a `FuzzyCompareOGTerminalContainer` instance. This allows `FuzzyCompareOGTerminalContainer` to hold a `shared_ptr` instead of a `weak_ptr`, which will also prevent it from holding an expired pointer.
- Removing external access to the `ConvertTo` that has held by `OGTerminal`, as it is not needed externally, and would allow a dangling pointer. 

Coverage:

Java: 79%
build/src/jshim: 0.8%
build/src/librdag: 16.4%
src/jshim: 55%
src/librdag: 91.3%
src/librdag/runners: 95.7%

All unchanged except for src/librdag, which is down 0.1% because of the deletion of code that was covered.
