### PR TITLE
Add logging using SLF4J

### DIFF
--- a/src/java/pom.xml
+++ b/src/java/pom.xml
@@ -21,5 +21,10 @@
 						<artifactId>testng</artifactId>
 						<scope>provided</scope>
 				</dependency>
+				<dependency>
+						<groupId>org.slf4j</groupId>
+						<artifactId>slf4j-api</artifactId>
+						<version>1.7.5</version>
+				</dependency>
 		</dependencies>
 </project>

--- a/src/java/src/main/CMakeLists.txt
+++ b/src/java/src/main/CMakeLists.txt
@@ -99,7 +99,18 @@ add_jar(${JAR_NAME_NO_EXTN} ${JAR_SOURCES}
 
 foreach(TARGET ${TARGET_TYPES})
   if(SUPPORT_${TARGET})
-    add_test(${NATIVE_SELF_TEST}_${TARGET} ${Java_JAVA_EXECUTABLE} -DinstructionSet=${TARGET} -jar ${PATH_AND_JAR_NAME})
+    add_test(${NATIVE_SELF_TEST}_${TARGET}
+             ${Java_JAVA_EXECUTABLE} -DinstructionSet=${TARGET}
+             -jar ${PATH_AND_JAR_NAME})
+    if (WIN32)
+      string(REPLACE ";" "\\;" CLASSPATH "${CMAKE_JAVA_INCLUDE_PATH};${PATH_AND_JAR_NAME}")
+    else()
+      set(CLASSPATH "${CMAKE_JAVA_INCLUDE_PATH}:${PATH_AND_JAR_NAME}")
+    endif()
+    add_test(${NATIVE_SELF_TEST}_${TARGET}_SLF4J
+             ${Java_JAVA_EXECUTABLE} -DinstructionSet=${TARGET}
+             -cp ${CLASSPATH}
+             com.opengamma.maths.nativeloader.NativeLibrariesSelfTest)
   endif()
 endforeach()
 

--- a/src/java/src/main/CMakeLists.txt
+++ b/src/java/src/main/CMakeLists.txt
@@ -8,6 +8,7 @@ set(JPACKAGEFQN "com.opengamma.maths")
 fqn_to_dir(JPACKAGEDIR ${JPACKAGEFQN})
 
 set(JAVA_FILES
+    DOGMA.java
     materialisers/Materialisers.java
     helpers/Catchers.java
     helpers/DenseMemoryManipulation.java
@@ -15,7 +16,10 @@ set(JAVA_FILES
     helpers/Iss.java
     helpers/MatrixPrimitiveUtils.java
     helpers/TestGroups.java
-    DOGMA.java
+    logging/Logger.java
+    logging/ILogger.java
+    logging/Slf4jLogger.java
+    logging/StderrLogger.java
     nodes/COPY.java
     nodes/CTRANSPOSE.java
     nodes/INV.java

--- a/src/java/src/main/java/com/opengamma/maths/exceptions/MathsExceptionNative.java
+++ b/src/java/src/main/java/com/opengamma/maths/exceptions/MathsExceptionNative.java
@@ -1,5 +1,7 @@
 package com.opengamma.maths.exceptions;
 
+import com.opengamma.maths.logging.Logger;
+
 /**
  * Base class for any exceptions that get thrown during the native code execution.
  */
@@ -19,6 +21,11 @@ public class MathsExceptionNative extends MathsException {
   private static final long serialVersionUID = 2689725471014028060L;
 
   /**
+   * The logger instance
+   */
+  private static Logger s_log = new Logger(MathsExceptionNative.class);
+
+  /**
    * This form of the constructor is used by the native code for generating the mixed-language backtrace.
    * Frames are represented by 4 strings, containing the class name, method name, file name and line no.
    * The Java side steps through this array to construct suitable StackTraceElement objects to push on
@@ -33,7 +40,7 @@ public class MathsExceptionNative extends MathsException {
     StackTraceElement[] javaStackTrace = getStackTrace();
     if ((backtraceInfo.length % 4) != 0) {
       // The backtrace information from C++ is "weird". We shall not attempt to use it.
-      System.err.println("WARNING: strange backtrace info received from native");
+      s_log.warn("Strange backtrace info received from native");
       return;
     }
 

--- a/src/java/src/main/java/com/opengamma/maths/helpers/FuzzyEquals.java
+++ b/src/java/src/main/java/com/opengamma/maths/helpers/FuzzyEquals.java
@@ -6,6 +6,8 @@
 
 package com.opengamma.maths.helpers;
 
+import com.opengamma.maths.logging.Logger;
+
 /**
  * Tests for values being equal allowing for a level of floating point fuzz
  * Based on the OG-Maths C++ fuzzy equals code .
@@ -21,6 +23,11 @@ public class FuzzyEquals {
     float64_eps = float64_t_machineEpsilon();
     default_tolerance = 10 * float64_eps;
   }
+
+  /**
+   * The logger instance
+   */
+  private static Logger s_log = new Logger(FuzzyEquals.class);
 
   /**
    * Gets machine precision for double precision floating point numbers on this machine.
@@ -234,12 +241,12 @@ public class FuzzyEquals {
 
   private static void DEBUG_PRINT(String str)
   {
-    System.out.println(str);
+    s_log.debug(str);
   }
 
   private static void DEBUG_PRINT(String str, double a, double b)
   {
-    System.out.format(str, a, b);
+    s_log.debug(String.format(str, a, b));
   }
 
   private static double float64_t_machineEpsilon() {

--- a/src/java/src/main/java/com/opengamma/maths/logging/ILogger.java
+++ b/src/java/src/main/java/com/opengamma/maths/logging/ILogger.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.maths.logging;
+
+/**
+ * Interface for logging implementations in OG-Maths
+ */
+public interface ILogger {
+  /**
+   * Log at the DEBUG log level
+   * @param msg The log message
+   */
+  public void debug(String msg);
+
+  /**
+   * Log at the INFO log level
+   * @param msg The log message
+   */
+  public void info(String msg);
+
+  /**
+   * Log at the WARN log level
+   * @param msg The log message
+   */
+  public void warn(String msg);
+
+  /**
+   * Log at the ERROR log level
+   * @param msg The log message
+   */
+  public void error(String msg);
+
+}

--- a/src/java/src/main/java/com/opengamma/maths/logging/Logger.java
+++ b/src/java/src/main/java/com/opengamma/maths/logging/Logger.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.maths.logging;
+
+/**
+ * The main logging class for OG-Maths.
+ *
+ * In order to allow OG-Maths to have no dependencies, we provide a wrapper
+ * around logging functionality in this class. If SLF4J is available, it is
+ * used. Otherwise, logging messages are written to stderr.
+ */
+public class Logger {
+
+  /**
+   * The logger implementation
+   */
+  private ILogger _logger;
+  /**
+   * Whether we managed to find SLF4J on the classpath
+   */
+  static boolean s_slf4j_available;
+
+  static {
+    ClassLoader classLoader = Logger.class.getClassLoader();
+    try {
+      Class slf4jLogger = classLoader.loadClass("org.slf4j.Logger");
+      Class slf4jLoggerFactory = classLoader.loadClass("org.slf4j.LoggerFactory");
+      s_slf4j_available = true;
+    } catch (ClassNotFoundException e) {
+      System.err.println("WARN: SLF4J not found - logging to stderr");
+    }
+  }
+
+  /**
+   * Construct a logger for the specified class
+   * @param c The class from which log messages will appear.
+   */
+  public Logger(Class c) {
+    if (s_slf4j_available) {
+      _logger = new Slf4jLogger(c);
+    } else {
+      _logger = new StderrLogger(c);
+    }
+  }
+
+  /**
+   * Log at the DEBUG log level
+   * @param msg The log message
+   */
+  public void debug(String msg) {
+    _logger.debug(msg);
+  }
+
+  /**
+   * Log at the INFO log level
+   * @param msg The log message
+   */
+  public void info(String msg) {
+    _logger.info(msg);
+  }
+
+  /**
+   * Log at the WARN log level
+   * @param msg The log message
+   */
+  public void warn(String msg) {
+    _logger.warn(msg);
+  }
+
+  /**
+   * Log at the ERROR log level
+   * @param msg The log message
+   */
+  public void error(String msg) {
+    _logger.error(msg);
+  }
+}

--- a/src/java/src/main/java/com/opengamma/maths/logging/Slf4jLogger.java
+++ b/src/java/src/main/java/com/opengamma/maths/logging/Slf4jLogger.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.maths.logging;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Logger implementation that logs all messages using SLF4J.
+ */
+public class Slf4jLogger implements ILogger {
+
+  /**
+   * The SLF4J Logger instance
+   */
+  private Logger _log;
+
+  /**
+   * Create an SLF4J logger for a given class
+   * @param c The class for which log messages are recorded
+   */
+  public Slf4jLogger(Class c) {
+    _log = LoggerFactory.getLogger(c);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void info(String msg) {
+    _log.info(msg);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void debug(String msg) {
+    _log.debug(msg);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void warn(String msg) {
+    _log.warn(msg);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void error(String msg) {
+    _log.error(msg);
+  }
+}

--- a/src/java/src/main/java/com/opengamma/maths/logging/StderrLogger.java
+++ b/src/java/src/main/java/com/opengamma/maths/logging/StderrLogger.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.maths.logging;
+
+/**
+ * Logger implementation that prints all messages to stderr.
+ */
+public class StderrLogger implements ILogger {
+
+  /**
+   * Name of the class we're logging for
+   */
+  private String _name;
+
+  /**
+   * Create a standard error logger for the given class
+   * @param c The class for which log messages are recorded
+   */
+  public StderrLogger(Class c) {
+    _name = c.getName();
+  }
+
+  private void log(String level, String msg) {
+    System.err.println(level + " " + _name + ": " + msg);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void info(String msg) {
+    log("INFO", msg);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void debug(String msg) {
+    log("DEBUG", msg);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void warn(String msg) {
+    log("WARN", msg);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void error(String msg) {
+    log("ERROR", msg);
+  }
+}

--- a/src/java/src/test/CMakeLists.txt
+++ b/src/java/src/test/CMakeLists.txt
@@ -31,6 +31,9 @@ set(JAVA_FILES
     helpers/DenseMemoryManipulationTest.java
     helpers/FuzzyEqualsTest.java
     helpers/MatrixPrimitiveUtilsTest.java
+    logging/TestLogger.java
+    logging/TestStderrLogger.java
+    logging/TestSlf4jLogger.java
     testhelpers/ArraysHelpers.java
     datacontainers/matrix/OGComplexDiagonalMatrixTest.java
     datacontainers/matrix/OGComplexDenseMatrixTest.java

--- a/src/java/src/test/java/com/opengamma/maths/logging/TestLogger.java
+++ b/src/java/src/test/java/com/opengamma/maths/logging/TestLogger.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.maths.logging;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class TestLogger {
+
+  private Logger _logger;
+
+  @BeforeClass
+  public void setUp() {
+    _logger = new Logger(TestLogger.class);
+  }
+
+  @Test
+  public void testDebug() {
+    _logger.debug("Debug message");
+  }
+
+  @Test
+  public void testInfo() {
+    _logger.info("Info message");
+  }
+
+  @Test
+  public void testWarn() {
+    _logger.warn("Warn message");
+  }
+
+  @Test
+  public void testError() {
+    _logger.error("Error message");
+  }
+}

--- a/src/java/src/test/java/com/opengamma/maths/logging/TestSlf4jLogger.java
+++ b/src/java/src/test/java/com/opengamma/maths/logging/TestSlf4jLogger.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.maths.logging;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class TestSlf4jLogger {
+
+  private Slf4jLogger _slf4jLogger;
+
+  @BeforeClass
+  public void setUp() {
+    _slf4jLogger = new Slf4jLogger(TestSlf4jLogger.class);
+  }
+
+  @Test
+  public void testDebug() {
+    _slf4jLogger.debug("Debug message");
+  }
+
+  @Test
+  public void testInfo() {
+    _slf4jLogger.info("Info message");
+  }
+
+  @Test
+  public void testWarn() {
+    _slf4jLogger.warn("Warn message");
+  }
+
+  @Test
+  public void testError() {
+    _slf4jLogger.error("Error message");
+  }
+}

--- a/src/java/src/test/java/com/opengamma/maths/logging/TestStderrLogger.java
+++ b/src/java/src/test/java/com/opengamma/maths/logging/TestStderrLogger.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.maths.logging;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class TestStderrLogger {
+
+  private StderrLogger _stderrLogger;
+
+  @BeforeClass
+  public void setUp() {
+    _stderrLogger = new StderrLogger(TestStderrLogger.class);
+  }
+
+  @Test
+  public void testDebug() {
+    _stderrLogger.debug("Debug message");
+  }
+
+  @Test
+  public void testInfo() {
+    _stderrLogger.info("Info message");
+  }
+
+  @Test
+  public void testWarn() {
+    _stderrLogger.warn("Warn message");
+  }
+
+  @Test
+  public void testError() {
+    _stderrLogger.error("Error message");
+  }
+}


### PR DESCRIPTION
In order to avoid a dependency on SLF4J being created, the `Logger`
class provides a logging interface for OG-Maths. It checks to see
if SLF4J is available - if it is, then new instances of it use
SLF4J. Otherwise, we fall back to a simple implementation that
prints all log messages to stderr.

Testing is added, but is limited to instantiating each of the
logging classes and attempting to use each of their methods.

An extra test is added that runs with all the JARs on the
classpath, so that NativeLibrariesSelfTest gets run both with and
without SLF4J available. Some instances of NativeLibrariesSelfTest
will still fail if we accidentally introduce a hard dependency on
SLF4J.

Calls to `println` are generally replaced with calls to the `Logger`.
This makes the library quiet from the Java side. Some `println`
calls remain, in places where the user would expect to see output
- for example, in the fuzzer and NativeLibrariesSelfTest.

Java coverage: 81% (unchanged)
Native coverage unchanged.
