### PR TITLE
Remove `using namespace std;` from header files

### DIFF
--- a/include/exceptions.hh
+++ b/include/exceptions.hh
@@ -17,8 +17,6 @@
  */
 #define FRAMEBUF_SIZE 50
 
-using namespace std;
-
 namespace dogma_exceptions {
 
 /**
@@ -43,7 +41,7 @@ class BacktraceElement
      * @param backtrace_symbol a single description of a frame from backtrace_symbols()
      * @param address the address of the instruction pointer for the frame
      */
-    BacktraceElement(const string& backtrace_symbol, const void* address);
+    BacktraceElement(const std::string& backtrace_symbol, const void* address);
     /**
      * Get the address of the instruction pointer for the frame.
      */
@@ -51,25 +49,25 @@ class BacktraceElement
     /**
      * Get the name and path of the object file that this frame is inside.
      */
-    const string getObjectFile() const;
+    const std::string getObjectFile() const;
     /**
      * Get the name of the function that this frame is inside.
      */
-    const string getFunction() const;
+    const std::string getFunction() const;
   private:
     /**
      * Converts any non-ascii characters to ascii characters
      */
-    string asciiOnly(string s);
+    std::string asciiOnly(std::string s);
     const void* _address;
-    string _object_file;
-    string _function;
+    std::string _object_file;
+    std::string _function;
 };
 
 /**
  * Any exception thrown during the execution of the DOGMA libraries
  */
-class dogma_error: public runtime_error
+class dogma_error: public std::runtime_error
 {
   public:
     /**
@@ -78,7 +76,7 @@ class dogma_error: public runtime_error
      * @param what Description of the exception, in a form suitable for printing to the user as the
      *             stack trace in Java.
      */
-    dogma_error(const string& what);
+    dogma_error(const std::string& what);
     /**
      * Copy constructor
      *

--- a/include/expressionbase.hh
+++ b/include/expressionbase.hh
@@ -12,9 +12,6 @@
 #include "numeric.hh"
 #include "visitor.hh"
 
-using namespace std;
-
-
 /**
  * The namespace for the DAG library
  */
@@ -25,8 +22,8 @@ namespace librdag
  * Container for expression arguments
  */
 
-typedef vector<OGNumeric::Ptr> ArgContainer;
-typedef vector<OGNumeric::Ptr> RegContainer;
+typedef std::vector<OGNumeric::Ptr> ArgContainer;
+typedef std::vector<OGNumeric::Ptr> RegContainer;
 
 /**
  *  Expr type

--- a/include/jterminals.hh
+++ b/include/jterminals.hh
@@ -29,7 +29,7 @@ DLLEXPORT_C jint getIntFromVoidJMethod(jmethodID id, jobject obj);
 class DLLEXPORT_C JOGRealScalar: public OGRealScalar
 {
   public:
-    typedef shared_ptr<const JOGRealScalar> Ptr;
+    typedef std::shared_ptr<const JOGRealScalar> Ptr;
     static JOGRealScalar::Ptr create(jobject obj);
     virtual ~JOGRealScalar() override;
     virtual void debug_print() const override;
@@ -48,7 +48,7 @@ class DLLEXPORT_C JOGRealScalar: public OGRealScalar
 class DLLEXPORT_C JOGComplexScalar: public OGComplexScalar
 {
   public:
-    typedef shared_ptr<const JOGComplexScalar> Ptr;
+    typedef std::shared_ptr<const JOGComplexScalar> Ptr;
     static JOGComplexScalar::Ptr create(jobject obj);
     virtual ~JOGComplexScalar() override;
     virtual void debug_print() const override;
@@ -67,7 +67,7 @@ class DLLEXPORT_C JOGComplexScalar: public OGComplexScalar
 class DLLEXPORT_C JOGIntegerScalar: public OGIntegerScalar
 {
   public:
-    typedef shared_ptr<const JOGIntegerScalar> Ptr;
+    typedef std::shared_ptr<const JOGIntegerScalar> Ptr;
     static JOGIntegerScalar::Ptr create(jobject obj);
     virtual ~JOGIntegerScalar() override;
     virtual void debug_print() const override;
@@ -83,7 +83,7 @@ class DLLEXPORT_C JOGIntegerScalar: public OGIntegerScalar
 class DLLEXPORT_C JOGRealMatrix: public OGRealMatrix
 {
   public:
-    typedef shared_ptr<const JOGRealMatrix> Ptr;
+    typedef std::shared_ptr<const JOGRealMatrix> Ptr;
     static JOGRealMatrix::Ptr create(jobject obj);
     virtual ~JOGRealMatrix() override;
     virtual void debug_print() const override;
@@ -98,7 +98,7 @@ class DLLEXPORT_C JOGRealMatrix: public OGRealMatrix
 class DLLEXPORT_C JOGComplexMatrix: public OGComplexMatrix
 {
   public:
-    typedef shared_ptr<const JOGComplexMatrix> Ptr;
+    typedef std::shared_ptr<const JOGComplexMatrix> Ptr;
     static JOGComplexMatrix::Ptr create(jobject obj);
     virtual ~JOGComplexMatrix() override;
     virtual void debug_print() const override;
@@ -113,7 +113,7 @@ class DLLEXPORT_C JOGComplexMatrix: public OGComplexMatrix
 class DLLEXPORT_C JOGLogicalMatrix: public OGLogicalMatrix
 {
   public:
-    typedef shared_ptr<const JOGLogicalMatrix> Ptr;
+    typedef std::shared_ptr<const JOGLogicalMatrix> Ptr;
     static JOGLogicalMatrix::Ptr create(jobject obj);
     virtual ~JOGLogicalMatrix() override;
     virtual void debug_print() const override;
@@ -128,7 +128,7 @@ class DLLEXPORT_C JOGLogicalMatrix: public OGLogicalMatrix
 class DLLEXPORT_C JOGRealSparseMatrix: public OGRealSparseMatrix
 {
   public:
-    typedef shared_ptr<const JOGRealSparseMatrix> Ptr;
+    typedef std::shared_ptr<const JOGRealSparseMatrix> Ptr;
     static JOGRealSparseMatrix::Ptr create(jobject obj);
     virtual ~JOGRealSparseMatrix() override;
     virtual void debug_print() const override;
@@ -145,7 +145,7 @@ class DLLEXPORT_C JOGRealSparseMatrix: public OGRealSparseMatrix
 class DLLEXPORT_C JOGComplexSparseMatrix: public OGComplexSparseMatrix
 {
   public:
-    typedef shared_ptr<const JOGComplexSparseMatrix> Ptr;
+    typedef std::shared_ptr<const JOGComplexSparseMatrix> Ptr;
     static JOGComplexSparseMatrix::Ptr create(jobject obj);
     virtual ~JOGComplexSparseMatrix() override;
     virtual void debug_print() const override;
@@ -162,7 +162,7 @@ class DLLEXPORT_C JOGComplexSparseMatrix: public OGComplexSparseMatrix
 class DLLEXPORT_C JOGRealDiagonalMatrix: public OGRealDiagonalMatrix
 {
   public:
-    typedef shared_ptr<const JOGRealDiagonalMatrix> Ptr;
+    typedef std::shared_ptr<const JOGRealDiagonalMatrix> Ptr;
     static JOGRealDiagonalMatrix::Ptr create(jobject obj);
     virtual ~JOGRealDiagonalMatrix() override;
     virtual void debug_print() const override;
@@ -177,7 +177,7 @@ class DLLEXPORT_C JOGRealDiagonalMatrix: public OGRealDiagonalMatrix
 class DLLEXPORT_C JOGComplexDiagonalMatrix: public OGComplexDiagonalMatrix
 {
   public:
-    typedef shared_ptr<const JOGComplexDiagonalMatrix> Ptr;
+    typedef std::shared_ptr<const JOGComplexDiagonalMatrix> Ptr;
     static JOGComplexDiagonalMatrix::Ptr create(jobject obj);
     virtual ~JOGComplexDiagonalMatrix() override;
     virtual void debug_print() const override;

--- a/include/numerictypes.hh
+++ b/include/numerictypes.hh
@@ -14,12 +14,8 @@
 #endif
 
 #ifdef __cplusplus
-using namespace std;
-#endif
-
-#ifdef __cplusplus
-typedef complex<double> complex16;
-typedef complex<float> complex8;
+typedef std::complex<double> complex16;
+typedef std::complex<float> complex8;
 typedef double real8;
 typedef float real4;
 #else

--- a/include/terminal.hh
+++ b/include/terminal.hh
@@ -21,11 +21,11 @@ namespace detail {
 class FuzzyCompareOGTerminalContainer
 {
   public:
-    FuzzyCompareOGTerminalContainer(const shared_ptr<const OGTerminal>& terminal);
+    FuzzyCompareOGTerminalContainer(const std::shared_ptr<const OGTerminal>& terminal);
     ~FuzzyCompareOGTerminalContainer();
-    const shared_ptr<const OGTerminal> getTerminal() const;
+    const std::shared_ptr<const OGTerminal> getTerminal() const;
   private:
-    const shared_ptr<const OGTerminal> _terminal;
+    const std::shared_ptr<const OGTerminal> _terminal;
 };
 
 } // end namespace detail

--- a/src/generator/createexprtemplates.py
+++ b/src/generator/createexprtemplates.py
@@ -24,6 +24,7 @@ createexpr_cc = """\
 namespace convert {
 
 using namespace librdag;
+using namespace std;
 
 OGNumeric::Ptr translateNode(JNIEnv* env, jobject obj, OGNumeric::Ptr arg0, OGNumeric::Ptr arg1)
 {

--- a/src/generator/dispatchtemplates.py
+++ b/src/generator/dispatchtemplates.py
@@ -94,7 +94,7 @@ dispatchop_class = """\
 template <typename T>
 class DispatchOp
 {
-  static_assert(is_pointer<T>::value, "Type T must be a pointer");
+  static_assert(std::is_pointer<T>::value, "Type T must be a pointer");
   public:
     DispatchOp();
     virtual ~DispatchOp();
@@ -171,6 +171,8 @@ dispatch_cc = """\
 #include "uncopyable.hh"
 #include <iostream>
 #include <sstream>
+
+using namespace std;
 
 namespace librdag {
 

--- a/src/generator/exprtemplates.py
+++ b/src/generator/exprtemplates.py
@@ -30,9 +30,6 @@ expression_hh = """\
 #include "visitor.hh"
 #include "exceptions.hh"
 
-using namespace std;
-
-
 /**
  * The namespace for the DAG library
  */

--- a/src/generator/runnertemplates.py
+++ b/src/generator/runnertemplates.py
@@ -45,6 +45,8 @@ runners_cc = """\
 #include "terminal.hh"
 #include "uncopyable.hh"
 
+using namespace std;
+
 namespace librdag {
 %(function_definitions)s
 } // end namespace librdag

--- a/src/jshim/exprfactory.cc
+++ b/src/jshim/exprfactory.cc
@@ -14,6 +14,7 @@
 namespace convert {
 
 using namespace librdag;
+using std::stack;
 
 /**
  * Represents direction of traversal through a Java expression tree

--- a/src/jshim/jdispatch.cc
+++ b/src/jshim/jdispatch.cc
@@ -15,6 +15,7 @@ namespace convert
 {
 
 using namespace librdag;
+using namespace std;
 
 /**
  * Real8AoA

--- a/src/jshim/jshim.cc
+++ b/src/jshim/jshim.cc
@@ -18,6 +18,7 @@
 
 using namespace convert;
 using namespace dogma_exceptions;
+using namespace std;
 
 /* Used to signal if something has gone wrong in our exception reporting code.
  * If this has happened, we are in real trouble (probably out of memory).

--- a/src/jshim/jterminals.cc
+++ b/src/jshim/jterminals.cc
@@ -12,6 +12,8 @@
 #include "exceptions.hh"
 #include "modifiermacros.h"
 
+using namespace std;
+
 namespace convert {
 
 /**

--- a/src/librdag/exceptions.cc
+++ b/src/librdag/exceptions.cc
@@ -17,11 +17,15 @@
 #include "exceptions.hh"
 #include "debug.h"
 
-using namespace std;
-
 namespace dogma_exceptions {
 
+using std::string;
+
 #ifdef __APPLE__
+using std::vector;
+using std::istringstream;
+using std::istream_iterator;
+
 vector<string> tokenize_backtrace(const string &backtrace_string)
 {
   istringstream s(backtrace_string);

--- a/src/librdag/execution.cc
+++ b/src/librdag/execution.cc
@@ -26,9 +26,9 @@ ExecutionList::ExecutionList(const OGNumeric::Ptr& tree)
   _execList = new _ExpressionList();
 
   // treePos contains the list of nodes we've visited but not finished with
-  stack<OGNumeric::Ptr> treePos;
+  std::stack<OGNumeric::Ptr> treePos;
   // argPos records how far down the arg of the node in a given position we've got
-  stack<size_t> argPos;
+  std::stack<size_t> argPos;
 
   // Start by going downwards
   Direction dir = Direction::DOWN;

--- a/src/librdag/lapack.cc
+++ b/src/librdag/lapack.cc
@@ -8,6 +8,7 @@
 #include "exceptions.hh"
 
 using namespace librdag;
+using namespace std;
 
 namespace lapack {
 

--- a/src/librdag/runners/ctransposerunner.cc
+++ b/src/librdag/runners/ctransposerunner.cc
@@ -16,6 +16,8 @@
 #include "uncopyable.hh"
 #include "lapack.hh"
 
+using namespace std;
+
 /*
  *  Unit contains code for CTRANSPOSE node runners
  */

--- a/src/librdag/runners/invrunner.cc
+++ b/src/librdag/runners/invrunner.cc
@@ -20,6 +20,8 @@
 #include <sstream>
 #include <limits>
 
+using namespace std;
+
 /*
  *  Unit contains code for INV node runners
  */

--- a/src/librdag/runners/lurunner.cc
+++ b/src/librdag/runners/lurunner.cc
@@ -14,6 +14,7 @@
 #include "lapack.hh"
 #include "debug.h"
 
+using namespace std;
 
 /**
  *  Unit contains code for LU node runners

--- a/src/librdag/runners/mtimesrunner.cc
+++ b/src/librdag/runners/mtimesrunner.cc
@@ -17,6 +17,7 @@
 #include <complex>
 #include <sstream>
 
+using namespace std;
 
 /*
  * Unit contains code for MTIMES node runners

--- a/src/librdag/runners/norm2runner.cc
+++ b/src/librdag/runners/norm2runner.cc
@@ -17,6 +17,8 @@
 #include <complex>
 #include <sstream>
 
+using namespace std;
+
 /*
  *  Unit contains code for NORM2 node runners
  */

--- a/src/librdag/runners/pinvrunner.cc
+++ b/src/librdag/runners/pinvrunner.cc
@@ -20,6 +20,8 @@
 #include <sstream>
 #include <limits>
 
+using namespace std;
+
 /*
  *  Unit contains code for PINV node runners
  */

--- a/src/librdag/runners/svdrunner.cc
+++ b/src/librdag/runners/svdrunner.cc
@@ -14,6 +14,7 @@
 #include "lapack.hh"
 #include "debug.h"
 
+using namespace std;
 
 /**
  *  Unit contains code for SVD node runners

--- a/src/librdag/runners/transposerunner.cc
+++ b/src/librdag/runners/transposerunner.cc
@@ -17,6 +17,8 @@
 #include <complex>
 #include <sstream>
 
+using namespace std;
+
 /*
  *  Unit contains code for TRANSPOSE node runners
  */

--- a/src/librdag/terminal.cc
+++ b/src/librdag/terminal.cc
@@ -17,6 +17,8 @@
 #include <iostream>
 #include <iomanip>
 
+using namespace std;
+
 namespace librdag {
 
 /**

--- a/src/librdag/test/check_exceptions.cc
+++ b/src/librdag/test/check_exceptions.cc
@@ -15,6 +15,7 @@
 #include "exceptions.hh"
 
 using namespace dogma_exceptions;
+using std::string;
 
 #ifdef __APPLE__
 const string backtrace_symbol = "2   librdag_dbg.0.dylib                 0x0000000102edcc48 _ZNK7librdag10OGTerminal20toReal8ArrayOfArraysEv + 150";

--- a/src/librdag/test/nodes/testnodes.hh
+++ b/src/librdag/test/nodes/testnodes.hh
@@ -12,7 +12,6 @@
 #include "execution.hh"
 #include "dispatch.hh"
 
-using namespace std;
 using namespace librdag;
 
 /**
@@ -32,12 +31,12 @@ TEST_P(__NODE##TEST, SimpleAssertResultTrue) {\
   EXPECT_TRUE(result);\
   if(result==false)\
   {\
-    cout << "_______________________________________" << std::endl;\
-    cout << "Test failure:" << std::endl << "Expected:" << std::endl;\
+    std::cout << "_______________________________________" << std::endl;\
+    std::cout << "Test failure:" << std::endl << "Expected:" << std::endl;\
     impl->getResultPair()->second->asOGTerminal()->debug_print();\
-    cout << "Calculated:" << std::endl;\
+    std::cout << "Calculated:" << std::endl;\
     impl->getResultPair()->first->asOGTerminal()->debug_print();\
-    cout << "_______________________________________" << std::endl;\
+    std::cout << "_______________________________________" << std::endl;\
   }\
   delete impl;\
 }
@@ -54,12 +53,12 @@ TEST_P(__NODE##TEST, SimpleAssertResultTrue) {\
   EXPECT_TRUE(result);\
   if(result==false)\
   {\
-    cout << "_______________________________________" << std::endl;\
-    cout << "Test failure:" << std::endl << "Expected:" << std::endl;\
+    std::cout << "_______________________________________" << std::endl;\
+    std::cout << "Test failure:" << std::endl << "Expected:" << std::endl;\
     impl->getResultPair()->second->asOGTerminal()->debug_print();\
-    cout << "Calculated:" << std::endl;\
+    std::cout << "Calculated:" << std::endl;\
     impl->getResultPair()->first->asOGTerminal()->debug_print();\
-    cout << "_______________________________________" << std::endl;\
+    std::cout << "_______________________________________" << std::endl;\
   }\
   delete impl;\
 }
@@ -73,7 +72,7 @@ TEST_P(__NODE##TEST, SimpleAssertResultTrue) {\
 /**
  * Container for results
  */
-typedef pair<OGNumeric::Ptr, OGNumeric::Ptr> ResultPair;
+typedef std::pair<OGNumeric::Ptr, OGNumeric::Ptr> ResultPair;
 
 /**
  * Indicate the method used for comparison


### PR DESCRIPTION
It is a bit rude to include the whole of the `std` namespace in our header files, because anyone including our headers then gets the whole of `std` in their global namespace.

This PR removes all `using namespace std;` from headers, mainly by pushing it down in to the source files. There are some instances where it was straightforward to use exactly the members of `std` that were required - in some cases I have done this.

Coverage: unchanged.
