### PR TITLE
[MAT-343] Always specify expected exceptions

### DIFF
--- a/src/jshim/jdispatch.cc
+++ b/src/jshim/jdispatch.cc
@@ -120,9 +120,7 @@ Complex16AoA::Complex16AoA(const OGNumeric::Ptr& node)
     break;
   case REAL_MATRIX_ENUM:
   case COMPLEX_MATRIX_ENUM:
-  case REAL_DIAGONAL_MATRIX_ENUM:
   case COMPLEX_DIAGONAL_MATRIX_ENUM:
-  case REAL_SPARSE_MATRIX_ENUM:
   case COMPLEX_SPARSE_MATRIX_ENUM:
     _data = node->asOGTerminal()->toComplex16ArrayOfArrays();
     _rows = node->asOGTerminal()->getRows();

--- a/src/jshim/test/check_jbindings.cc
+++ b/src/jshim/test/check_jbindings.cc
@@ -14,6 +14,7 @@
 #include "jvmmanager.hh"
 #include "debug.h"
 #include "test/fake_jvm.hh"
+#include "exceptions.hh"
 
 using namespace std;
 using namespace convert;
@@ -41,7 +42,7 @@ TEST(JBindings, Test_bindPrimitiveArrayData_bad_obj)
     jobject obj = nullptr;
     jmethodID meth = new _jmethodID();
     bindRunner * clazz = new bindRunner();
-    ASSERT_ANY_THROW(clazz->run(obj,meth));
+    ASSERT_THROW(clazz->run(obj,meth), convert_error);
     delete clazz;
     delete meth;
 }
@@ -51,7 +52,7 @@ TEST(JBindings, Test_bindPrimitiveArrayData_bad_method)
     jobject obj = new _jobject();
     jmethodID meth = nullptr;
     bindRunner * clazz = new bindRunner();
-    ASSERT_ANY_THROW(clazz->run(obj,meth));
+    ASSERT_THROW(clazz->run(obj,meth), convert_error);
     delete obj;
     delete clazz;
 }
@@ -78,7 +79,7 @@ TEST(JBindings, Test_bindPrimitiveArrayData_bad_method)
 //     jobject obj = new _jobject();
 //     jmethodID meth = new _jmethodID();
 //     bindRunner * clazz = new bindRunner();
-//     ASSERT_ANY_THROW(clazz->run(obj,meth));
+//     ASSERT_THROW(clazz->run(obj,meth), convert_error);
 //     delete jvm;
 //     delete env;
 //     delete obj;
@@ -102,7 +103,7 @@ TEST(JBindings, Test_bindPrimitiveArrayData_bad_callobjmethod)
     jobject obj = new _jobject();
     jmethodID meth = new _jmethodID();
     bindRunner * clazz = new bindRunner();
-    ASSERT_ANY_THROW(clazz->run(obj,meth));
+    ASSERT_THROW(clazz->run(obj,meth), convert_error);
     delete jvm;
     delete env;
     delete obj;
@@ -116,7 +117,7 @@ TEST(JBindings, Test_unbindPrimitiveArrayData_bad_data)
   jobject obj = new _jobject();
   jmethodID meth = new _jmethodID();
   unbindRunner * clazz = new unbindRunner();
-  ASSERT_ANY_THROW(clazz->run(data,obj,meth));
+  ASSERT_THROW(clazz->run(data,obj,meth), convert_error);
   delete obj;
   delete meth;
   delete clazz;
@@ -128,7 +129,7 @@ TEST(JBindings, Test_unbindPrimitiveArrayData_bad_obj)
   jobject obj = nullptr;
   jmethodID meth = new _jmethodID();
   unbindRunner * clazz = new unbindRunner();
-  ASSERT_ANY_THROW(clazz->run(data,obj,meth));
+  ASSERT_THROW(clazz->run(data,obj,meth), convert_error);
   delete[] data;
   delete meth;
   delete clazz;
@@ -140,7 +141,7 @@ TEST(JBindings, Test_unbindPrimitiveArrayData_bad_meth)
   jobject obj = new _jobject();
   jmethodID meth = nullptr;
   unbindRunner * clazz = new unbindRunner();
-  ASSERT_ANY_THROW(clazz->run(data,obj,meth));
+  ASSERT_THROW(clazz->run(data,obj,meth), convert_error);
   delete[] data;
   delete obj;
   delete clazz;
@@ -170,7 +171,7 @@ TEST(JBindings, Test_unbindPrimitiveArrayData_bad_meth)
 //     jobject obj = new _jobject();
 //     jmethodID meth = new _jmethodID();
 //     unbindRunner * clazz = new unbindRunner();
-//     ASSERT_ANY_THROW(clazz->run(data,obj,meth));
+//     ASSERT_THROW(clazz->run(data,obj,meth), convert_error);
 //     delete jvm;
 //     delete env;
 //     delete[] data;
@@ -196,7 +197,7 @@ TEST(JBindings, Test_unbindPrimitiveArrayData_bad_callobjmethod)
     jobject obj = new _jobject();
     jmethodID meth = new _jmethodID();
     unbindRunner * clazz = new unbindRunner();
-    ASSERT_ANY_THROW(clazz->run(data,obj,meth));
+    ASSERT_THROW(clazz->run(data,obj,meth), convert_error);
     delete jvm;
     delete env;
     delete[] data;

--- a/src/jshim/test/check_jdispatch.cc
+++ b/src/jshim/test/check_jdispatch.cc
@@ -25,7 +25,7 @@ TEST(JDispatch, Test_DispatchToReal16ArrayOfArrays_OGExpr)
 {
   OGNumeric::Ptr scal = OGRealScalar::create(10);
   OGExpr::Ptr expr = NORM2::create(scal);
-  ASSERT_ANY_THROW(Real16AoA{expr});
+  ASSERT_THROW(Real16AoA{expr}, convert_error);
 }
 
 TEST(JDispatch, Test_DispatchToReal16ArrayOfArrays_OGRealScalar)
@@ -41,13 +41,13 @@ TEST(JDispatch, Test_DispatchToReal16ArrayOfArrays_OGRealScalar)
 TEST(JDispatch, Test_DispatchToReal16ArrayOfArrays_OGComplexScalar)
 {
   OGNumeric::Ptr scal = OGComplexScalar::create({1,2});
-  ASSERT_ANY_THROW(Real16AoA{scal});
+  ASSERT_THROW(Real16AoA{scal}, convert_error);
 }
 
 TEST(JDispatch, Test_DispatchToReal16ArrayOfArrays_OGIntegerScalar)
 {
   OGNumeric::Ptr scal = OGIntegerScalar::create(12);
-  ASSERT_ANY_THROW(Real16AoA{scal});
+  ASSERT_THROW(Real16AoA{scal}, convert_error);
 }
 
 
@@ -75,7 +75,7 @@ TEST(JDispatch, Test_DispatchToReal16ArrayOfArrays_OGRealMatrix)
 TEST(JDispatch, Test_DispatchToReal16ArrayOfArrays_OGComplexMatrix)
 {
   OGNumeric::Ptr mat = OGComplexMatrix::create(new complex16[1]{12},1,1, OWNER);
-  ASSERT_ANY_THROW(Real16AoA{mat});
+  ASSERT_THROW(Real16AoA{mat}, convert_error);
 }
 
 TEST(JDispatch, Test_DispatchToReal16ArrayOfArrays_OGRealDiagonalMatrix)
@@ -105,7 +105,7 @@ TEST(JDispatch, Test_DispatchToReal16ArrayOfArrays_OGComplexDiagonalMatrix)
 {
   complex16 data[1] = { {12, 0} };
   OGNumeric::Ptr mat = OGComplexDiagonalMatrix::create(data,1,1);
-  ASSERT_ANY_THROW(Real16AoA{mat});
+  ASSERT_THROW(Real16AoA{mat}, convert_error);
 }
 
 
@@ -147,7 +147,7 @@ TEST(JDispatch, Test_DispatchToReal16ArrayOfArrays_OGComplexSparseMatrix)
   int * colPtr=new int[4]{0, 2, 4, 5};
 
   OGNumeric::Ptr mat = OGComplexSparseMatrix::create(colPtr, rowInd, data, rows, cols);
-  ASSERT_ANY_THROW(Real16AoA{mat});
+  ASSERT_THROW(Real16AoA{mat}, convert_error);
   delete[] data;
   delete[] rowInd;
   delete[] colPtr;
@@ -160,7 +160,7 @@ TEST(JDispatch, Test_DispatchToComplex16ArrayOfArrays_OGExpr)
 {
   OGNumeric::Ptr scal = OGRealScalar::create(10);
   OGExpr::Ptr expr = NORM2::create(scal);
-  ASSERT_ANY_THROW(Complex16AoA{expr});
+  ASSERT_THROW(Complex16AoA{expr}, convert_error);
 }
 
 TEST(JDispatch, Test_DispatchToComplex16ArrayOfArrays_OGComplexScalar)
@@ -186,7 +186,7 @@ TEST(JDispatch, Test_DispatchToComplex16ArrayOfArrays_OGRealScalar)
 TEST(JDispatch, Test_DispatchToComplex16ArrayOfArrays_OGIntegerScalar)
 {
   OGNumeric::Ptr scal = OGIntegerScalar::create(10);
-  ASSERT_ANY_THROW(Complex16AoA{scal});
+  ASSERT_THROW(Complex16AoA{scal}, convert_error);
 }
 
 TEST(JDispatch, Test_DispatchToComplex16ArrayOfArrays_OGComplexMatrix)
@@ -258,7 +258,7 @@ TEST(JDispatch, Test_DispatchToComplex16ArrayOfArrays_OGRealDiagonalMatrix)
 {
   real16 * data = new real16[1]{12};
   OGNumeric::Ptr mat = OGRealDiagonalMatrix::create(data,1,1);
-  ASSERT_ANY_THROW(Complex16AoA{mat});
+  ASSERT_THROW(Complex16AoA{mat}, convert_error);
   delete [] data;
 }
 
@@ -301,7 +301,7 @@ TEST(JDispatch, Test_DispatchToComplex16ArrayOfArrays_OGRealSparseMatrix)
   int * colPtr=new int[4]{0, 2, 4, 5};
 
   OGNumeric::Ptr mat = OGRealSparseMatrix::create(colPtr, rowInd, data, rows, cols);
-  ASSERT_ANY_THROW(Complex16AoA{mat});
+  ASSERT_THROW(Complex16AoA{mat}, convert_error);
   delete[] data;
   delete[] rowInd;
   delete[] colPtr;

--- a/src/jshim/test/check_jterminals.cc
+++ b/src/jshim/test/check_jterminals.cc
@@ -15,6 +15,7 @@
 #include "debug.h"
 #include "equals.hh"
 #include "test/fake_jvm.hh"
+#include "exceptions.hh"
 
 using namespace std;
 using namespace convert;
@@ -23,14 +24,14 @@ using namespace convert;
 TEST(JTerminals, Test_getIntFromVoidJMethod_null_meth)
 {
   jobject obj = new _jobject();
-  ASSERT_ANY_THROW(getIntFromVoidJMethod(nullptr,obj));
+  ASSERT_THROW(getIntFromVoidJMethod(nullptr,obj), convert_error);
   delete obj;
 }
 
 TEST(JTerminals, Test_getIntFromVoidJMethod_null_obj)
 {
   jmethodID meth = new _jmethodID();
-  ASSERT_ANY_THROW(getIntFromVoidJMethod(meth,nullptr));
+  ASSERT_THROW(getIntFromVoidJMethod(meth,nullptr), convert_error);
   delete meth;
 }
 
@@ -54,7 +55,7 @@ TEST(JTerminals, Test_getIntFromVoidJMethod_null_obj)
 //   JVMManager::initialize(jvm);
 //   jmethodID meth = new _jmethodID();
 //   jobject obj = new _jobject();
-//   ASSERT_ANY_THROW(getIntFromVoidJMethod(meth,obj));
+//   ASSERT_THROW(getIntFromVoidJMethod(meth,obj), convert_error);
 //   delete env;
 //   delete jvm;
 //   delete meth;
@@ -181,7 +182,7 @@ TEST(JTerminals, Test_binding_getArrayFromJava_bad_GetDoubleArrayElements)
     JVMManager::initialize(jvm);
 
     jobject obj =  new _jobject();
-    ASSERT_ANY_THROW(JOGRealScalar::create(obj));
+    ASSERT_THROW(JOGRealScalar::create(obj), convert_error);
 
     delete obj;
     delete env;
@@ -205,7 +206,7 @@ TEST(JTerminals, Test_binding_getArrayFromJava_bad_GetIntArrayElements)
     JVMManager::initialize(jvm);
 
     jobject obj =  new _jobject();
-    ASSERT_ANY_THROW(JOGIntegerScalar::create(obj));
+    ASSERT_THROW(JOGIntegerScalar::create(obj), convert_error);
 
     delete obj;
     delete env;
@@ -422,8 +423,8 @@ TEST(JTerminals, Test_JOGRealSparseMatrix_ctor)
 
     mat->debug_print();
 
-    ASSERT_ANY_THROW(mat->toReal16ArrayOfArrays());
-    ASSERT_ANY_THROW(mat->toComplex16ArrayOfArrays());
+    ASSERT_THROW(mat->toReal16ArrayOfArrays(), convert_error);
+    ASSERT_THROW(mat->toComplex16ArrayOfArrays(), convert_error);
 
     // Need to delete the node now so that the fake environment and jvm are still around
     // for its unbinding
@@ -456,8 +457,8 @@ TEST(JTerminals, Test_JOGComplexSparseMatrix_ctor)
 
     mat->debug_print();
 
-    ASSERT_ANY_THROW(mat->toReal16ArrayOfArrays());
-    ASSERT_ANY_THROW(mat->toComplex16ArrayOfArrays());
+    ASSERT_THROW(mat->toReal16ArrayOfArrays(), convert_error);
+    ASSERT_THROW(mat->toComplex16ArrayOfArrays(), convert_error);
 
     // Need to delete the node now so that the fake environment and jvm are still around
     // for its unbinding

--- a/src/jshim/test/check_jvmmanager_fakejni.cc
+++ b/src/jshim/test/check_jvmmanager_fakejni.cc
@@ -41,7 +41,7 @@ TEST(JVMManagerFakeJNITest, Test_JVMManager_initialize_badversion)
     JNIEnv theEnv;
     JNIEnv * env  = &theEnv;   
     jvm->setEnv((void **) &env);
-    ASSERT_ANY_THROW(jvm_manager->initialize(jvm));
+    ASSERT_THROW(jvm_manager->initialize(jvm), convert_error);
     
     
     delete jvm;
@@ -182,7 +182,7 @@ TEST(JVMManagerFakeJNITest, Test_JVMManager_test_registerReferences_badFindClass
     Fake_JavaVM * jvm = new Fake_JavaVM();
     Fake_Broken_ClassRef_JNIEnv * broken_env  = new Fake_Broken_ClassRef_JNIEnv();
     jvm->setEnv(broken_env);
-    ASSERT_ANY_THROW(jvm_manager->initialize(jvm));
+    ASSERT_THROW(jvm_manager->initialize(jvm), convert_error);
        
     delete broken_env;
     delete jvm;
@@ -208,7 +208,7 @@ TEST(JVMManagerFakeJNITest, Test_JVMManager_test_registerReferences_badNewGlobal
     Fake_JavaVM * jvm = new Fake_JavaVM();
     Fake_Broken_NewGlobalRef_JNIEnv * broken_env  = new Fake_Broken_NewGlobalRef_JNIEnv();
     jvm->setEnv(broken_env);
-    ASSERT_ANY_THROW(jvm_manager->initialize(jvm));
+    ASSERT_THROW(jvm_manager->initialize(jvm), convert_error);
        
     delete broken_env;
     delete jvm;
@@ -239,7 +239,7 @@ TEST(JVMManagerFakeJNITest, Test_JVMManager_test_registerReferences_badGetMethod
     Fake_JavaVM * jvm = new Fake_JavaVM();
     Fake_Broken_MethodIDRef_JNIEnv * broken_env  = new Fake_Broken_MethodIDRef_JNIEnv();
     jvm->setEnv(broken_env);
-    ASSERT_ANY_THROW(jvm_manager->initialize(jvm));
+    ASSERT_THROW(jvm_manager->initialize(jvm), convert_error);
        
     delete broken_env;
     delete jvm;
@@ -270,7 +270,7 @@ TEST(JVMManagerFakeJNITest, Test_JVMManager_test_registerReferences_badGetFieldI
     Fake_JavaVM * jvm = new Fake_JavaVM();
     Fake_Broken_FieldIDRef_JNIEnv * broken_env  = new Fake_Broken_FieldIDRef_JNIEnv();
     jvm->setEnv(broken_env);
-    ASSERT_ANY_THROW(jvm_manager->initialize(jvm));
+    ASSERT_THROW(jvm_manager->initialize(jvm), convert_error);
        
     delete broken_env;
     delete jvm;
@@ -349,7 +349,7 @@ TEST(JVMManagerFakeJNITest, Test_JVMManager_newObjectArray)
     
     Fake_Broken_JNIEnv * env_broken  = new Fake_Broken_JNIEnv();
     jvm->setEnv(env_broken);
-    ASSERT_ANY_THROW(jvm_manager->newObjectArray(env_broken, 10, clazz , init));
+    ASSERT_THROW(jvm_manager->newObjectArray(env_broken, 10, clazz , init), convert_error);
     
     delete clazz;
     delete env;
@@ -430,7 +430,7 @@ TEST(JVMManagerFakeJNITest, Test_JVMManager_newDoubleArray)
     
     Fake_Broken_JNIEnv * env_broken  = new Fake_Broken_JNIEnv();
     jvm->setEnv(env_broken);
-    ASSERT_ANY_THROW(jvm_manager->newDoubleArray(env_broken, 10));
+    ASSERT_THROW(jvm_manager->newDoubleArray(env_broken, 10), convert_error);
     
     delete clazz;
     delete env;
@@ -498,7 +498,7 @@ TEST(JVMManagerFakeJNITest, Test_JVMManager_CallObjectMethod)
     Fake_Broken_JNIEnv * env_broken  = new Fake_Broken_JNIEnv();
     jvm->setEnv(env_broken);
     ptrEnv = jvm->getEnv();
-    ASSERT_ANY_THROW(jvm_manager->callObjectMethod(ptrEnv, someobj, somemeth, nullptr));    
+    ASSERT_THROW(jvm_manager->callObjectMethod(ptrEnv, someobj, somemeth, nullptr), convert_error);    
     
     delete someobj;
     delete somemeth;
@@ -569,7 +569,7 @@ TEST(JVMManagerFakeJNITest, Test_JVMManager_getEnv)
 //     jvm_manager->initialize(jvm);
 //     JNIEnv newJNIEnv;
 //     JNIEnv * newJNIEnvPtr;
-//     ASSERT_ANY_THROW(jvm_manager->getEnv((void **) &newJNIEnvPtr));
+//     ASSERT_THROW(jvm_manager->getEnv((void **) &newJNIEnvPtr), convert_error);
 //       
 //     delete jvm_manager;
 //     delete jvm;
@@ -646,7 +646,7 @@ TEST(JVMManagerFakeJNITest, Test_JVMManager_checkEx_exfound)
   Fake_JNIEnv_testRegister * env  = new Fake_JNIEnv_will_throw();
   jvm->setEnv(env);
   jvm_manager->initialize(jvm);
-  ASSERT_ANY_THROW(checkEx(env));
+  ASSERT_THROW(checkEx(env), convert_error);
   delete jvm_manager;
   delete jvm;
   delete env;
@@ -680,7 +680,7 @@ TEST(JVMManagerFakeJNITest, Test_JVMManager_checknewIntArray_fail)
   jvm->setEnv(env);
   jvm_manager->initialize(jvm);
   jsize sz = 10;
-  ASSERT_ANY_THROW(jvm_manager->newIntArray(env,sz));
+  ASSERT_THROW(jvm_manager->newIntArray(env,sz), convert_error);
   delete jvm_manager;
   delete jvm;
   delete env;
@@ -718,7 +718,7 @@ TEST(JVMManagerFakeJNITest, Test_JVMManager_checknewDouble_fail)
   jvm->setEnv(env);
   jvm_manager->initialize(jvm);
   jdouble value = 10;
-  ASSERT_ANY_THROW(jvm_manager->newDouble(env,value));
+  ASSERT_THROW(jvm_manager->newDouble(env,value), convert_error);
   delete jvm_manager;
   delete jvm;
   delete env;

--- a/src/librdag/test/check_terminals.cc
+++ b/src/librdag/test/check_terminals.cc
@@ -1168,5 +1168,5 @@ public:
 
 TEST(OGArrayTest, NegativeDatalen)
 {
-  EXPECT_ANY_THROW(OGNaughtyArray(-1));
+  EXPECT_THROW(OGNaughtyArray(-1), rdag_error);
 }


### PR DESCRIPTION
The use of ASSERT_ANY_THROW/EXPECT_ANY_THROW allows for things to
go wrong that we're not expecting, and still get a test pass. This
commit changes all ASSERT_ANY_THROW and EXPECT_ANY_THROW for
ASSERT_THROW and EXPECT_THROW.

Additionally, after doing this it was discovered that conversion
of real diagonal and real sparse matrices to Complex16AoA was not
actually working, and was throwing an rdag_error. Therefore,
support for attempting to do this has been removed from
Complex16AoA. I have created [[MAT-413]](http://jira.opengamma.com/browse/MAT-413) for this.

Coverage: unchanged.
