### PR TITLE
Mat 355

### DIFF
--- a/include/lapack.hh
+++ b/include/lapack.hh
@@ -29,6 +29,7 @@ extern char U;
 extern char D;
 extern char ONE;
 extern char O;
+extern char V;
 extern int4 ione;
 extern int4 izero;
 extern real8 rone;
@@ -37,6 +38,8 @@ extern real8 rzero;
 extern complex16 czero;
 
 template<typename T>char charmagic();
+template<typename T>std::string xxxgqrcharmagic();
+
 
 template<typename T> void xscal(int4 * N, T * DA, T * DX, int4 * INCX);
 template<typename T>void xswap(int4 * N, T * DX, int4 * INCX, T * DY, int4 * INCY);
@@ -49,6 +52,12 @@ template<typename T> void xpotrf(char * UPLO, int4 * N, T * A, int4 * LDA, int4 
 template<typename T> void xtrtrs(char * UPLO, char * TRANS, char * DIAG, int4 * N, int4 * NRHS, T * A, int4 * LDA, T * B, int4 * LDB, int4 * INFO);
 template<typename T> void xgetrf(int4 * M, int4 * N, T * A, int4 * LDA, int4 * IPIV, int4 *INFO);
 template<typename T> void xgetri(int4 * N, T * A, int4 * LDA, int4 * IPIV, T * WORK, int4 * LWORK, int4 * INFO );
+template<typename T> real8 xlange(char * NORM, int4 * M, int4 * N, T * A, int4 * LDA, real8 * WORK );
+template<typename T> void xgetrs(char * TRANS, int4 * N, int4 * NRHS, T * A, int4 * LDA, int4 * IPIV, T * B, int4 * LDB, int4 * INFO);
+template<typename T> void xgels(char * TRANS, int4 * M, int4 * N, int4 * NRHS, T * A, int4 * LDA, T * B, int4 * LDB, T * WORK, int4 * LWORK, int4 * INFO );
+template<typename T> void xgeqrf(int4 * M, int4 * N, T * A, int4 * LDA, T * TAU, T * WORK, int4 * LWORK, int4 *INFO);
+template<typename T> void xxxgqr(int4 * M, int4 * N, int4 * K, T * A, int4 * LDA, T * TAU, T * WORK, int4 * LWORK, int4 * INFO);
+
 }
 
 /**
@@ -83,6 +92,10 @@ extern char * ONE;
  * The F77 character 'O'
  */
 extern char * O;
+/**
+ * The F77 character 'V'
+ */
+extern char * V;
 /**
  * The F77 integer '1'
  */
@@ -248,7 +261,7 @@ template<typename T> void xtrcon(char * NORM, char * UPLO, char * DIAG, int4 * N
 template<typename T> void xtrtrs(char * UPLO, char * TRANS, char * DIAG, int4 * N, int4 * NRHS, T * A, int4 * LDA, T * B, int4 * LDB, int4 * INFO);
 
 /**
- * xpotrf() computes the Cholesky factorization of a Hermitian positive definite matrix A.
+ * xpotrf() computes the Cholesky factorisation of a Hermitian positive definite matrix A.
  * @param UPLO as LAPACK dpotrf UPLO
  * @param N as LAPACK dpotrf N
  * @param A data type specific with intent as LAPACK dpotrf A
@@ -306,7 +319,114 @@ real8 zlanhe(char * NORM, char * UPLO, int4 * N, complex16 * A, int4 * LDA);
  */
 template<typename T> void xpotrs(char * UPLO, int4 * N, int4 * NRHS, T * A, int4 * LDA, T * B, int4 * LDB, int4 * INFO);
 
+/**
+ * xlange() computes matrix norms (one, Inf, Frobenius)
+ * @param NORM as LAPACK dlange NORM.
+ * @param M as LAPACK dlange M.
+ * @param N as LAPACK dlange N.
+ * @param A data type specific with intent as LAPACK dlange A.
+ * @param LDA as LAPACK dlange LDA.
+ */
+template<typename T> real8 xlange(char * NORM, int4 * M, int4 * N, T * A, int4 * LDA);
+
+/**
+ * xgecon() computes reciprocal condition numbers calculated from a LU factorisation as
+ * computed by xgetrf().
+ * @param NORM as LAPACK dgecon NORM.
+ * @param N as LAPACK dgecon N.
+ * @param A data type specific with intent as LAPACK dgecon A.
+ * @param LDA as LAPACK dgecon LDA.
+ * @param ANORM as LAPACK dgecon ANORM.
+ * @param RCOND as LAPACK dgecon RCOND.
+ * @param INFO as LAPACK dgecon INFO.
+ */
+template<typename T> void xgecon(char * NORM, int4 * N, T * A, int4 * LDA, real8 * ANORM, real8 * RCOND, int4 * INFO);
+
+/**
+ * xgetrs() solves linear systems using a LU factorisation computed by xgetrf().
+ * @param TRANS as LAPACK xgetrs TRANS.
+ * @param N as LAPACK xgetrs N.
+ * @param NRHS as LAPACK xgetrs NRHS.
+ * @param A data type specific with intent as LAPACK xgetrs A.
+ * @param LDA as LAPACK xgetrs LDA.
+ * @param IPIV as LAPACK xgetrs IPIV.
+ * @param B data type specific with intent as LAPACK xgetrs B.
+ * @param LDB as LAPACK xgetrs LDB.
+ * @param INFO as LAPACK xgetrs INFO.
+ */
+template<typename T>void xgetrs(char * TRANS, int4 * N, int4 * NRHS, T * A, int4 * LDA, int4 * IPIV, T * B, int4 * LDB, int4 * INFO);
+
+/**
+ * xgels() solves {over,under}determined linear systems via QR decomposition.
+ * @param TRANS as LAPACK dgels TRANS.
+ * @param M as LAPACK dgels M.
+ * @param N as LAPACK dgels N.
+ * @param NRHS as LAPACK dgels NRHS.
+ * @param A data type specific with intent as LAPACK dgels A.
+ * @param LDA as LAPACK dgels LDA.
+ * @param B data type specific with intent as  LAPACK dgels TRANS.
+ * @param LDB as LAPACK dgels LDB.
+ * @param INFO as LAPACK dgels INFO.
+ */
+template<typename T> void xgels(char * TRANS, int4 * M, int4 * N, int4 * NRHS, T * A, int4 * LDA, T * B, int4 * LDB, int4 * INFO );
+
+/**
+ * xgelsd() solves {over,under}determined linear systems via SV decomposition.
+ * @param M as LAPACK dgelsd M.
+ * @param N as LAPACK dgelsd N.
+ * @param NRHS as LAPACK dgelsd NRHS.
+ * @param A data type specific with intent as LAPACK dgelsd A.
+ * @param LDA as LAPACK dgelsd LDA.
+ * @param B data type specific with intent as LAPACK dgelsd TRANS.
+ * @param LDB as LAPACK dgelsd LDB.
+ * @param S as LAPACK dgelsd S.
+ * @param RCOND as LAPACK dgelsd RCOND.
+ * @param INFO as LAPACK dgels INFO.
+ */
+template<typename T> void xgelsd(int4 * M, int4 * N, int4 * NRHS, T * A, int4 * LDA, T * B, int4 * LDB, real8 * S, real8 * RCOND, int4 * RANK, int4 * INFO );
+
+/**
+ * xgeev() computes eigen{values,vectors}.
+ * @param JOBVL as LAPACK dgeev JOBVL.
+ * @param JOBVR as LAPACK dgeev JOBVR.
+ * @param N as LAPACK dgeev N.
+ * @param A data type specific with intent as LAPACK dgeev A.
+ * @param LDA as LAPACK dgeev LDA.
+ * @param W the computed eigenvalues.
+ * @param VL data type specific with intent as LAPACK dgeev VL.
+ * @param LDVL as LAPACK dgeev LDVL.
+ * @param VR data type specific with intent as LAPACK dgeev VR.
+ * @param LDVR as LAPACK dgeev LDVR.
+ * @param LDVL as LAPACK dgeev INFO.
+ */
+template<typename T> void xgeev(char * JOBVL, char * JOBVR, int4 * N, T * A, int4 * LDA, complex16 * W, T * VL, int4 * LDVL, T * VR, int4 * LDVR, int4 * INFO);
+
+
+/**
+ * xgeqrf() computes the QR decomposition.
+ * @param M as LAPACK degqrf M.
+ * @param N as LAPACK degqrf N.
+ * @param A data type specific with intent as LAPACK degqrf A.
+ * @param LDA as LAPACK dgeqrf LDA.
+ * @param TAU  data type specific with intent as LAPACK degqrf TAU.
+ * @param INFO as LAPACK degqrf INFO.
+ */
+template<typename T> void xgeqrf(int4 * M, int4 * N, T * A, int4 * LDA, T * TAU, int4 *INFO);
+
+
+/**
+ * xxxgqr() computes the orthogonal Q matrix from elementary reflectors as returned by xgeqrf()
+ * @param M as LAPACK dorgqr M.
+ * @param N as LAPACK dorgqr N.
+ * @param K as LAPACK dorgqr K.
+ * @param A data type specific with intent as LAPACK degqrf A.
+ * @param LDA as LAPACK dgeqrf LDA.
+ * @param TAU  data type specific with intent as LAPACK degqrf TAU.
+ * @param INFO as LAPACK degqrf INFO.
+ */
+template<typename T>void xxxgqr(int4 * M, int4 * N, int4 * K, T * A, int4 * LDA, T * TAU, int4 * INFO);
 }
+
 
 
 #endif // _LAPACK_HH

--- a/include/lapack.hh
+++ b/include/lapack.hh
@@ -381,6 +381,7 @@ template<typename T> void xgels(char * TRANS, int4 * M, int4 * N, int4 * NRHS, T
  * @param LDB as LAPACK dgelsd LDB.
  * @param S as LAPACK dgelsd S.
  * @param RCOND as LAPACK dgelsd RCOND.
+ * @param RANK as LAPACK dgelsd RANK.
  * @param INFO as LAPACK dgels INFO.
  */
 template<typename T> void xgelsd(int4 * M, int4 * N, int4 * NRHS, T * A, int4 * LDA, T * B, int4 * LDB, real8 * S, real8 * RCOND, int4 * RANK, int4 * INFO );

--- a/include/lapack_raw.h
+++ b/include/lapack_raw.h
@@ -19,64 +19,64 @@
 
 // Xerbla handing, these are ISO C bound so no name mangling required
 #ifdef __cplusplus
-extern "C" 
+extern "C"
 #endif
 void set_xerbla_death_switch(int4 * value);
 
 #ifdef __cplusplus
-extern "C" 
+extern "C"
 #endif
 int4 get_xerbla_death_switch();
 
 // BLAS
 // Standard xSCAL
 #ifdef __cplusplus
-extern "C" 
+extern "C"
 #endif
 void F77FUNC(dscal)(int4 * N, real8 * DA, real8* DX, int4 * INCX);
 #ifdef __cplusplus
-extern "C" 
+extern "C"
 #endif
 void F77FUNC(zscal)(int4 * N, complex16 * DA, complex16* DX, int4 * INCX);
 
 // Standard xSWAP
 #ifdef __cplusplus
-extern "C" 
+extern "C"
 #endif
 void F77FUNC(dswap)(int4 * N, real8 * DX, int4 * INCX, real8 * DY, int4 * INCY);
 #ifdef __cplusplus
-extern "C" 
+extern "C"
 #endif
 void F77FUNC(zswap)(int4 * N, complex16 * DX, int4 * INCX, complex16 * DY, int4 * INCY);
 
 
 // Standard xGEMV
 #ifdef __cplusplus
-extern "C" 
+extern "C"
 #endif
 void F77FUNC(dgemv)(char * TRANS, int4 * M, int4 * N, real8 * ALPHA, real8 * A, int4 * LDA, real8 * X, int4 * INCX, real8 * BETA, real8 * Y, int4 * INCY);
 #ifdef __cplusplus
-extern "C" 
+extern "C"
 #endif
 void F77FUNC(zgemv)(char * TRANS, int4 * M, int4 * N, complex16 * ALPHA, complex16 * A, int4 * LDA, complex16 * X, int4 * INCX, complex16 * BETA, complex16 * Y, int4 * INCY);
 
 // Standard xGEMM
 #ifdef __cplusplus
-extern "C" 
+extern "C"
 #endif
 void F77FUNC(dgemm)(char * TRANSA, char * TRANSB, int4 * M, int4 * N, int4 * K, real8 * ALPHA, real8 * A, int4 * LDA, real8 * B, int4 * LDB, real8 * BETA, real8 * C, int4 * LDC );
 #ifdef __cplusplus
-extern "C" 
+extern "C"
 #endif
 void F77FUNC(zgemm)(char * TRANSA, char * TRANSB, int4 * M, int4 * N, int4 * K, complex16 * ALPHA, complex16 * A, int4 * LDA, complex16 * B, int4 * LDB, complex16 * BETA, complex16 * C, int4 * LDC );
 
 // Standard NORM2 implementations.
 #ifdef __cplusplus
-extern "C" 
+extern "C"
 #endif
 real8 F77FUNC(dnrm2)(int4 * N, real8 * X, int4 * INCX);
 #ifdef __cplusplus
-extern "C" 
+extern "C"
 #endif
 real8 F77FUNC(dznrm2)(int4 * N, complex16 * X, int4 * INCX);
 
@@ -85,99 +85,179 @@ real8 F77FUNC(dznrm2)(int4 * N, complex16 * X, int4 * INCX);
 
 // Standard SVD implementations.
 #ifdef __cplusplus
-extern "C" 
+extern "C"
 #endif
 void F77FUNC(dgesvd)(char * JOBU, char * JOBVT, int4 * M, int4 * N, real8 * A, int4 * LDA, real8 * S, real8 * U, int4 * LDU, real8 * VT, int4 * LDVT, real8 * WORK, int4 * LWORK, int4 * INFO);
 #ifdef __cplusplus
-extern "C" 
+extern "C"
 #endif
 void F77FUNC(zgesvd)(char * JOBU, char * JOBVT, int4 * M, int4 * N, complex16 * A, int4 * LDA, real8 * S, complex16 * U, int4 * LDU, complex16 * VT, int4 * LDVT, complex16 * WORK, int4 * LWORK, real8 * RWORK, int4 * INFO);
 
 // Reciprocal condition number estimates
 #ifdef __cplusplus
-extern "C" 
+extern "C"
 #endif
 void F77FUNC(dtrcon)(char * NORM, char * UPLO, char * DIAG, int4 * N, real8 * A, int4 * LDA, real8 * RCOND, real8 * WORK, int4 * IWORK, int4 * INFO);
 #ifdef __cplusplus
-extern "C" 
+extern "C"
 #endif
 void F77FUNC(ztrcon)(char * NORM, char * UPLO, char * DIAG, int4 * N, complex16 * A, int4 * LDA, real8 * RCOND, complex16 * WORK, real8 * IWORK, int4 * INFO);
 
 // LUP decomposition
 #ifdef __cplusplus
-extern "C" 
+extern "C"
 #endif
 void F77FUNC(dgetrf)(int4 * M, int4 * N, real8 * A, int4 * LDA, int4 * IPIV, int4 *INFO);
 #ifdef __cplusplus
-extern "C" 
+extern "C"
 #endif
 void F77FUNC(zgetrf)(int4 * M, int4 * N, complex16 * A, int4 * LDA, int4 * IPIV, int4 *INFO);
 
 // inverse based on LU
 #ifdef __cplusplus
-extern "C" 
+extern "C"
 #endif
 void F77FUNC(dgetri)(int4 * N, real8 * A, int4 * LDA, int4 * IPIV, real8 * WORK, int4 * LWORK, int4 * INFO );
 #ifdef __cplusplus
-extern "C" 
+extern "C"
 #endif
 void F77FUNC(zgetri)(int4 * N, complex16 * A, int4 * LDA, int4 * IPIV, complex16 * WORK, int4 * LWORK, int4 * INFO );
 
 // solves a triangular system of the form : A * X = B  or  A**T * X = B
 #ifdef __cplusplus
-extern "C" 
+extern "C"
 #endif
 void F77FUNC(dtrtrs)(char * UPLO, char * TRANS, char * DIAG, int4 * N, int4 * NRHS, real8 * A, int4 * LDA, real8 * B, int4 * LDB, int4 * INFO);
 #ifdef __cplusplus
-extern "C" 
+extern "C"
 #endif
 void F77FUNC(ztrtrs)(char * UPLO, char * TRANS, char * DIAG, int4 * N, int4 * NRHS, complex16 * A, int4 * LDA, complex16 * B, int4 * LDB, int4 * INFO);
 
 // Cholesky factorisation for s.p.d matrices
 #ifdef __cplusplus
-extern "C" 
+extern "C"
 #endif
 void F77FUNC(dpotrf)(char * UPLO, int4 * N, real8 * A, int4 * LDA, int4 * INFO);
 #ifdef __cplusplus
-extern "C" 
+extern "C"
 #endif
 void F77FUNC(zpotrf)(char * UPLO, int4 * N, complex16 * A, int4 * LDA, int4 * INFO);
 
 // Reciprocal condition estimate in the 1-norm of a Cholesky decomposition as computed by xpotrf
 #ifdef __cplusplus
-extern "C" 
+extern "C"
 #endif
 void F77FUNC(dpocon)(char * UPLO, int4 * N, real8 * A, int4 * LDA, real8 * ANORM, real8 * RCOND, real8 * WORK, int4 * IWORK, int4 * INFO);
 #ifdef __cplusplus
-extern "C" 
+extern "C"
 #endif
 void F77FUNC(zpocon)(char * UPLO, int4 * N, complex16 * A, int4 * LDA, real8 * ANORM, real8 * RCOND, complex16 * WORK, real8 * RWORK, int4 * INFO);
 
 // Norm calculators for symmetric matrices
 #ifdef __cplusplus
-extern "C" 
+extern "C"
 #endif
 real8 F77FUNC(dlansy)(char * NORM, char * UPLO, int4 * N, real8 * A, int4 * LDA, real8 * WORK);
 #ifdef __cplusplus
-extern "C" 
+extern "C"
 #endif
 real8 F77FUNC(zlansy)(char * NORM, char * UPLO, int4 * N, complex16 * A, int4 * LDA, real8 * WORK);
 
 // Norm calculator for Hermitian matrix
 #ifdef __cplusplus
-extern "C" 
+extern "C"
 #endif
 real8 F77FUNC(zlanhe)(char * NORM, char * UPLO, int4 * N, complex16 * A, int4 * LDA, real8 * WORK);
 
-
 // Cholesky based solvers
 #ifdef __cplusplus
-extern "C" 
+extern "C"
 #endif
 void F77FUNC(dpotrs)(char * UPLO, int4 * N, int4 * NRHS, real8 * A, int4 * LDA, real8 * B, int4 * LDB, int4 * INFO);
 #ifdef __cplusplus
-extern "C" 
+extern "C"
 #endif
 void F77FUNC(zpotrs)(char * UPLO, int4 * N, int4 * NRHS, complex16 * A, int4 * LDA, complex16 * B, int4 * LDB, int4 * INFO);
 
-#endif //_LAPACK_RAW_H
+// Matrix norms, {1,Inf,Frob}
+#ifdef __cplusplus
+extern "C"
+#endif
+real8 F77FUNC(dlange)(char * NORM, int4 * M, int4 * N, real8 * A, int4 * LDA, real8 * WORK );
+#ifdef __cplusplus
+extern "C"
+#endif
+real8 F77FUNC(zlange)(char * NORM, int4 * M, int4 * N, complex16 * A, int4 * LDA, real8 * WORK );
+
+// Reciprocal condition number calculated from a LU factorisation computed by XGETRF
+#ifdef __cplusplus
+extern "C"
+#endif
+void F77FUNC(dgecon)(char * NORM, int4 * N, real8 * A, int4 * LDA, real8 * ANORM, real8 * RCOND, real8 * WORK, int4 * IWORK, int4 * INFO);
+#ifdef __cplusplus
+extern "C"
+#endif
+void F77FUNC(zgecon)(char * NORM, int4 * N, complex16 * A, int4 * LDA, real8 * ANORM, real8 * RCOND, complex16 * WORK, real8 * RWORK, int4 * INFO);
+
+// Solves linear systems using a LU factorisation computed by XGETRF
+#ifdef __cplusplus
+extern "C"
+#endif
+void F77FUNC(dgetrs)(char * TRANS, int4 * N, int4 * NRHS, real8 * A, int4 * LDA, int4 * IPIV, real8 * B, int4 * LDB, int4 * INFO);
+#ifdef __cplusplus
+extern "C"
+#endif
+void F77FUNC(zgetrs)(char * TRANS, int4 * N, int4 * NRHS, complex16 * A, int4 * LDA, int4 * IPIV, complex16 * B, int4 * LDB, int4 * INFO);
+
+// Solve {over,under}determined linear systems via QR decomposition
+#ifdef __cplusplus
+extern "C"
+#endif
+void F77FUNC(dgels)(char * TRANS, int4 * M, int4 * N, int4 * NRHS, real8 * A, int4 * LDA, real8 * B, int4 * LDB, real8 * WORK, int4 * LWORK, int4 * INFO);
+#ifdef __cplusplus
+extern "C"
+#endif
+void F77FUNC(zgels)(char * TRANS, int4 * M, int4 * N, int4 * NRHS, complex16 * A, int4 * LDA, complex16 * B, int4 * LDB, complex16 * WORK, int4 * LWORK, int4 * INFO);
+
+// Solve {over,under}determined linear systems via SV decomposition
+#ifdef __cplusplus
+extern "C"
+#endif
+void F77FUNC(dgelsd)(int4 * M, int4 * N, int4 * NRHS, real8 * A, int4 * LDA, real8 * B, int4 * LDB, real8 * S, real8 * RCOND, int4 * RANK, real8 * WORK, int4 * LWORK, int4 * IWORK, int4 * INFO );
+#ifdef __cplusplus
+extern "C"
+#endif
+void F77FUNC(zgelsd)(int4 * M, int4 * N, int4 * NRHS, complex16 * A, int4 * LDA, complex16 * B, int4 * LDB, real8 * S, real8 * RCOND, int4 * RANK, complex16 * WORK, int4 * LWORK, real8 * RWORK, int4 * IWORK, int4 * INFO);
+
+// Compute eig{values,vectors}
+#ifdef __cplusplus
+extern "C"
+#endif
+void F77FUNC(dgeev)(char * JOBVL, char * JOBVR, int4 * N, real8 * A, int4 * LDA, real8 * WR, real8 * WI, real8 * VL, int4 * LDVL, real8 * VR, int4 * LDVR, real8 * WORK, int4 * LWORK, int4 * INFO);
+#ifdef __cplusplus
+extern "C"
+#endif
+void F77FUNC(zgeev)(char * JOBVL, char * JOBVR, int4 * N, complex16 * A, int4 * LDA, complex16 * W, complex16 * VL, int4 * LDVL, complex16 * VR, int4 * LDVR, complex16 * WORK, int4 * LWORK, real8 * RWORK, int4 * INFO);
+
+
+// Compute QR factorisation
+#ifdef __cplusplus
+extern "C"
+#endif
+void F77FUNC(dgeqrf)(int4 * M, int4 * N, real8 * A, int4 * LDA, real8 * TAU, real8 * WORK, int4 * LWORK, int4 *INFO);
+#ifdef __cplusplus
+extern "C"
+#endif
+void F77FUNC(zgeqrf)(int4 * M, int4 * N, complex16 * A, int4 * LDA, complex16 * TAU, complex16 * WORK, int4 * LWORK, int4 *INFO);
+
+// Generate orthogonal Q matrix from elementary reflectors as returned by xgeqrf()
+#ifdef __cplusplus
+extern "C"
+#endif
+void F77FUNC(dorgqr)(int4 * M, int4 * N, int4 * K, real8 * A, int4 * LDA, real8 * TAU, real8 * WORK, int4 * LWORK, int4 * INFO);
+#ifdef __cplusplus
+extern "C"
+#endif
+void F77FUNC(zungqr)(int4 * M, int4 * N, int4 * K, complex16 * A, int4 * LDA, complex16 * TAU, complex16 * WORK, int4 * LWORK, int4 * INFO);
+
+#endif//_LAPACK_RAW_H

--- a/src/librdag/lapack.cc
+++ b/src/librdag/lapack.cc
@@ -172,52 +172,52 @@ namespace detail
   }
 
   //xLANGE specialisation
-  template<> real8 xlange(char * NORM, int * M, int * N, real8 * A, int * LDA, real8 * WORK )
+  template<> real8 xlange(char * NORM, int4 * M, int4 * N, real8 * A, int4 * LDA, real8 * WORK )
   {
     return F77FUNC(dlange)(NORM, M, N, A, LDA, WORK);
   }
 
-  template<> real8 xlange(char * NORM, int * M, int * N, complex16 * A, int * LDA, real8 * WORK )
+  template<> real8 xlange(char * NORM, int4 * M, int4 * N, complex16 * A, int4 * LDA, real8 * WORK )
   {
     return F77FUNC(zlange)(NORM, M, N, A, LDA, WORK);
   }
 
   // xGETRS specialisations
-  template<> void xgetrs(char * TRANS, int * N, int * NRHS, real8 * A, int * LDA, int * IPIV, real8 * B, int * LDB, int * INFO)
+  template<> void xgetrs(char * TRANS, int4 * N, int4 * NRHS, real8 * A, int4 * LDA, int4 * IPIV, real8 * B, int4 * LDB, int4 * INFO)
   {
     F77FUNC(dgetrs)(TRANS, N, NRHS, A, LDA, IPIV, B, LDB, INFO);
   }
-  template<> void xgetrs(char * TRANS, int * N, int * NRHS, complex16 * A, int * LDA, int * IPIV, complex16 * B, int * LDB, int * INFO)
+  template<> void xgetrs(char * TRANS, int4 * N, int4 * NRHS, complex16 * A, int4 * LDA, int4 * IPIV, complex16 * B, int4 * LDB, int4 * INFO)
   {
     F77FUNC(zgetrs)(TRANS, N, NRHS, A, LDA, IPIV, B, LDB, INFO);
   }
 
   //xGELS specialisations
-  template<> void xgels(char * TRANS, int * M, int * N, int * NRHS, real8 * A, int * LDA, real8 * B, int * LDB, real8 * WORK, int * LWORK, int * INFO )
+  template<> void xgels(char * TRANS, int4 * M, int4 * N, int4 * NRHS, real8 * A, int4 * LDA, real8 * B, int4 * LDB, real8 * WORK, int4 * LWORK, int4 * INFO )
   {
     F77FUNC(dgels)(TRANS, M, N, NRHS, A, LDA, B, LDB, WORK, LWORK, INFO );
   }
-  template<> void xgels(char * TRANS, int * M, int * N, int * NRHS, complex16 * A, int * LDA, complex16 * B, int * LDB, complex16 * WORK, int * LWORK, int * INFO )
+  template<> void xgels(char * TRANS, int4 * M, int4 * N, int4 * NRHS, complex16 * A, int4 * LDA, complex16 * B, int4 * LDB, complex16 * WORK, int4 * LWORK, int4 * INFO )
   {
     F77FUNC(zgels)(TRANS, M, N, NRHS, A, LDA, B, LDB, WORK, LWORK, INFO );
   }
 
   //xGEQRF specialisations
-  template<> void xgeqrf(int * M, int * N, real8 * A, int * LDA, real8 * TAU, real8 * WORK, int * LWORK, int *INFO)
+  template<> void xgeqrf(int4 * M, int4 * N, real8 * A, int4 * LDA, real8 * TAU, real8 * WORK, int4 * LWORK, int4 *INFO)
   {
     F77FUNC(dgeqrf)(M, N, A, LDA, TAU, WORK, LWORK, INFO);
   }
-  template<> void xgeqrf(int * M, int * N, complex16 * A, int * LDA, complex16 * TAU, complex16 * WORK, int * LWORK, int *INFO)
+  template<> void xgeqrf(int4 * M, int4 * N, complex16 * A, int4 * LDA, complex16 * TAU, complex16 * WORK, int4 * LWORK, int4 *INFO)
   {
     F77FUNC(zgeqrf)(M, N, A, LDA, TAU, WORK, LWORK, INFO);
   }
 
   // xxxGQR specialisations
-  template<> void xxxgqr(int * M, int * N, int * K, real8 * A, int * LDA, real8 * TAU, real8 * WORK, int * LWORK, int * INFO)
+  template<> void xxxgqr(int4 * M, int4 * N, int4 * K, real8 * A, int4 * LDA, real8 * TAU, real8 * WORK, int4 * LWORK, int4 * INFO)
   {
     F77FUNC(dorgqr)(M, N, K, A, LDA, TAU, WORK, LWORK, INFO);
   }
-  template<> void xxxgqr(int * M, int * N, int * K, complex16 * A, int * LDA, complex16 * TAU, complex16 * WORK, int * LWORK, int * INFO)
+  template<> void xxxgqr(int4 * M, int4 * N, int4 * K, complex16 * A, int4 * LDA, complex16 * TAU, complex16 * WORK, int4 * LWORK, int4 * INFO)
   {
     F77FUNC(zungqr)(M, N, K, A, LDA, TAU, WORK, LWORK, INFO);
   }
@@ -295,7 +295,7 @@ template<>  void xgesvd(char * JOBU, char * JOBVT, int4 * M, int4 * N, real8 * A
   set_xerbla_death_switch(lapack::izero);
 
   real8 tmp;
-  int lwork = -1; // set for query
+  int4 lwork = -1; // set for query
 
   // work space query
   F77FUNC(dgesvd)(JOBU, JOBVT, M, N, A, LDA, S, U, LDU, VT, LDVT, &tmp, &lwork, INFO);
@@ -308,7 +308,7 @@ template<>  void xgesvd(char * JOBU, char * JOBVT, int4 * M, int4 * N, real8 * A
   }
 
   // query complete tmp contains size needed
-  lwork = (int)tmp;
+  lwork = (int4)tmp;
   std::unique_ptr<real8[]> workPtr(new real8[lwork]());
   real8 * WORK = workPtr.get();
 
@@ -325,9 +325,9 @@ template<>  void xgesvd(char * JOBU, char * JOBVT, int4 * M, int4 * N, complex16
 {
   set_xerbla_death_switch(lapack::izero);
 
-  int minmn = *M > *N ? *N : *M; // compute scale for RWORK
+  int4 minmn = *M > *N ? *N : *M; // compute scale for RWORK
   complex16 tmp;
-  int lwork = -1; // set for query
+  int4 lwork = -1; // set for query
   real8 * RWORK = nullptr;
 
   // work space query
@@ -340,7 +340,7 @@ template<>  void xgesvd(char * JOBU, char * JOBVT, int4 * M, int4 * N, complex16
   }
 
   // query complete tmp contains size needed
-  lwork = (int)(tmp.real());
+  lwork = (int4)(tmp.real());
 
   std::unique_ptr<complex16[]> workPtr(new complex16[lwork]);
   complex16 * WORK = workPtr.get();
@@ -395,7 +395,7 @@ template<typename T> void xgetri(int4 * N, T * A, int4 * LDA, int4 * IPIV, int4 
   // will check on true call below.
 
   // Allocate work space based on queried value
-  lwork = (int)std::real(worktmp);
+  lwork = (int4)std::real(worktmp);
   std::unique_ptr<T[]> workPtr (new T[lwork]);
   T * work = workPtr.get();
 
@@ -432,8 +432,8 @@ template<> void xtrcon(char * NORM, char * UPLO, char * DIAG, int4 * N, real8 * 
 
   std::unique_ptr<real8[]> workPtr (new real8[ 3 * *N]);
   real8 * WORK = workPtr.get();
-  std::unique_ptr<int[]> iworkPtr (new int[*N]);
-  int * IWORK = iworkPtr.get();
+  std::unique_ptr<int4[]> iworkPtr (new int4[*N]);
+  int4 * IWORK = iworkPtr.get();
 
   F77FUNC(dtrcon)(NORM, UPLO, DIAG, N, A, LDA, RCOND, WORK, IWORK, INFO);
   if(*INFO!=0)
@@ -523,8 +523,8 @@ template<> void xpocon(char * UPLO, int4 * N, real8 * A, int4 * LDA, real8 * ANO
 
   std::unique_ptr<real8[]> workPtr (new real8[3 * (*N)]);
   real8 * WORK = workPtr.get();
-  std::unique_ptr<int[]> iworkPtr (new int[(*N)]);
-  int * IWORK = iworkPtr.get();
+  std::unique_ptr<int4[]> iworkPtr (new int4[(*N)]);
+  int4 * IWORK = iworkPtr.get();
 
   F77FUNC(dpocon)(UPLO, N, A, LDA, ANORM, RCOND, WORK, IWORK, INFO);
   if(*INFO<0)
@@ -605,7 +605,7 @@ template void xpotrs<real8>(char * UPLO, int4 * N, int4 * NRHS, real8 * A, int4 
 template void xpotrs<complex16>(char * UPLO, int4 * N, int4 * NRHS, complex16 * A, int4 * LDA, complex16 * B, int4 * LDB, int4 * INFO);
 
 
-template<typename T> real8 xlange(char * NORM, int * M, int * N, T * A, int * LDA)
+template<typename T> real8 xlange(char * NORM, int4 * M, int4 * N, T * A, int4 * LDA)
 {
   set_xerbla_death_switch(lapack::izero);
   if(*M<=0)
@@ -619,11 +619,11 @@ template<typename T> real8 xlange(char * NORM, int * M, int * N, T * A, int * LD
   real8 ret = detail::xlange(NORM, M, N, A, LDA, WORK);
   return ret;
 }
-template real8 xlange<real8>(char * NORM, int * M, int * N, real8 * A, int * LDA);
-template real8 xlange<complex16>(char * NORM, int * M, int * N, complex16 * A, int * LDA);
+template real8 xlange<real8>(char * NORM, int4 * M, int4 * N, real8 * A, int4 * LDA);
+template real8 xlange<complex16>(char * NORM, int4 * M, int4 * N, complex16 * A, int4 * LDA);
 
 
-template<> void xgecon(char * NORM, int * N, real8 * A, int * LDA, real8 * ANORM, real8 * RCOND, int * INFO)
+template<> void xgecon(char * NORM, int4 * N, real8 * A, int4 * LDA, real8 * ANORM, real8 * RCOND, int4 * INFO)
 {
   set_xerbla_death_switch(lapack::izero);
   if(*N<=0)
@@ -635,8 +635,8 @@ template<> void xgecon(char * NORM, int * N, real8 * A, int * LDA, real8 * ANORM
 
   std::unique_ptr<real8[]> workPtr (new real8[4*(*N)]);
   real8 * WORK = workPtr.get();
-  std::unique_ptr<int[]> iworkPtr (new int[*N]);
-  int * IWORK = iworkPtr.get();
+  std::unique_ptr<int4[]> iworkPtr (new int4[*N]);
+  int4 * IWORK = iworkPtr.get();
   F77FUNC(dgecon)(NORM, N, A, LDA, ANORM, RCOND, WORK, IWORK, INFO);
 
   if(*INFO<0)
@@ -647,7 +647,7 @@ template<> void xgecon(char * NORM, int * N, real8 * A, int * LDA, real8 * ANORM
   }
 }
 
-template<> void xgecon(char * NORM, int * N, complex16 * A, int * LDA, real8 * ANORM, real8 * RCOND, int * INFO)
+template<> void xgecon(char * NORM, int4 * N, complex16 * A, int4 * LDA, real8 * ANORM, real8 * RCOND, int4 * INFO)
 {
   set_xerbla_death_switch(lapack::izero);
   if(*N<=0)
@@ -673,7 +673,7 @@ template<> void xgecon(char * NORM, int * N, complex16 * A, int * LDA, real8 * A
 }
 
 
-template<typename T> void xgetrs(char * TRANS, int * N, int * NRHS, T * A, int * LDA, int * IPIV, T * B, int * LDB, int * INFO)
+template<typename T> void xgetrs(char * TRANS, int4 * N, int4 * NRHS, T * A, int4 * LDA, int4 * IPIV, T * B, int4 * LDB, int4 * INFO)
 {
   set_xerbla_death_switch(lapack::izero);
   detail::xgetrs(TRANS, N, NRHS, A, LDA, IPIV, B, LDB, INFO);
@@ -684,15 +684,15 @@ template<typename T> void xgetrs(char * TRANS, int * N, int * NRHS, T * A, int *
     throw rdag_error(message.str());
   }
 }
-template void xgetrs<real8>(char * TRANS, int * N, int * NRHS, real8 * A, int * LDA, int * IPIV, real8 * B, int * LDB, int * INFO);
-template void xgetrs<complex16>(char * TRANS, int * N, int * NRHS, complex16 * A, int * LDA, int * IPIV, complex16 * B, int * LDB, int * INFO);
+template void xgetrs<real8>(char * TRANS, int4 * N, int4 * NRHS, real8 * A, int4 * LDA, int4 * IPIV, real8 * B, int4 * LDB, int4 * INFO);
+template void xgetrs<complex16>(char * TRANS, int4 * N, int4 * NRHS, complex16 * A, int4 * LDA, int4 * IPIV, complex16 * B, int4 * LDB, int4 * INFO);
 
 
-template<typename T> void xgels(char * TRANS, int * M, int * N, int * NRHS, T * A, int * LDA, T * B, int * LDB, int * INFO )
+template<typename T> void xgels(char * TRANS, int4 * M, int4 * N, int4 * NRHS, T * A, int4 * LDA, T * B, int4 * LDB, int4 * INFO )
 {
   set_xerbla_death_switch(lapack::izero);
   T worktmp;
-  int lwork = -1; // -1 to trigger size query
+  int4 lwork = -1; // -1 to trigger size query
 
   // Workspace size query
   detail::xgels(TRANS, M, N, NRHS, A, LDA, B, LDB, &worktmp, &lwork, INFO);
@@ -706,7 +706,7 @@ template<typename T> void xgels(char * TRANS, int * M, int * N, int * NRHS, T * 
   // will check on true call below.
 
   // Allocate work space based on queried value
-  lwork = (int)std::real(worktmp);
+  lwork = (int4)std::real(worktmp);
   std::unique_ptr<T[]> workPtr (new T[lwork]);
   T * work = workPtr.get();
 
@@ -729,16 +729,16 @@ template<typename T> void xgels(char * TRANS, int * M, int * N, int * NRHS, T * 
   }
   // normal return
 }
-template void xgels<real8>(char * TRANS, int * M, int * N, int * NRHS, real8 * A, int * LDA, real8 * B, int * LDB, int * INFO );
-template void xgels<complex16>(char * TRANS, int * M, int * N, int * NRHS, complex16 * A, int * LDA, complex16 * B, int * LDB, int * INFO );
+template void xgels<real8>(char * TRANS, int4 * M, int4 * N, int4 * NRHS, real8 * A, int4 * LDA, real8 * B, int4 * LDB, int4 * INFO );
+template void xgels<complex16>(char * TRANS, int4 * M, int4 * N, int4 * NRHS, complex16 * A, int4 * LDA, complex16 * B, int4 * LDB, int4 * INFO );
 
 
-template<> void xgelsd(int * M, int * N, int * NRHS, real8 * A, int * LDA, real8 * B, int * LDB, real8 * S, real8 * RCOND, int * RANK, int * INFO )
+template<> void xgelsd(int4 * M, int4 * N, int4 * NRHS, real8 * A, int4 * LDA, real8 * B, int4 * LDB, real8 * S, real8 * RCOND, int4 * RANK, int4 * INFO )
 {
   set_xerbla_death_switch(lapack::izero);
   real8 worktmp;
-  int iworktmp;
-  int lwork = -1; // -1 to trigger size query
+  int4 iworktmp;
+  int4 lwork = -1; // -1 to trigger size query
 
   // Workspace size query
   F77FUNC(dgelsd)(M, N, NRHS, A, LDA, B, LDB, S, RCOND, RANK, &worktmp, &lwork, &iworktmp, INFO);
@@ -752,13 +752,13 @@ template<> void xgelsd(int * M, int * N, int * NRHS, real8 * A, int * LDA, real8
   // will check on true call below.
 
   // Allocate work space based on queried value
-  lwork = (int)(worktmp);
+  lwork = (int4)(worktmp);
 
   std::unique_ptr<real8[]> workPtr (new real8[lwork]);
   real8 * work = workPtr.get();
 
-  std::unique_ptr<int[]> iworkPtr (new int[iworktmp]);
-  int * iwork = iworkPtr.get();
+  std::unique_ptr<int4[]> iworkPtr (new int4[iworktmp]);
+  int4 * iwork = iworkPtr.get();
 
   // the actual call
   F77FUNC(dgelsd)(M, N, NRHS, A, LDA, B, LDB, S, RCOND, RANK, work, &lwork, iwork, INFO);
@@ -781,13 +781,13 @@ template<> void xgelsd(int * M, int * N, int * NRHS, real8 * A, int * LDA, real8
 }
 
 
-template<> void xgelsd(int * M, int * N, int * NRHS, complex16 * A, int * LDA, complex16 * B, int * LDB, real8 * S, real8 * RCOND, int * RANK, int * INFO )
+template<> void xgelsd(int4 * M, int4 * N, int4 * NRHS, complex16 * A, int4 * LDA, complex16 * B, int4 * LDB, real8 * S, real8 * RCOND, int4 * RANK, int4 * INFO )
 {
   set_xerbla_death_switch(lapack::izero);
   complex16 worktmp;
   real8 rworktmp;
-  int iworktmp;
-  int lwork = -1; // -1 to trigger size query
+  int4 iworktmp;
+  int4 lwork = -1; // -1 to trigger size query
 
   // Workspace size query
   F77FUNC(zgelsd)(M, N, NRHS, A, LDA, B, LDB, S, RCOND, RANK, &worktmp, &lwork, &rworktmp, &iworktmp, INFO);
@@ -801,15 +801,15 @@ template<> void xgelsd(int * M, int * N, int * NRHS, complex16 * A, int * LDA, c
   // will check on true call below.
 
   // Allocate work space based on queried value
-  lwork = (int)std::real(worktmp);
+  lwork = (int4)std::real(worktmp);
 
   std::unique_ptr<complex16[]> workPtr (new complex16[lwork]);
-  std::unique_ptr<real8[]> rworkPtr (new real8[(int)(rworktmp)]);
-  std::unique_ptr<int[]> iworkPtr (new int[iworktmp]);
+  std::unique_ptr<real8[]> rworkPtr (new real8[(int4)(rworktmp)]);
+  std::unique_ptr<int4[]> iworkPtr (new int4[iworktmp]);
 
   complex16 * work = workPtr.get();
   real8 * rwork = rworkPtr.get();
-  int * iwork = iworkPtr.get();
+  int4 * iwork = iworkPtr.get();
 
   // the actual call
   F77FUNC(zgelsd)(M, N, NRHS, A, LDA, B, LDB, S, RCOND, RANK, work, &lwork, rwork, iwork, INFO);
@@ -832,11 +832,11 @@ template<> void xgelsd(int * M, int * N, int * NRHS, complex16 * A, int * LDA, c
 }
 
 
-template<> void xgeev(char * JOBVL, char * JOBVR, int * N, real8 * A, int * LDA, complex16 * W, real8 * VL, int * LDVL, real8 * VR, int * LDVR, int * INFO)
+template<> void xgeev(char * JOBVL, char * JOBVR, int4 * N, real8 * A, int4 * LDA, complex16 * W, real8 * VL, int4 * LDVL, real8 * VR, int4 * LDVR, int4 * INFO)
 {
   set_xerbla_death_switch(lapack::izero);
   real8 worktmp;
-  int lwork = -1; // -1 to trigger size query
+  int4 lwork = -1; // -1 to trigger size query
 
   real8 * WR = nullptr;
   real8 * WI = nullptr;
@@ -856,7 +856,7 @@ template<> void xgeev(char * JOBVL, char * JOBVR, int * N, real8 * A, int * LDA,
   WI = ptrWI.get();
 
     // Allocate work space based on queried value
-  lwork = (int)(worktmp);
+  lwork = (int4)(worktmp);
   std::unique_ptr<real8 []> ptrWORK (new real8[lwork]);
   real8 * work = ptrWORK.get();
 
@@ -864,7 +864,7 @@ template<> void xgeev(char * JOBVL, char * JOBVR, int * N, real8 * A, int * LDA,
   F77FUNC(dgeev)(JOBVL, JOBVR, N, A, LDA, WR, WI, VL, LDVL, VR, LDVR, work, &lwork, INFO);
 
   // copy back answer
-  for(int i = 0 ; i < *N; i++)
+  for(int4 i = 0 ; i < *N; i++)
   {
     W[i] = std::complex<real8>(WR[i],WI[i]);
   }
@@ -886,12 +886,12 @@ template<> void xgeev(char * JOBVL, char * JOBVR, int * N, real8 * A, int * LDA,
 }
 
 
-template<> void xgeev(char * JOBVL, char * JOBVR, int * N, complex16 * A, int * LDA, complex16 * W, complex16 * VL, int * LDVL, complex16 * VR, int * LDVR, int * INFO)
+template<> void xgeev(char * JOBVL, char * JOBVR, int4 * N, complex16 * A, int4 * LDA, complex16 * W, complex16 * VL, int4 * LDVL, complex16 * VR, int4 * LDVR, int4 * INFO)
 {
   set_xerbla_death_switch(lapack::izero);
   complex16 worktmp;
   real8 * rwork = nullptr;
-  int lwork = -1; // -1 to trigger size query
+  int4 lwork = -1; // -1 to trigger size query
 
   // Workspace size query
   F77FUNC(zgeev)(JOBVL, JOBVR, N, A, LDA, W, VL, LDVL, VR, LDVR, &worktmp, &lwork, rwork, INFO);
@@ -904,7 +904,7 @@ template<> void xgeev(char * JOBVL, char * JOBVR, int * N, complex16 * A, int * 
   }
 
     // Allocate work space based on queried value
-  lwork = (int)std::real(worktmp);
+  lwork = (int4)std::real(worktmp);
   std::unique_ptr<complex16 []> workPtr (new complex16[lwork]);
   complex16 * work = workPtr.get();
   std::unique_ptr<real8 []> rworkPtr (new real8[2 * (*N)]);
@@ -930,11 +930,11 @@ template<> void xgeev(char * JOBVL, char * JOBVR, int * N, complex16 * A, int * 
 }
 
 
-template<typename T> void xgeqrf(int * M, int * N, T * A, int * LDA, T * TAU, int *INFO)
+template<typename T> void xgeqrf(int4 * M, int4 * N, T * A, int4 * LDA, T * TAU, int4 *INFO)
 {
   set_xerbla_death_switch(lapack::izero);
   T worktmp;
-  int lwork = -1; // -1 to trigger size query
+  int4 lwork = -1; // -1 to trigger size query
 
   detail::xgeqrf(M, N, A, LDA, TAU, &worktmp, &lwork, INFO );
 
@@ -945,7 +945,7 @@ template<typename T> void xgeqrf(int * M, int * N, T * A, int * LDA, T * TAU, in
     throw rdag_error(message.str());
   }
 
-  lwork = (int)std::real(worktmp);
+  lwork = (int4)std::real(worktmp);
   std::unique_ptr<T[]> workPtr (new T[lwork]);
   T * work = workPtr.get();
 
@@ -957,14 +957,14 @@ template<typename T> void xgeqrf(int * M, int * N, T * A, int * LDA, T * TAU, in
     throw rdag_error(message.str());
   }
 }
-template void xgeqrf<real8>(int * M, int * N, real8 * A, int * LDA, real8 * TAU, int *INFO);
-template void xgeqrf<complex16>(int * M, int * N, complex16 * A, int * LDA, complex16 * TAU, int *INFO);
+template void xgeqrf<real8>(int4 * M, int4 * N, real8 * A, int4 * LDA, real8 * TAU, int4 *INFO);
+template void xgeqrf<complex16>(int4 * M, int4 * N, complex16 * A, int4 * LDA, complex16 * TAU, int4 *INFO);
 
-template<typename T>void xxxgqr(int * M, int * N, int * K, T * A, int * LDA, T * TAU, int * INFO)
+template<typename T>void xxxgqr(int4 * M, int4 * N, int4 * K, T * A, int4 * LDA, T * TAU, int4 * INFO)
 {
   set_xerbla_death_switch(lapack::izero);
   T worktmp;
-  int lwork = -1; // -1 to trigger size query
+  int4 lwork = -1; // -1 to trigger size query
 
   detail::xxxgqr(M, N, K, A, LDA, TAU, &worktmp, &lwork, INFO);
 
@@ -975,7 +975,7 @@ template<typename T>void xxxgqr(int * M, int * N, int * K, T * A, int * LDA, T *
     throw rdag_error(message.str());
   }
 
-  lwork = (int)std::real(worktmp);
+  lwork = (int4)std::real(worktmp);
   std::unique_ptr<T[]> workPtr (new T[lwork]);
   T * work = workPtr.get();
 
@@ -987,7 +987,7 @@ template<typename T>void xxxgqr(int * M, int * N, int * K, T * A, int * LDA, T *
     throw rdag_error(message.str());
   }
 }
-template void xxxgqr<real8>(int * M, int * N, int * K, real8 * A, int * LDA, real8 * TAU, int * INFO);
-template void xxxgqr<complex16>(int * M, int * N, int * K, complex16 * A, int * LDA, complex16 * TAU, int * INFO);
+template void xxxgqr<real8>(int4 * M, int4 * N, int4 * K, real8 * A, int4 * LDA, real8 * TAU, int4 * INFO);
+template void xxxgqr<complex16>(int4 * M, int4 * N, int4 * K, complex16 * A, int4 * LDA, complex16 * TAU, int4 * INFO);
 
 } // end namespace lapack

--- a/src/librdag/lapack.cc
+++ b/src/librdag/lapack.cc
@@ -303,7 +303,7 @@ template<>  void xgesvd(char * JOBU, char * JOBVT, int4 * M, int4 * N, real8 * A
   if(*INFO < 0)
   {
     std::stringstream message;
-    message << "Input to LAPACK::dgesvd call incorrect at arg: " << *INFO;
+    message << "Input to LAPACK::dgesvd call incorrect at arg: " << -(*INFO);
     throw rdag_error(message.str());
   }
 
@@ -335,7 +335,7 @@ template<>  void xgesvd(char * JOBU, char * JOBVT, int4 * M, int4 * N, complex16
   if(*INFO < 0)
   {
     std::stringstream message;
-    message << "Input to LAPACK::zgesvd call incorrect at arg: " << *INFO;
+    message << "Input to LAPACK::zgesvd call incorrect at arg: " << -(*INFO);
     throw rdag_error(message.str());
   }
 
@@ -365,7 +365,7 @@ template<typename T> void xgetrf(int4 * M, int4 * N, T * A, int4 * LDA, int4 * I
     std::stringstream message;
     if(*INFO<0)
     {
-      message << "Input to LAPACK::xgetrf call incorrect at arg: " << *INFO << ".";
+      message << "Input to LAPACK::xgetrf call incorrect at arg: " << -(*INFO) << ".";
     }
     else
     {
@@ -388,7 +388,7 @@ template<typename T> void xgetri(int4 * N, T * A, int4 * LDA, int4 * IPIV, int4 
   if(*INFO<0)
   {
     std::stringstream message;
-    message << "Input to LAPACK::xgetri call incorrect at arg: " << *INFO;
+    message << "Input to LAPACK::xgetri call incorrect at arg: " << -(*INFO);
     throw rdag_error(message.str());
   }
   // else { continue }. NOTE: Workspace query doesn't care about validity of inversion,
@@ -404,14 +404,7 @@ template<typename T> void xgetri(int4 * N, T * A, int4 * LDA, int4 * IPIV, int4 
   if(*INFO!=0)
   {
     std::stringstream message;
-    if(*INFO<0)
-    {
-      message << "Input to LAPACK::xgetri call incorrect at arg: " << *INFO << ".";
-    }
-    else
-    {
-      message << "LAPACK::xgetri, in LU decomposition, matrix U is singular at U[" << (*INFO - 1) << "," << (*INFO - 1) << "].";
-    }
+    message << "LAPACK::xgetri, in LU decomposition, matrix U is singular at U[" << (*INFO - 1) << "," << (*INFO - 1) << "].";
     throw rdag_error(message.str());
   }
 
@@ -439,7 +432,7 @@ template<> void xtrcon(char * NORM, char * UPLO, char * DIAG, int4 * N, real8 * 
   if(*INFO!=0)
   {
       std::stringstream message;
-      message << "Input to LAPACK::dtrcon call incorrect at arg: " << *INFO;
+      message << "Input to LAPACK::dtrcon call incorrect at arg: " << -(*INFO);
       throw rdag_error(message.str());
   }
 }
@@ -464,7 +457,7 @@ template<> void xtrcon(char * NORM, char * UPLO, char * DIAG, int4 * N, complex1
   if(*INFO!=0)
   {
     std::stringstream message;
-    message << "Input to LAPACK::ztrcon call incorrect at arg: " << *INFO;
+    message << "Input to LAPACK::ztrcon call incorrect at arg: " << -(*INFO);
     throw rdag_error(message.str());
   }
 }
@@ -473,17 +466,20 @@ template<typename T> void xtrtrs(char * UPLO, char * TRANS, char * DIAG, int4 * 
 {
   set_xerbla_death_switch(lapack::izero);
   detail::xtrtrs(UPLO, TRANS, DIAG, N, NRHS, A, LDA, B, LDB, INFO);
-  if(*INFO>0)
-  {
-    std::stringstream message;
-    message << "LAPACK::"<<detail::charmagic<T>()<<"trtrs matrix is reported as being singular, the " << *INFO << "th diagonal is zero. No solutions have been computed.";
-    throw rdag_error(message.str());
-  }
   if(*INFO!=0)
   {
-    std::stringstream message;
-    message << "Input to LAPACK::"<<detail::charmagic<T>()<<"trtrs call incorrect at arg: " << *INFO;
-    throw rdag_error(message.str());
+    if(*INFO>0)
+    {
+      std::stringstream message;
+      message << "LAPACK::"<<detail::charmagic<T>()<<"trtrs matrix is reported as being singular, the " << *INFO << "th diagonal is zero. No solutions have been computed.";
+      throw rdag_error(message.str());
+    }
+    else
+    {
+      std::stringstream message;
+      message << "Input to LAPACK::"<<detail::charmagic<T>()<<"trtrs call incorrect at arg: " << -(*INFO);
+      throw rdag_error(message.str());
+    }
   }
 }
 template void xtrtrs<real8>(char * UPLO, char * TRANS, char * DIAG, int4 * N, int4 * NRHS, real8 * A, int4 * LDA, real8 * B, int4 * LDB, int4 * INFO);
@@ -494,17 +490,20 @@ template<typename T> void xpotrf(char * UPLO, int4 * N, T * A, int4 * LDA, int4 
 {
   set_xerbla_death_switch(lapack::izero);
   detail::xpotrf(UPLO, N, A, LDA, INFO);
-  if(*INFO>0)
+  if(*INFO!=0)
   {
-    std::stringstream message;
-    message << "LAPACK::"<<detail::charmagic<T>()<<"potrf matrix is reported as being non s.p.d OR the factorisation failed. The " << *INFO << "th leading minor is not positive definite.";
-    throw rdag_error(message.str());
-  }
-  if(*INFO<0)
-  {
-    std::stringstream message;
-    message << "Input to LAPACK::"<<detail::charmagic<T>()<<"potrf call incorrect at arg: " << *INFO;
-    throw rdag_error(message.str());
+    if(*INFO>0)
+    {
+      std::stringstream message;
+      message << "LAPACK::"<<detail::charmagic<T>()<<"potrf matrix is reported as being non s.p.d OR the factorisation failed. The " << *INFO << "th leading minor is not positive definite.";
+      throw rdag_error(message.str());
+    }
+    else
+    {
+      std::stringstream message;
+      message << "Input to LAPACK::"<<detail::charmagic<T>()<<"potrf call incorrect at arg: " << -(*INFO);
+      throw rdag_error(message.str());
+    }
   }
 }
 template void xpotrf<real8>(char * UPLO, int4 * N, real8 * A, int4 * LDA, int4 * INFO);
@@ -530,7 +529,7 @@ template<> void xpocon(char * UPLO, int4 * N, real8 * A, int4 * LDA, real8 * ANO
   if(*INFO<0)
   {
     std::stringstream message;
-    message << "Input to LAPACK::dpocon call incorrect at arg: " << *INFO;
+    message << "Input to LAPACK::dpocon call incorrect at arg: " << -(*INFO);
     throw rdag_error(message.str());
   }
 }
@@ -554,7 +553,7 @@ template<> void xpocon(char * UPLO, int4 * N, complex16 * A, int4 * LDA, real8 *
   if(*INFO<0)
   {
     std::stringstream message;
-    message << "Input to LAPACK::dpocon call incorrect at arg: " << *INFO;
+    message << "Input to LAPACK::dpocon call incorrect at arg: " << -(*INFO);
     throw rdag_error(message.str());
   }
 }
@@ -581,7 +580,12 @@ template real8  xlansy<complex16>(char * NORM, char * UPLO, int4 * N, complex16 
 real8 zlanhe(char * NORM, char * UPLO, int4 * N, complex16 * A, int4 * LDA)
 {
   set_xerbla_death_switch(lapack::izero);
-
+  if(*N<=0)
+  {
+    std::stringstream message;
+    message << "Input to LAPACK::zlanhe call incorrect at arg: " << 3;
+    throw rdag_error(message.str());
+  }
   std::unique_ptr<real8[]> workPtr (new real8[*N]);// allocate regardless of *NORM
   real8 * WORK = workPtr.get();
   real8 ret = F77FUNC(zlanhe)(NORM, UPLO, N, A, LDA, WORK);
@@ -597,7 +601,7 @@ template<typename T> void xpotrs(char * UPLO, int4 * N, int4 * NRHS, T * A, int4
   if(*INFO<0)
   {
     std::stringstream message;
-    message << "Input to LAPACK::"<<detail::charmagic<T>()<<"potrs call incorrect at arg: " << *INFO;
+    message << "Input to LAPACK::"<<detail::charmagic<T>()<<"potrs call incorrect at arg: " <<  -(*INFO);
     throw rdag_error(message.str());
   }
 }
@@ -638,11 +642,10 @@ template<> void xgecon(char * NORM, int4 * N, real8 * A, int4 * LDA, real8 * ANO
   std::unique_ptr<int4[]> iworkPtr (new int4[*N]);
   int4 * IWORK = iworkPtr.get();
   F77FUNC(dgecon)(NORM, N, A, LDA, ANORM, RCOND, WORK, IWORK, INFO);
-
   if(*INFO<0)
   {
     std::stringstream message;
-    message << "Input to LAPACK::dgecon call incorrect at arg: " << *INFO;
+    message << "Input to LAPACK::dgecon call incorrect at arg: " <<  -(*INFO);
     throw rdag_error(message.str());
   }
 }
@@ -663,11 +666,10 @@ template<> void xgecon(char * NORM, int4 * N, complex16 * A, int4 * LDA, real8 *
   real8 * RWORK = rworkPtr.get();
 
   F77FUNC(zgecon)(NORM, N, A, LDA, ANORM, RCOND, WORK, RWORK, INFO);
-
   if(*INFO<0)
   {
     std::stringstream message;
-    message << "Input to LAPACK::zgecon call incorrect at arg: " << *INFO;
+    message << "Input to LAPACK::zgecon call incorrect at arg: " <<  -(*INFO);
     throw rdag_error(message.str());
   }
 }
@@ -680,7 +682,7 @@ template<typename T> void xgetrs(char * TRANS, int4 * N, int4 * NRHS, T * A, int
   if(*INFO<0)
   {
     std::stringstream message;
-    message << "Input to LAPACK::"<<detail::charmagic<T>()<<"getrs call incorrect at arg: " << *INFO;
+    message << "Input to LAPACK::"<<detail::charmagic<T>()<<"getrs call incorrect at arg: " <<  -(*INFO);
     throw rdag_error(message.str());
   }
 }
@@ -699,7 +701,7 @@ template<typename T> void xgels(char * TRANS, int4 * M, int4 * N, int4 * NRHS, T
   if(*INFO<0)
   {
     std::stringstream message;
-    message << "Input to LAPACK::xgels call incorrect at arg: " << *INFO;
+    message << "Input to LAPACK::xgels call incorrect at arg: " <<  -(*INFO);
     throw rdag_error(message.str());
   }
   // else { continue }. NOTE: Workspace query doesn't care about validity of solution,
@@ -715,16 +717,9 @@ template<typename T> void xgels(char * TRANS, int4 * M, int4 * N, int4 * NRHS, T
   if(*INFO!=0)
   {
     std::stringstream message;
-    if(*INFO<0)
-    {
-      message << "Input to LAPACK::xgels call incorrect at arg: " << *INFO << ".";
-    }
-    else
-    {
-      message << "LAPACK::xgels, the [" << (*INFO - 1) << " element of the triangular " <<
-      "factorisation of A is zero, A does not have full rank, the least squares solution " <<
-      "could not be computed";
-    }
+    message << "LAPACK::xgels, the [" << (*INFO - 1) << " element of the triangular " <<
+    "factorisation of A is zero, A does not have full rank, the least squares solution " <<
+    "could not be computed";
     throw rdag_error(message.str());
   }
   // normal return
@@ -745,7 +740,7 @@ template<> void xgelsd(int4 * M, int4 * N, int4 * NRHS, real8 * A, int4 * LDA, r
   if(*INFO<0)
   {
     std::stringstream message;
-    message << "Input to LAPACK::dgelsd call incorrect at arg: " << *INFO;
+    message << "Input to LAPACK::dgelsd call incorrect at arg: " <<  -(*INFO);
     throw rdag_error(message.str());
   }
   // else { continue }. NOTE: Workspace query doesn't care about validity of solution,
@@ -766,15 +761,8 @@ template<> void xgelsd(int4 * M, int4 * N, int4 * NRHS, real8 * A, int4 * LDA, r
   if(*INFO!=0)
   {
     std::stringstream message;
-    if(*INFO<0)
-    {
-      message << "Input to LAPACK::dgelsd call incorrect at arg: " << *INFO << ".";
-    }
-    else
-    {
-      message << "LAPACK::dgelsd, SVD computation failed to converge, " << (*INFO) <<
-      " elements of the intermediate bi-diagonal form did not converge to zero.";
-    }
+    message << "LAPACK::dgelsd, SVD computation failed to converge, " << (*INFO) <<
+    " elements of the intermediate bi-diagonal form did not converge to zero.";
     throw rdag_error(message.str());
   }
 
@@ -794,7 +782,7 @@ template<> void xgelsd(int4 * M, int4 * N, int4 * NRHS, complex16 * A, int4 * LD
   if(*INFO<0)
   {
     std::stringstream message;
-    message << "Input to LAPACK::zgelsd call incorrect at arg: " << *INFO;
+    message << "Input to LAPACK::zgelsd call incorrect at arg: " <<  -(*INFO);
     throw rdag_error(message.str());
   }
   // else { continue }. NOTE: Workspace query doesn't care about validity of solution,
@@ -817,15 +805,8 @@ template<> void xgelsd(int4 * M, int4 * N, int4 * NRHS, complex16 * A, int4 * LD
   if(*INFO!=0)
   {
     std::stringstream message;
-    if(*INFO<0)
-    {
-      message << "Input to LAPACK::zgelsd call incorrect at arg: " << *INFO << ".";
-    }
-    else
-    {
-      message << "LAPACK::zgelsd, SVD computation failed to converge, " << (*INFO) <<
-      " elements of the intermediate bi-diagonal form did not converge to zero.";
-    }
+    message << "LAPACK::zgelsd, SVD computation failed to converge, " << (*INFO) <<
+    " elements of the intermediate bi-diagonal form did not converge to zero.";
     throw rdag_error(message.str());
   }
 
@@ -846,7 +827,7 @@ template<> void xgeev(char * JOBVL, char * JOBVR, int4 * N, real8 * A, int4 * LD
   if(*INFO<0)
   {
     std::stringstream message;
-    message << "Input to LAPACK::dgeev call incorrect at arg: " << *INFO;
+    message << "Input to LAPACK::dgeev call incorrect at arg: " <<  -(*INFO);
     throw rdag_error(message.str());
   }
 
@@ -863,26 +844,20 @@ template<> void xgeev(char * JOBVL, char * JOBVR, int4 * N, real8 * A, int4 * LD
   // the actual call
   F77FUNC(dgeev)(JOBVL, JOBVR, N, A, LDA, WR, WI, VL, LDVL, VR, LDVR, work, &lwork, INFO);
 
+  if(*INFO!=0)
+  {
+    std::stringstream message;
+    message << "LAPACK::dgeev, QR alg failed. Eigenvalues in elements, " << (*INFO - 1) <<
+    ":" << (*N-1) << " have successfully converged, no eigenvectors have been computed.";
+    throw rdag_error(message.str());
+  }
+
   // copy back answer
   for(int4 i = 0 ; i < *N; i++)
   {
     W[i] = std::complex<real8>(WR[i],WI[i]);
   }
 
-  if(*INFO!=0)
-  {
-    std::stringstream message;
-    if(*INFO<0)
-    {
-      message << "Input to LAPACK::dgeev call incorrect at arg: " << *INFO << ".";
-    }
-    else
-    {
-      message << "LAPACK::dgeev, QR alg failed. Eigenvalues in elements, " << (*INFO - 1) <<
-      ":" << (*N-1) << " have successfully converged, no eigenvectors have been computed.";
-    }
-    throw rdag_error(message.str());
-  }
 }
 
 
@@ -899,7 +874,7 @@ template<> void xgeev(char * JOBVL, char * JOBVR, int4 * N, complex16 * A, int4 
   if(*INFO<0)
   {
     std::stringstream message;
-    message << "Input to LAPACK::zgeev call incorrect at arg: " << *INFO;
+    message << "Input to LAPACK::zgeev call incorrect at arg: " <<  -(*INFO);
     throw rdag_error(message.str());
   }
 
@@ -916,15 +891,8 @@ template<> void xgeev(char * JOBVL, char * JOBVR, int4 * N, complex16 * A, int4 
   if(*INFO!=0)
   {
     std::stringstream message;
-    if(*INFO<0)
-    {
-      message << "Input to LAPACK::zgeev call incorrect at arg: " << *INFO << ".";
-    }
-    else
-    {
-      message << "LAPACK::zgeev, QR alg failed. Eigenvalues in elements, " << (*INFO - 1) <<
-      ":" << (*N-1) << " have successfully converged, no eigenvectors have been computed.";
-    }
+    message << "LAPACK::zgeev, QR alg failed. Eigenvalues in elements, " << (*INFO - 1) <<
+    ":" << (*N-1) << " have successfully converged, no eigenvectors have been computed.";
     throw rdag_error(message.str());
   }
 }
@@ -941,7 +909,7 @@ template<typename T> void xgeqrf(int4 * M, int4 * N, T * A, int4 * LDA, T * TAU,
   if(*INFO<0)
   {
     std::stringstream message;
-    message << "Input to LAPACK::" << detail::charmagic<T>() << "geqrf call incorrect at arg: "  << *INFO;
+    message << "Input to LAPACK::" << detail::charmagic<T>() << "geqrf call incorrect at arg: "  << -(*INFO);
     throw rdag_error(message.str());
   }
 
@@ -950,12 +918,7 @@ template<typename T> void xgeqrf(int4 * M, int4 * N, T * A, int4 * LDA, T * TAU,
   T * work = workPtr.get();
 
   detail::xgeqrf(M, N, A, LDA, TAU, work, &lwork, INFO );
-  if(*INFO<0)
-  {
-    std::stringstream message;
-    message << "Input to LAPACK::" << detail::charmagic<T>() << "geqrf call incorrect at arg: "  << *INFO;
-    throw rdag_error(message.str());
-  }
+
 }
 template void xgeqrf<real8>(int4 * M, int4 * N, real8 * A, int4 * LDA, real8 * TAU, int4 *INFO);
 template void xgeqrf<complex16>(int4 * M, int4 * N, complex16 * A, int4 * LDA, complex16 * TAU, int4 *INFO);
@@ -971,7 +934,7 @@ template<typename T>void xxxgqr(int4 * M, int4 * N, int4 * K, T * A, int4 * LDA,
   if(*INFO<0)
   {
     std::stringstream message;
-    message << "Input to LAPACK::" << detail::xxxgqrcharmagic<T>() << "gqr call incorrect at arg: "  << *INFO;
+    message << "Input to LAPACK::" << detail::xxxgqrcharmagic<T>() << "gqr call incorrect at arg: "  << -(*INFO);
     throw rdag_error(message.str());
   }
 
@@ -980,12 +943,7 @@ template<typename T>void xxxgqr(int4 * M, int4 * N, int4 * K, T * A, int4 * LDA,
   T * work = workPtr.get();
 
   detail::xxxgqr(M, N, K, A, LDA, TAU, work, &lwork, INFO);
-  if(*INFO<0)
-  {
-    std::stringstream message;
-    message << "Input to LAPACK::" << detail::xxxgqrcharmagic<T>() << "gqr call incorrect at arg: "  << *INFO;
-    throw rdag_error(message.str());
-  }
+
 }
 template void xxxgqr<real8>(int4 * M, int4 * N, int4 * K, real8 * A, int4 * LDA, real8 * TAU, int4 * INFO);
 template void xxxgqr<complex16>(int4 * M, int4 * N, int4 * K, complex16 * A, int4 * LDA, complex16 * TAU, int4 * INFO);

--- a/src/librdag/lapack.cc
+++ b/src/librdag/lapack.cc
@@ -7,8 +7,9 @@
 #include "lapack.hh"
 #include "exceptions.hh"
 
+#include <memory>
+
 using namespace librdag;
-using namespace std;
 
 namespace lapack {
 
@@ -21,6 +22,7 @@ namespace detail
   char U = 'U';
   char D = 'D';
   char O = 'O';
+  char V = 'V';
   char ONE = '1';
   int4 ione = 1;
   int4 izero = 0;
@@ -37,6 +39,16 @@ namespace detail
   template<>char charmagic<complex16>()
   {
     return 'z';
+  }
+
+  // xxxgqrcharmagic specialisation, orthogonal vs unitary means extra chars needed
+  template<>std::string xxxgqrcharmagic<real8>()
+  {
+    return "dor";
+  }
+  template<>std::string xxxgqrcharmagic<complex16>()
+  {
+    return "zun";
   }
 
   // xSCAL specialisations
@@ -158,6 +170,57 @@ namespace detail
   {
     F77FUNC(zgetri)(N,A,LDA,IPIV,WORK,LWORK,INFO);
   }
+
+  //xLANGE specialisation
+  template<> real8 xlange(char * NORM, int * M, int * N, real8 * A, int * LDA, real8 * WORK )
+  {
+    return F77FUNC(dlange)(NORM, M, N, A, LDA, WORK);
+  }
+
+  template<> real8 xlange(char * NORM, int * M, int * N, complex16 * A, int * LDA, real8 * WORK )
+  {
+    return F77FUNC(zlange)(NORM, M, N, A, LDA, WORK);
+  }
+
+  // xGETRS specialisations
+  template<> void xgetrs(char * TRANS, int * N, int * NRHS, real8 * A, int * LDA, int * IPIV, real8 * B, int * LDB, int * INFO)
+  {
+    F77FUNC(dgetrs)(TRANS, N, NRHS, A, LDA, IPIV, B, LDB, INFO);
+  }
+  template<> void xgetrs(char * TRANS, int * N, int * NRHS, complex16 * A, int * LDA, int * IPIV, complex16 * B, int * LDB, int * INFO)
+  {
+    F77FUNC(zgetrs)(TRANS, N, NRHS, A, LDA, IPIV, B, LDB, INFO);
+  }
+
+  //xGELS specialisations
+  template<> void xgels(char * TRANS, int * M, int * N, int * NRHS, real8 * A, int * LDA, real8 * B, int * LDB, real8 * WORK, int * LWORK, int * INFO )
+  {
+    F77FUNC(dgels)(TRANS, M, N, NRHS, A, LDA, B, LDB, WORK, LWORK, INFO );
+  }
+  template<> void xgels(char * TRANS, int * M, int * N, int * NRHS, complex16 * A, int * LDA, complex16 * B, int * LDB, complex16 * WORK, int * LWORK, int * INFO )
+  {
+    F77FUNC(zgels)(TRANS, M, N, NRHS, A, LDA, B, LDB, WORK, LWORK, INFO );
+  }
+
+  //xGEQRF specialisations
+  template<> void xgeqrf(int * M, int * N, real8 * A, int * LDA, real8 * TAU, real8 * WORK, int * LWORK, int *INFO)
+  {
+    F77FUNC(dgeqrf)(M, N, A, LDA, TAU, WORK, LWORK, INFO);
+  }
+  template<> void xgeqrf(int * M, int * N, complex16 * A, int * LDA, complex16 * TAU, complex16 * WORK, int * LWORK, int *INFO)
+  {
+    F77FUNC(zgeqrf)(M, N, A, LDA, TAU, WORK, LWORK, INFO);
+  }
+
+  // xxxGQR specialisations
+  template<> void xxxgqr(int * M, int * N, int * K, real8 * A, int * LDA, real8 * TAU, real8 * WORK, int * LWORK, int * INFO)
+  {
+    F77FUNC(dorgqr)(M, N, K, A, LDA, TAU, WORK, LWORK, INFO);
+  }
+  template<> void xxxgqr(int * M, int * N, int * K, complex16 * A, int * LDA, complex16 * TAU, complex16 * WORK, int * LWORK, int * INFO)
+  {
+    F77FUNC(zungqr)(M, N, K, A, LDA, TAU, WORK, LWORK, INFO);
+  }
 }
 
 // f77 constants
@@ -168,6 +231,7 @@ char *      L     = &detail::L;
 char *      U     = &detail::U;
 char *      D     = &detail::D;
 char *      O     = &detail::O;
+char *      V     = &detail::V;
 char *      ONE   = &detail::ONE;
 int4 *       ione  = &detail::ione;
 int4 *       izero  = &detail::izero;
@@ -229,33 +293,27 @@ template real8 xnrm2<complex16>(int4 * N, complex16 * X, int4 * INCX);
 template<>  void xgesvd(char * JOBU, char * JOBVT, int4 * M, int4 * N, real8 * A, int4 * LDA, real8 * S, real8 * U, int4 * LDU, real8 * VT, int4 * LDVT, int4 * INFO)
 {
   set_xerbla_death_switch(lapack::izero);
-  real8 * tmp = new real8[1]; // buffer, alloc slot of 1 needed as the work space dimension is written here.
-  int4 lwork = -1; // set for query
-  real8 * WORK = tmp; // set properly after query
+
+  real8 tmp;
+  int lwork = -1; // set for query
 
   // work space query
-  F77FUNC(dgesvd)(JOBU, JOBVT, M, N, A, LDA, S, U, LDU, VT, LDVT, WORK, &lwork, INFO);
+  F77FUNC(dgesvd)(JOBU, JOBVT, M, N, A, LDA, S, U, LDU, VT, LDVT, &tmp, &lwork, INFO);
 
   if(*INFO < 0)
   {
-    delete [] tmp;
-    stringstream message;
+    std::stringstream message;
     message << "Input to LAPACK::dgesvd call incorrect at arg: " << *INFO;
-    message << std::endl << "LDVT is " << *LDVT;
-    cout << message.str();
     throw rdag_error(message.str());
   }
 
-  // query complete WORK[0] contains size needed
-  lwork = (int4)WORK[0];
-  WORK = new real8[lwork]();
+  // query complete tmp contains size needed
+  lwork = (int)tmp;
+  std::unique_ptr<real8[]> workPtr(new real8[lwork]());
+  real8 * WORK = workPtr.get();
 
   // full execution
   F77FUNC(dgesvd)(JOBU, JOBVT, M, N, A, LDA, S, U, LDU, VT, LDVT, WORK, &lwork, INFO);
-
-  // clean up
-  delete [] tmp;
-  delete [] WORK;
 
   if(*INFO!=0)
   {
@@ -266,36 +324,31 @@ template<>  void xgesvd(char * JOBU, char * JOBVT, int4 * M, int4 * N, real8 * A
 template<>  void xgesvd(char * JOBU, char * JOBVT, int4 * M, int4 * N, complex16 * A, int4 * LDA, real8 * S, complex16 * U, int4 * LDU, complex16 * VT, int4 * LDVT, int4 * INFO)
 {
   set_xerbla_death_switch(lapack::izero);
-  int4 minmn = *M > *N ? *N : *M; // compute scale for RWORK
-  complex16 * tmp = new complex16[1]; // buffer, alloc slot of 1 needed as the work space dimension is written here.
-  int4 lwork = -1; // set for query
-  real8    * RWORK = nullptr;
-  complex16 * WORK = tmp; // set properly after query
+
+  int minmn = *M > *N ? *N : *M; // compute scale for RWORK
+  complex16 tmp;
+  int lwork = -1; // set for query
+  real8 * RWORK = nullptr;
 
   // work space query
-  F77FUNC(zgesvd)(JOBU, JOBVT, M, N, A, LDA, S, U, LDU, VT, LDVT, WORK, &lwork, RWORK, INFO);
+  F77FUNC(zgesvd)(JOBU, JOBVT, M, N, A, LDA, S, U, LDU, VT, LDVT, &tmp, &lwork, RWORK, INFO);
   if(*INFO < 0)
   {
-    delete [] tmp;
-    stringstream message;
+    std::stringstream message;
     message << "Input to LAPACK::zgesvd call incorrect at arg: " << *INFO;
-    message << std::endl << "LDVT is " << *LDVT;
-    cout << message.str();
     throw rdag_error(message.str());
   }
 
-  // query complete WORK[0] contains size needed
-  lwork = (int4)(WORK[0].real());
-  WORK = new complex16[lwork];
-  RWORK = new real8[5*minmn];
+  // query complete tmp contains size needed
+  lwork = (int)(tmp.real());
+
+  std::unique_ptr<complex16[]> workPtr(new complex16[lwork]);
+  complex16 * WORK = workPtr.get();
+  std::unique_ptr<real8[]> rworkPtr(new real8[5*minmn]);
+  RWORK = rworkPtr.get();
 
   // full execution
   F77FUNC(zgesvd)(JOBU, JOBVT, M, N, A, LDA, S, U, LDU, VT, LDVT, WORK, &lwork, RWORK, INFO);
-
-  // clean up
-  delete [] tmp;
-  delete [] WORK;
-  delete [] RWORK;
 
   if(*INFO!=0)
   {
@@ -309,7 +362,7 @@ template<typename T> void xgetrf(int4 * M, int4 * N, T * A, int4 * LDA, int4 * I
   detail::xgetrf(M,N,A,LDA,IPIV,INFO);
   if(*INFO!=0)
   {
-    stringstream message;
+    std::stringstream message;
     if(*INFO<0)
     {
       message << "Input to LAPACK::xgetrf call incorrect at arg: " << *INFO << ".";
@@ -334,24 +387,23 @@ template<typename T> void xgetri(int4 * N, T * A, int4 * LDA, int4 * IPIV, int4 
   detail::xgetri(N, A, LDA, IPIV, &worktmp, &lwork, INFO);
   if(*INFO<0)
   {
-    stringstream message;
+    std::stringstream message;
     message << "Input to LAPACK::xgetri call incorrect at arg: " << *INFO;
     throw rdag_error(message.str());
   }
   // else { continue }. NOTE: Workspace query doesn't care about validity of inversion,
   // will check on true call below.
 
-
   // Allocate work space based on queried value
-  lwork = (int4)std::real(worktmp);
-  T * work = new T[lwork];
+  lwork = (int)std::real(worktmp);
+  std::unique_ptr<T[]> workPtr (new T[lwork]);
+  T * work = workPtr.get();
 
   // the actual call
   detail::xgetri(N, A, LDA, IPIV, work, &lwork, INFO);
   if(*INFO!=0)
   {
-    stringstream message;
-    delete [] work;
+    std::stringstream message;
     if(*INFO<0)
     {
       message << "Input to LAPACK::xgetri call incorrect at arg: " << *INFO << ".";
@@ -363,9 +415,6 @@ template<typename T> void xgetri(int4 * N, T * A, int4 * LDA, int4 * IPIV, int4 
     throw rdag_error(message.str());
   }
 
-
-  // normal return
-  delete [] work;
 }
 template void xgetri<real8>(int4 * N, real8 * A, int4 * LDA, int4 * IPIV, int4 * INFO);
 template void xgetri<complex16>(int4 * N, complex16 * A, int4 * LDA, int4 * IPIV, int4 * INFO);
@@ -374,20 +423,22 @@ template void xgetri<complex16>(int4 * N, complex16 * A, int4 * LDA, int4 * IPIV
 template<> void xtrcon(char * NORM, char * UPLO, char * DIAG, int4 * N, real8 * A, int4 * LDA, real8 * RCOND, int4 * INFO)
 {
   set_xerbla_death_switch(lapack::izero);
-  if(*N<0)
+  if(*N<=0)
   {
-    stringstream message;
+    std::stringstream message;
     message << "Input to LAPACK::dtrcon call incorrect at arg: " << 4;
     throw rdag_error(message.str());
   }
-  real8 * WORK = new real8[ 3 * *N];
-  int4 * IWORK = new int4[*N];
+
+  std::unique_ptr<real8[]> workPtr (new real8[ 3 * *N]);
+  real8 * WORK = workPtr.get();
+  std::unique_ptr<int[]> iworkPtr (new int[*N]);
+  int * IWORK = iworkPtr.get();
+
   F77FUNC(dtrcon)(NORM, UPLO, DIAG, N, A, LDA, RCOND, WORK, IWORK, INFO);
-  delete [] WORK;
-  delete [] IWORK;
   if(*INFO!=0)
   {
-      stringstream message;
+      std::stringstream message;
       message << "Input to LAPACK::dtrcon call incorrect at arg: " << *INFO;
       throw rdag_error(message.str());
   }
@@ -399,18 +450,20 @@ template<> void xtrcon(char * NORM, char * UPLO, char * DIAG, int4 * N, complex1
   set_xerbla_death_switch(lapack::izero);
   if(*N<0)
   {
-    stringstream message;
+    std::stringstream message;
     message << "Input to LAPACK::ztrcon call incorrect at arg: " << 4;
     throw rdag_error(message.str());
   }
-  complex16 * WORK = new complex16[ 2 * *N];
-  real8 * RWORK = new real8[*N];
+
+  std::unique_ptr<complex16[]> workPtr (new complex16[ 2 * *N]);
+  complex16 * WORK = workPtr.get();
+  std::unique_ptr<real8[]> rworkPtr (new real8[*N]);
+  real8 * RWORK = rworkPtr.get();
+
   F77FUNC(ztrcon)(NORM, UPLO, DIAG, N, A, LDA, RCOND, WORK, RWORK, INFO);
-  delete [] WORK;
-  delete [] RWORK;
   if(*INFO!=0)
   {
-    stringstream message;
+    std::stringstream message;
     message << "Input to LAPACK::ztrcon call incorrect at arg: " << *INFO;
     throw rdag_error(message.str());
   }
@@ -422,13 +475,13 @@ template<typename T> void xtrtrs(char * UPLO, char * TRANS, char * DIAG, int4 * 
   detail::xtrtrs(UPLO, TRANS, DIAG, N, NRHS, A, LDA, B, LDB, INFO);
   if(*INFO>0)
   {
-    stringstream message;
+    std::stringstream message;
     message << "LAPACK::"<<detail::charmagic<T>()<<"trtrs matrix is reported as being singular, the " << *INFO << "th diagonal is zero. No solutions have been computed.";
     throw rdag_error(message.str());
   }
   if(*INFO!=0)
   {
-    stringstream message;
+    std::stringstream message;
     message << "Input to LAPACK::"<<detail::charmagic<T>()<<"trtrs call incorrect at arg: " << *INFO;
     throw rdag_error(message.str());
   }
@@ -443,13 +496,13 @@ template<typename T> void xpotrf(char * UPLO, int4 * N, T * A, int4 * LDA, int4 
   detail::xpotrf(UPLO, N, A, LDA, INFO);
   if(*INFO>0)
   {
-    stringstream message;
+    std::stringstream message;
     message << "LAPACK::"<<detail::charmagic<T>()<<"potrf matrix is reported as being non s.p.d OR the factorisation failed. The " << *INFO << "th leading minor is not positive definite.";
     throw rdag_error(message.str());
   }
   if(*INFO<0)
   {
-    stringstream message;
+    std::stringstream message;
     message << "Input to LAPACK::"<<detail::charmagic<T>()<<"potrf call incorrect at arg: " << *INFO;
     throw rdag_error(message.str());
   }
@@ -461,20 +514,22 @@ template void xpotrf<complex16>(char * UPLO, int4 * N, complex16 * A, int4 * LDA
 template<> void xpocon(char * UPLO, int4 * N, real8 * A, int4 * LDA, real8 * ANORM, real8 * RCOND, int4 * INFO)
 {
   set_xerbla_death_switch(lapack::izero);
-  if(*N<0)
+  if(*N<=0)
   {
-    stringstream message;
+    std::stringstream message;
     message << "Input to LAPACK::dpocon call incorrect at arg: " << 2;
     throw rdag_error(message.str());
   }
-  real8 * WORK = new real8[3 * (*N)];
-  int4 * IWORK = new int4[(*N)];
+
+  std::unique_ptr<real8[]> workPtr (new real8[3 * (*N)]);
+  real8 * WORK = workPtr.get();
+  std::unique_ptr<int[]> iworkPtr (new int[(*N)]);
+  int * IWORK = iworkPtr.get();
+
   F77FUNC(dpocon)(UPLO, N, A, LDA, ANORM, RCOND, WORK, IWORK, INFO);
-  delete [] WORK;
-  delete [] IWORK;
   if(*INFO<0)
   {
-    stringstream message;
+    std::stringstream message;
     message << "Input to LAPACK::dpocon call incorrect at arg: " << *INFO;
     throw rdag_error(message.str());
   }
@@ -483,20 +538,22 @@ template<> void xpocon(char * UPLO, int4 * N, real8 * A, int4 * LDA, real8 * ANO
 template<> void xpocon(char * UPLO, int4 * N, complex16 * A, int4 * LDA, real8 * ANORM, real8 * RCOND, int4 * INFO)
 {
   set_xerbla_death_switch(lapack::izero);
-  if(*N<0)
+  if(*N<=0)
   {
-    stringstream message;
+    std::stringstream message;
     message << "Input to LAPACK::zpocon call incorrect at arg: " << 2;
     throw rdag_error(message.str());
   }
-  complex16 * WORK = new complex16[2 * *N];
-  real8 * RWORK = new real8[*N];
+
+  std::unique_ptr<complex16[]> workPtr (new complex16[2 * *N]);
+  complex16 * WORK = workPtr.get();
+  std::unique_ptr<real8[]> rworkPtr (new real8[*N]);
+  real8 * RWORK = rworkPtr.get();
+
   F77FUNC(zpocon)(UPLO, N, A, LDA, ANORM, RCOND, WORK, RWORK, INFO);
-  delete [] WORK;
-  delete [] RWORK;
   if(*INFO<0)
   {
-    stringstream message;
+    std::stringstream message;
     message << "Input to LAPACK::dpocon call incorrect at arg: " << *INFO;
     throw rdag_error(message.str());
   }
@@ -505,15 +562,17 @@ template<> void xpocon(char * UPLO, int4 * N, complex16 * A, int4 * LDA, real8 *
 template<typename T>real8 xlansy(char * NORM, char * UPLO, int4 * N, T * A, int4 * LDA)
 {
   set_xerbla_death_switch(lapack::izero);
-  if(*N<0)
+  if(*N<=0)
   {
-    stringstream message;
+    std::stringstream message;
     message << "Input to LAPACK::"<<detail::charmagic<T>()<<"lansy call incorrect at arg: " << 3;
     throw rdag_error(message.str());
   }
-  real8 * WORK = new real8[*N]; // allocate regardless of *NORM
+
+  std::unique_ptr<real8[]> workPtr (new real8[*N]);// allocate regardless of *NORM
+  real8 * WORK = workPtr.get();
   real8 ret = detail::xlansy(NORM, UPLO, N, A, LDA, WORK);
-  delete [] WORK;
+
   return ret;
 }
 template real8 xlansy<real8>(char * NORM, char * UPLO, int4 * N, real8 * A, int4 * LDA);
@@ -522,9 +581,11 @@ template real8  xlansy<complex16>(char * NORM, char * UPLO, int4 * N, complex16 
 real8 zlanhe(char * NORM, char * UPLO, int4 * N, complex16 * A, int4 * LDA)
 {
   set_xerbla_death_switch(lapack::izero);
-  real8 * WORK = new real8[*N]; // allocate regardless of *NORM
+
+  std::unique_ptr<real8[]> workPtr (new real8[*N]);// allocate regardless of *NORM
+  real8 * WORK = workPtr.get();
   real8 ret = F77FUNC(zlanhe)(NORM, UPLO, N, A, LDA, WORK);
-  delete [] WORK;
+
   return ret;
 }
 
@@ -535,7 +596,7 @@ template<typename T> void xpotrs(char * UPLO, int4 * N, int4 * NRHS, T * A, int4
   detail::xpotrs(UPLO, N, NRHS, A, LDA, B, LDB, INFO);
   if(*INFO<0)
   {
-    stringstream message;
+    std::stringstream message;
     message << "Input to LAPACK::"<<detail::charmagic<T>()<<"potrs call incorrect at arg: " << *INFO;
     throw rdag_error(message.str());
   }
@@ -543,5 +604,390 @@ template<typename T> void xpotrs(char * UPLO, int4 * N, int4 * NRHS, T * A, int4
 template void xpotrs<real8>(char * UPLO, int4 * N, int4 * NRHS, real8 * A, int4 * LDA, real8 * B, int4 * LDB, int4 * INFO);
 template void xpotrs<complex16>(char * UPLO, int4 * N, int4 * NRHS, complex16 * A, int4 * LDA, complex16 * B, int4 * LDB, int4 * INFO);
 
+
+template<typename T> real8 xlange(char * NORM, int * M, int * N, T * A, int * LDA)
+{
+  set_xerbla_death_switch(lapack::izero);
+  if(*M<=0)
+  {
+    std::stringstream message;
+    message << "Input to LAPACK::"<<detail::charmagic<T>()<<"lange call incorrect at arg: " << 2;
+    throw rdag_error(message.str());
+  }
+  std::unique_ptr<real8[]> workPtr (new real8[*M]);// allocate regardless of *NORM
+  real8 * WORK = workPtr.get();
+  real8 ret = detail::xlange(NORM, M, N, A, LDA, WORK);
+  return ret;
+}
+template real8 xlange<real8>(char * NORM, int * M, int * N, real8 * A, int * LDA);
+template real8 xlange<complex16>(char * NORM, int * M, int * N, complex16 * A, int * LDA);
+
+
+template<> void xgecon(char * NORM, int * N, real8 * A, int * LDA, real8 * ANORM, real8 * RCOND, int * INFO)
+{
+  set_xerbla_death_switch(lapack::izero);
+  if(*N<=0)
+  {
+    std::stringstream message;
+    message << "Input to LAPACK::dgecon call incorrect at arg: " << 2;
+    throw rdag_error(message.str());
+  }
+
+  std::unique_ptr<real8[]> workPtr (new real8[4*(*N)]);
+  real8 * WORK = workPtr.get();
+  std::unique_ptr<int[]> iworkPtr (new int[*N]);
+  int * IWORK = iworkPtr.get();
+  F77FUNC(dgecon)(NORM, N, A, LDA, ANORM, RCOND, WORK, IWORK, INFO);
+
+  if(*INFO<0)
+  {
+    std::stringstream message;
+    message << "Input to LAPACK::dgecon call incorrect at arg: " << *INFO;
+    throw rdag_error(message.str());
+  }
+}
+
+template<> void xgecon(char * NORM, int * N, complex16 * A, int * LDA, real8 * ANORM, real8 * RCOND, int * INFO)
+{
+  set_xerbla_death_switch(lapack::izero);
+  if(*N<=0)
+  {
+    std::stringstream message;
+    message << "Input to LAPACK::zgecon call incorrect at arg: " << 2;
+    throw rdag_error(message.str());
+  }
+
+  std::unique_ptr<complex16[]> workPtr (new complex16[2*(*N)]);
+  complex16 * WORK = workPtr.get();
+  std::unique_ptr<real8[]> rworkPtr (new real8[2*(*N)]);
+  real8 * RWORK = rworkPtr.get();
+
+  F77FUNC(zgecon)(NORM, N, A, LDA, ANORM, RCOND, WORK, RWORK, INFO);
+
+  if(*INFO<0)
+  {
+    std::stringstream message;
+    message << "Input to LAPACK::zgecon call incorrect at arg: " << *INFO;
+    throw rdag_error(message.str());
+  }
+}
+
+
+template<typename T> void xgetrs(char * TRANS, int * N, int * NRHS, T * A, int * LDA, int * IPIV, T * B, int * LDB, int * INFO)
+{
+  set_xerbla_death_switch(lapack::izero);
+  detail::xgetrs(TRANS, N, NRHS, A, LDA, IPIV, B, LDB, INFO);
+  if(*INFO<0)
+  {
+    std::stringstream message;
+    message << "Input to LAPACK::"<<detail::charmagic<T>()<<"getrs call incorrect at arg: " << *INFO;
+    throw rdag_error(message.str());
+  }
+}
+template void xgetrs<real8>(char * TRANS, int * N, int * NRHS, real8 * A, int * LDA, int * IPIV, real8 * B, int * LDB, int * INFO);
+template void xgetrs<complex16>(char * TRANS, int * N, int * NRHS, complex16 * A, int * LDA, int * IPIV, complex16 * B, int * LDB, int * INFO);
+
+
+template<typename T> void xgels(char * TRANS, int * M, int * N, int * NRHS, T * A, int * LDA, T * B, int * LDB, int * INFO )
+{
+  set_xerbla_death_switch(lapack::izero);
+  T worktmp;
+  int lwork = -1; // -1 to trigger size query
+
+  // Workspace size query
+  detail::xgels(TRANS, M, N, NRHS, A, LDA, B, LDB, &worktmp, &lwork, INFO);
+  if(*INFO<0)
+  {
+    std::stringstream message;
+    message << "Input to LAPACK::xgels call incorrect at arg: " << *INFO;
+    throw rdag_error(message.str());
+  }
+  // else { continue }. NOTE: Workspace query doesn't care about validity of solution,
+  // will check on true call below.
+
+  // Allocate work space based on queried value
+  lwork = (int)std::real(worktmp);
+  std::unique_ptr<T[]> workPtr (new T[lwork]);
+  T * work = workPtr.get();
+
+  // the actual call
+  detail::xgels(TRANS, M, N, NRHS, A, LDA, B, LDB, work, &lwork, INFO);
+  if(*INFO!=0)
+  {
+    std::stringstream message;
+    if(*INFO<0)
+    {
+      message << "Input to LAPACK::xgels call incorrect at arg: " << *INFO << ".";
+    }
+    else
+    {
+      message << "LAPACK::xgels, the [" << (*INFO - 1) << " element of the triangular " <<
+      "factorisation of A is zero, A does not have full rank, the least squares solution " <<
+      "could not be computed";
+    }
+    throw rdag_error(message.str());
+  }
+  // normal return
+}
+template void xgels<real8>(char * TRANS, int * M, int * N, int * NRHS, real8 * A, int * LDA, real8 * B, int * LDB, int * INFO );
+template void xgels<complex16>(char * TRANS, int * M, int * N, int * NRHS, complex16 * A, int * LDA, complex16 * B, int * LDB, int * INFO );
+
+
+template<> void xgelsd(int * M, int * N, int * NRHS, real8 * A, int * LDA, real8 * B, int * LDB, real8 * S, real8 * RCOND, int * RANK, int * INFO )
+{
+  set_xerbla_death_switch(lapack::izero);
+  real8 worktmp;
+  int iworktmp;
+  int lwork = -1; // -1 to trigger size query
+
+  // Workspace size query
+  F77FUNC(dgelsd)(M, N, NRHS, A, LDA, B, LDB, S, RCOND, RANK, &worktmp, &lwork, &iworktmp, INFO);
+  if(*INFO<0)
+  {
+    std::stringstream message;
+    message << "Input to LAPACK::dgelsd call incorrect at arg: " << *INFO;
+    throw rdag_error(message.str());
+  }
+  // else { continue }. NOTE: Workspace query doesn't care about validity of solution,
+  // will check on true call below.
+
+  // Allocate work space based on queried value
+  lwork = (int)(worktmp);
+
+  std::unique_ptr<real8[]> workPtr (new real8[lwork]);
+  real8 * work = workPtr.get();
+
+  std::unique_ptr<int[]> iworkPtr (new int[iworktmp]);
+  int * iwork = iworkPtr.get();
+
+  // the actual call
+  F77FUNC(dgelsd)(M, N, NRHS, A, LDA, B, LDB, S, RCOND, RANK, work, &lwork, iwork, INFO);
+
+  if(*INFO!=0)
+  {
+    std::stringstream message;
+    if(*INFO<0)
+    {
+      message << "Input to LAPACK::dgelsd call incorrect at arg: " << *INFO << ".";
+    }
+    else
+    {
+      message << "LAPACK::dgelsd, SVD computation failed to converge, " << (*INFO) <<
+      " elements of the intermediate bi-diagonal form did not converge to zero.";
+    }
+    throw rdag_error(message.str());
+  }
+
+}
+
+
+template<> void xgelsd(int * M, int * N, int * NRHS, complex16 * A, int * LDA, complex16 * B, int * LDB, real8 * S, real8 * RCOND, int * RANK, int * INFO )
+{
+  set_xerbla_death_switch(lapack::izero);
+  complex16 worktmp;
+  real8 rworktmp;
+  int iworktmp;
+  int lwork = -1; // -1 to trigger size query
+
+  // Workspace size query
+  F77FUNC(zgelsd)(M, N, NRHS, A, LDA, B, LDB, S, RCOND, RANK, &worktmp, &lwork, &rworktmp, &iworktmp, INFO);
+  if(*INFO<0)
+  {
+    std::stringstream message;
+    message << "Input to LAPACK::zgelsd call incorrect at arg: " << *INFO;
+    throw rdag_error(message.str());
+  }
+  // else { continue }. NOTE: Workspace query doesn't care about validity of solution,
+  // will check on true call below.
+
+  // Allocate work space based on queried value
+  lwork = (int)std::real(worktmp);
+
+  std::unique_ptr<complex16[]> workPtr (new complex16[lwork]);
+  std::unique_ptr<real8[]> rworkPtr (new real8[(int)(rworktmp)]);
+  std::unique_ptr<int[]> iworkPtr (new int[iworktmp]);
+
+  complex16 * work = workPtr.get();
+  real8 * rwork = rworkPtr.get();
+  int * iwork = iworkPtr.get();
+
+  // the actual call
+  F77FUNC(zgelsd)(M, N, NRHS, A, LDA, B, LDB, S, RCOND, RANK, work, &lwork, rwork, iwork, INFO);
+
+  if(*INFO!=0)
+  {
+    std::stringstream message;
+    if(*INFO<0)
+    {
+      message << "Input to LAPACK::zgelsd call incorrect at arg: " << *INFO << ".";
+    }
+    else
+    {
+      message << "LAPACK::zgelsd, SVD computation failed to converge, " << (*INFO) <<
+      " elements of the intermediate bi-diagonal form did not converge to zero.";
+    }
+    throw rdag_error(message.str());
+  }
+
+}
+
+
+template<> void xgeev(char * JOBVL, char * JOBVR, int * N, real8 * A, int * LDA, complex16 * W, real8 * VL, int * LDVL, real8 * VR, int * LDVR, int * INFO)
+{
+  set_xerbla_death_switch(lapack::izero);
+  real8 worktmp;
+  int lwork = -1; // -1 to trigger size query
+
+  real8 * WR = nullptr;
+  real8 * WI = nullptr;
+
+  // Workspace size query
+  F77FUNC(dgeev)(JOBVL, JOBVR, N, A, LDA, WR, WI, VL, LDVL, VR, LDVR, &worktmp, &lwork, INFO);
+  if(*INFO<0)
+  {
+    std::stringstream message;
+    message << "Input to LAPACK::dgeev call incorrect at arg: " << *INFO;
+    throw rdag_error(message.str());
+  }
+
+  std::unique_ptr<real8 []> ptrWR (new real8[*N]);
+  WR = ptrWR.get();
+  std::unique_ptr<real8 []> ptrWI (new real8[*N]);
+  WI = ptrWI.get();
+
+    // Allocate work space based on queried value
+  lwork = (int)(worktmp);
+  std::unique_ptr<real8 []> ptrWORK (new real8[lwork]);
+  real8 * work = ptrWORK.get();
+
+  // the actual call
+  F77FUNC(dgeev)(JOBVL, JOBVR, N, A, LDA, WR, WI, VL, LDVL, VR, LDVR, work, &lwork, INFO);
+
+  // copy back answer
+  for(int i = 0 ; i < *N; i++)
+  {
+    W[i] = std::complex<real8>(WR[i],WI[i]);
+  }
+
+  if(*INFO!=0)
+  {
+    std::stringstream message;
+    if(*INFO<0)
+    {
+      message << "Input to LAPACK::dgeev call incorrect at arg: " << *INFO << ".";
+    }
+    else
+    {
+      message << "LAPACK::dgeev, QR alg failed. Eigenvalues in elements, " << (*INFO - 1) <<
+      ":" << (*N-1) << " have successfully converged, no eigenvectors have been computed.";
+    }
+    throw rdag_error(message.str());
+  }
+}
+
+
+template<> void xgeev(char * JOBVL, char * JOBVR, int * N, complex16 * A, int * LDA, complex16 * W, complex16 * VL, int * LDVL, complex16 * VR, int * LDVR, int * INFO)
+{
+  set_xerbla_death_switch(lapack::izero);
+  complex16 worktmp;
+  real8 * rwork = nullptr;
+  int lwork = -1; // -1 to trigger size query
+
+  // Workspace size query
+  F77FUNC(zgeev)(JOBVL, JOBVR, N, A, LDA, W, VL, LDVL, VR, LDVR, &worktmp, &lwork, rwork, INFO);
+
+  if(*INFO<0)
+  {
+    std::stringstream message;
+    message << "Input to LAPACK::zgeev call incorrect at arg: " << *INFO;
+    throw rdag_error(message.str());
+  }
+
+    // Allocate work space based on queried value
+  lwork = (int)std::real(worktmp);
+  std::unique_ptr<complex16 []> workPtr (new complex16[lwork]);
+  complex16 * work = workPtr.get();
+  std::unique_ptr<real8 []> rworkPtr (new real8[2 * (*N)]);
+  rwork = rworkPtr.get();
+
+  // the actual call
+  F77FUNC(zgeev)(JOBVL, JOBVR, N, A, LDA, W, VL, LDVL, VR, LDVR, work, &lwork, rwork, INFO);
+
+  if(*INFO!=0)
+  {
+    std::stringstream message;
+    if(*INFO<0)
+    {
+      message << "Input to LAPACK::zgeev call incorrect at arg: " << *INFO << ".";
+    }
+    else
+    {
+      message << "LAPACK::zgeev, QR alg failed. Eigenvalues in elements, " << (*INFO - 1) <<
+      ":" << (*N-1) << " have successfully converged, no eigenvectors have been computed.";
+    }
+    throw rdag_error(message.str());
+  }
+}
+
+
+template<typename T> void xgeqrf(int * M, int * N, T * A, int * LDA, T * TAU, int *INFO)
+{
+  set_xerbla_death_switch(lapack::izero);
+  T worktmp;
+  int lwork = -1; // -1 to trigger size query
+
+  detail::xgeqrf(M, N, A, LDA, TAU, &worktmp, &lwork, INFO );
+
+  if(*INFO<0)
+  {
+    std::stringstream message;
+    message << "Input to LAPACK::" << detail::charmagic<T>() << "geqrf call incorrect at arg: "  << *INFO;
+    throw rdag_error(message.str());
+  }
+
+  lwork = (int)std::real(worktmp);
+  std::unique_ptr<T[]> workPtr (new T[lwork]);
+  T * work = workPtr.get();
+
+  detail::xgeqrf(M, N, A, LDA, TAU, work, &lwork, INFO );
+  if(*INFO<0)
+  {
+    std::stringstream message;
+    message << "Input to LAPACK::" << detail::charmagic<T>() << "geqrf call incorrect at arg: "  << *INFO;
+    throw rdag_error(message.str());
+  }
+}
+template void xgeqrf<real8>(int * M, int * N, real8 * A, int * LDA, real8 * TAU, int *INFO);
+template void xgeqrf<complex16>(int * M, int * N, complex16 * A, int * LDA, complex16 * TAU, int *INFO);
+
+template<typename T>void xxxgqr(int * M, int * N, int * K, T * A, int * LDA, T * TAU, int * INFO)
+{
+  set_xerbla_death_switch(lapack::izero);
+  T worktmp;
+  int lwork = -1; // -1 to trigger size query
+
+  detail::xxxgqr(M, N, K, A, LDA, TAU, &worktmp, &lwork, INFO);
+
+  if(*INFO<0)
+  {
+    std::stringstream message;
+    message << "Input to LAPACK::" << detail::xxxgqrcharmagic<T>() << "gqr call incorrect at arg: "  << *INFO;
+    throw rdag_error(message.str());
+  }
+
+  lwork = (int)std::real(worktmp);
+  std::unique_ptr<T[]> workPtr (new T[lwork]);
+  T * work = workPtr.get();
+
+  detail::xxxgqr(M, N, K, A, LDA, TAU, work, &lwork, INFO);
+  if(*INFO<0)
+  {
+    std::stringstream message;
+    message << "Input to LAPACK::" << detail::xxxgqrcharmagic<T>() << "gqr call incorrect at arg: "  << *INFO;
+    throw rdag_error(message.str());
+  }
+}
+template void xxxgqr<real8>(int * M, int * N, int * K, real8 * A, int * LDA, real8 * TAU, int * INFO);
+template void xxxgqr<complex16>(int * M, int * N, int * K, complex16 * A, int * LDA, complex16 * TAU, int * INFO);
 
 } // end namespace lapack

--- a/src/librdag/test/check_lapack.cc
+++ b/src/librdag/test/check_lapack.cc
@@ -749,7 +749,7 @@ TEST(LAPACKTest_xlange, dlange) {
   real8 * A = new real8[16];
   std::copy(rspd,rspd+n*n,A);
   real8 answer = lapack::xlange(lapack::O, &n, &n, A, &n);
-  EXPECT_TRUE(answer == 79);
+  EXPECT_TRUE(SingleValueFuzzyEquals(answer, 79.e0));
   // check throw on bad arg
   n=-1;
   EXPECT_THROW(lapack::xlange(lapack::O, &n, &n, A, &n), rdag_error);
@@ -780,7 +780,7 @@ TEST(LAPACKTest_xgecon, dgecon) {
   // need a 1 norm
   real8 anorm = lapack::xlange(lapack::O, &m, &n, Acpy, &m);
   // check it
-  EXPECT_TRUE(anorm==82.e0);
+  EXPECT_TRUE(SingleValueFuzzyEquals(anorm, 82.e0));
 
   // need a LU decomp
   int4 * ipiv = new int4[minmn]();
@@ -1012,7 +1012,7 @@ TEST(LAPACKTest_xgelsd, dgelsd) {
 
   EXPECT_TRUE(ArrayFuzzyEquals(expected_S,S,minmn,1e-13,1e-13));
 
-  EXPECT_TRUE(RANK==n);
+  EXPECT_EQ(RANK, n);
 
   // xerbla test
   n=-1;
@@ -1060,7 +1060,7 @@ TEST(LAPACKTest_xgelsd, zgelsd) {
 
   EXPECT_TRUE(ArrayFuzzyEquals(expected_S,S,minmn,1e-13,1e-13));
 
-  EXPECT_TRUE(RANK==n);
+  EXPECT_EQ(RANK, n);
 
   // xerbla test
   n=-1;

--- a/src/librdag/test/check_lapack.cc
+++ b/src/librdag/test/check_lapack.cc
@@ -745,7 +745,7 @@ TEST(LAPACKTest_xpotrs, zpotrs) {
 
 
 TEST(LAPACKTest_xlange, dlange) {
-  int n = 4;
+  int4 n = 4;
   real8 * A = new real8[16];
   std::copy(rspd,rspd+n*n,A);
   real8 answer = lapack::xlange(lapack::O, &n, &n, A, &n);
@@ -757,7 +757,7 @@ TEST(LAPACKTest_xlange, dlange) {
 }
 
 TEST(LAPACKTest_xlange, zlange) {
-  int n = 4;
+  int4 n = 4;
   complex16 * A = new complex16[16];
   std::copy(cspd,cspd+n*n,A);
   real8 answer = lapack::xlange(lapack::O, &n, &n, A, &n);
@@ -769,10 +769,10 @@ TEST(LAPACKTest_xlange, zlange) {
 }
 
 TEST(LAPACKTest_xgecon, dgecon) {
-  int m = 5;
-  int n = 4;
-  const int minmn = m > n ? n : m;
-  int INFO = 0;
+  int4 m = 5;
+  int4 n = 4;
+  const int4 minmn = m > n ? n : m;
+  int4 INFO = 0;
 
   real8 * Acpy = new real8[20];
   std::copy(rcondok5x4,rcondok5x4+m*n,Acpy);
@@ -783,7 +783,7 @@ TEST(LAPACKTest_xgecon, dgecon) {
   EXPECT_TRUE(anorm==82.e0);
 
   // need a LU decomp
-  int * ipiv = new int[minmn]();
+  int4 * ipiv = new int4[minmn]();
   lapack::xgetrf(&m,&n,Acpy,&m,ipiv,&INFO);
 
   // make the call
@@ -805,10 +805,10 @@ TEST(LAPACKTest_xgecon, dgecon) {
 
 
 TEST(LAPACKTest_xgecon, zgecon) {
-  int m = 5;
-  int n = 4;
-  const int minmn = m > n ? n : m;
-  int INFO = 0;
+  int4 m = 5;
+  int4 n = 4;
+  const int4 minmn = m > n ? n : m;
+  int4 INFO = 0;
 
   complex16 * Acpy = new complex16[20];
   std::copy(ccondok5x4,ccondok5x4+m*n,Acpy);
@@ -820,7 +820,7 @@ TEST(LAPACKTest_xgecon, zgecon) {
   EXPECT_TRUE(SingleValueFuzzyEquals(anorm,183.35757415498276e0));
 
   // need a LU decomp
-  int * ipiv = new int[minmn]();
+  int4 * ipiv = new int4[minmn]();
   lapack::xgetrf(&m,&n,Acpy,&m,ipiv,&INFO);
 
   // make the call
@@ -841,16 +841,16 @@ TEST(LAPACKTest_xgecon, zgecon) {
 
 
 TEST(LAPACKTest_xgetrs, dgetrs) {
-  int m = 5;
-  int n = 4;
-  const int minmn = m > n ? n : m;
-  int INFO = 0;
+  int4 m = 5;
+  int4 n = 4;
+  const int4 minmn = m > n ? n : m;
+  int4 INFO = 0;
 
   real8 * Acpy = new real8[20];
   std::copy(rcondok5x4,rcondok5x4+m*n,Acpy);
 
   // need a LU decomp
-  int * ipiv = new int[minmn]();
+  int4 * ipiv = new int4[minmn]();
   lapack::xgetrf(&m,&n,Acpy,&m,ipiv,&INFO);
 
   // need an RHS
@@ -862,7 +862,7 @@ TEST(LAPACKTest_xgetrs, dgetrs) {
   };
 
   // make the call
-  int two = 2;
+  int4 two = 2;
   lapack::xgetrs(lapack::N, &n, &two, Acpy, &m, ipiv, rhs, &n, &INFO);
 
   EXPECT_TRUE(ArrayFuzzyEquals(expected,rhs,8,1e-14,1e-14));
@@ -879,16 +879,16 @@ TEST(LAPACKTest_xgetrs, dgetrs) {
 }
 
 TEST(LAPACKTest_xgetrs, zgetrs) {
-  int m = 5;
-  int n = 4;
-  const int minmn = m > n ? n : m;
-  int INFO = 0;
+  int4 m = 5;
+  int4 n = 4;
+  const int4 minmn = m > n ? n : m;
+  int4 INFO = 0;
 
   complex16 * Acpy = new complex16[20];
   std::copy(ccondok5x4,ccondok5x4+m*n,Acpy);
 
   // need a LU decomp
-  int * ipiv = new int[minmn]();
+  int4 * ipiv = new int4[minmn]();
   lapack::xgetrf(&m,&n,Acpy,&m,ipiv,&INFO);
 
   // need an RHS
@@ -898,7 +898,7 @@ TEST(LAPACKTest_xgetrs, zgetrs) {
   complex16 * expected = new complex16[8]{{      1.0758441558441547,      -0.6794805194805187}, {     -0.4540259740259733,       0.2867532467532462}, {     -0.0592207792207793,       0.0374025974025975}, {     -0.5625974025974027,       0.3553246753246754}, {      1.0758441558441547,      -0.6794805194805187}, {     -0.4540259740259733,       0.2867532467532462}, {     -0.0592207792207793,       0.0374025974025975}, {     -0.5625974025974027,       0.3553246753246754}};
 
   // make the call
-  int two = 2;
+  int4 two = 2;
   lapack::xgetrs(lapack::N, &n, &two, Acpy, &m, ipiv, rhs, &n, &INFO);
 
   EXPECT_TRUE(ArrayFuzzyEquals(expected,rhs,8,1e-14,1e-14));
@@ -915,9 +915,9 @@ TEST(LAPACKTest_xgetrs, zgetrs) {
 }
 
 TEST(LAPACKTest_xgels, dgels) {
-  int m = 5;
-  int n = 4;
-  int INFO = 0;
+  int4 m = 5;
+  int4 n = 4;
+  int4 INFO = 0;
 
   real8 * Acpy = new real8[20];
   std::copy(rcondok5x4,rcondok5x4+m*n,Acpy);
@@ -929,7 +929,7 @@ TEST(LAPACKTest_xgels, dgels) {
   real8 * expected = new real8[8]{-6.1464892723569555,3.3470608493900018,-0.1305926637544035,0.2247336970641731,-6.1464892723569555,3.3470608493900018,-0.1305926637544035,0.2247336970641731};
 
   // make the call
-  int two = 2;
+  int4 two = 2;
   lapack::xgels(lapack::N, &m, &n, &two, Acpy, &m, rhs, &m, &INFO);
 
   // answers are striped in "n" length columns in RHS
@@ -948,9 +948,9 @@ TEST(LAPACKTest_xgels, dgels) {
 
 
 TEST(LAPACKTest_xgels, zgels) {
-  int m = 5;
-  int n = 4;
-  int INFO = 0;
+  int4 m = 5;
+  int4 n = 4;
+  int4 INFO = 0;
 
   complex16 * Acpy = new complex16[20];
   std::copy(ccondok5x4,ccondok5x4+m*n,Acpy);
@@ -962,7 +962,7 @@ TEST(LAPACKTest_xgels, zgels) {
   complex16 * expected = new complex16[8]{{     23.3566592349563571,     -14.7515742536566901}, {    -12.7188312276819353,       8.0329460385359930}, {      0.4962521222667151,      -0.3134223930105628}, {     -0.8539880488438545,       0.5393608729540187}, {     23.3566592349563571,     -14.7515742536566901}, {    -12.7188312276819353,       8.0329460385359930}, {      0.4962521222667151,      -0.3134223930105628}, {     -0.8539880488438545,       0.5393608729540187}};
 
   // make the call
-  int two = 2;
+  int4 two = 2;
   lapack::xgels(lapack::N, &m, &n, &two, Acpy, &m, rhs, &m, &INFO);
 
   // answers are striped in "n" length columns in RHS
@@ -981,10 +981,10 @@ TEST(LAPACKTest_xgels, zgels) {
 
 
 TEST(LAPACKTest_xgelsd, dgelsd) {
-  int m = 5;
-  int n = 4;
-  int INFO = 0;
-  int minmn = m > n ? n : m;
+  int4 m = 5;
+  int4 n = 4;
+  int4 INFO = 0;
+  int4 minmn = m > n ? n : m;
 
   real8 * Acpy = new real8[20];
   std::copy(rcondok5x4,rcondok5x4+m*n,Acpy);
@@ -1000,10 +1000,10 @@ TEST(LAPACKTest_xgelsd, dgelsd) {
   real8 * S = new real8[minmn];
   // condition and rank
   real8 RCOND = - 1; // -1 so rank is computed wrt machine precision
-  int RANK;
+  int4 RANK;
 
   // make the call
-  int two = 2;
+  int4 two = 2;
   lapack::xgelsd(&m, &n, &two, Acpy, &m, rhs, &m, S, &RCOND, &RANK, &INFO);
 
   // answers are striped in "n" length columns in RHS
@@ -1029,10 +1029,10 @@ TEST(LAPACKTest_xgelsd, dgelsd) {
 
 
 TEST(LAPACKTest_xgelsd, zgelsd) {
-  int m = 5;
-  int n = 4;
-  int INFO = 0;
-  int minmn = m > n ? n : m;
+  int4 m = 5;
+  int4 n = 4;
+  int4 INFO = 0;
+  int4 minmn = m > n ? n : m;
 
   complex16 * Acpy = new complex16[20];
   std::copy(ccondok5x4,ccondok5x4+m*n,Acpy);
@@ -1048,10 +1048,10 @@ TEST(LAPACKTest_xgelsd, zgelsd) {
   real8 * S = new real8[minmn];
   // condition and rank
   real8 RCOND = - 1; // -1 so rank is computed wrt machine precision
-  int RANK;
+  int4 RANK;
 
   // make the call
-  int two = 2;
+  int4 two = 2;
   lapack::xgelsd(&m, &n, &two, Acpy, &m, rhs, &m, S, &RCOND, &RANK, &INFO);
 
   // answers are striped in "n" length columns in RHS
@@ -1076,10 +1076,10 @@ TEST(LAPACKTest_xgelsd, zgelsd) {
 
 
 TEST(LAPACKTest_xgeev, dgeev) {
-  int m = 4;
-  int n = 4;
-  int minmn = m > n ? n : m;
-  int INFO = 0;
+  int4 m = 4;
+  int4 n = 4;
+  int4 minmn = m > n ? n : m;
+  int4 INFO = 0;
 
   real8 * A = new real8[16] {1.,3.,10.,-2.,3.,6.,-1.,-1.,4.,4.,4.,6.,5.,-5.,7.,-10.};
 
@@ -1117,10 +1117,10 @@ TEST(LAPACKTest_xgeev, dgeev) {
 }
 
 TEST(LAPACKTest_xgeev, zgeev) {
-  int m = 4;
-  int n = 4;
-  int minmn = m > n ? n : m;
-  int INFO = 0;
+  int4 m = 4;
+  int4 n = 4;
+  int4 minmn = m > n ? n : m;
+  int4 INFO = 0;
 
   complex16 * A = new complex16[16] {{1.,10.}, {3.,30.}, {10.,100.}, {-2.,-20.}, {3.,30.}, {6.,60.}, {-1.,-10.}, {-1.,-10.}, {4.,40.}, {4.,40.}, {4.,40.}, {6.,60.}, {5.,50.}, {-5.,-50.}, {7.,70.}, {-10.,-100.}};
 
@@ -1160,10 +1160,10 @@ TEST(LAPACKTest_xgeev, zgeev) {
 
 TEST(LAPACKTest_xgeqrf, dgeqrf) {
 
-  int m = 5;
-  int n = 4;
-  int INFO = 0;
-  int minmn = m > n ? n : m;
+  int4 m = 5;
+  int4 n = 4;
+  int4 INFO = 0;
+  int4 minmn = m > n ? n : m;
 
   real8 * TAU = new real8[minmn];
 
@@ -1192,10 +1192,10 @@ TEST(LAPACKTest_xgeqrf, dgeqrf) {
 
 TEST(LAPACKTest_xgeqrf, zgeqrf) {
 
-  int m = 5;
-  int n = 4;
-  int INFO = 0;
-  int minmn = m > n ? n : m;
+  int4 m = 5;
+  int4 n = 4;
+  int4 INFO = 0;
+  int4 minmn = m > n ? n : m;
 
   complex16 * TAU = new complex16[minmn];
 
@@ -1225,10 +1225,10 @@ TEST(LAPACKTest_xgeqrf, zgeqrf) {
 
 TEST(LAPACKTest_xxxgqr, dorgqr) {
 
-  int m = 5;
-  int n = 4;
-  int INFO = 0;
-  int minmn = m > n ? n : m;
+  int4 m = 5;
+  int4 n = 4;
+  int4 INFO = 0;
+  int4 minmn = m > n ? n : m;
 
   real8 * TAU = new real8[minmn];
 
@@ -1241,7 +1241,7 @@ TEST(LAPACKTest_xxxgqr, dorgqr) {
   lapack::xgeqrf(&m, &n, Acpy, &m, TAU, &INFO);
 
   // extract Q from packed form of xgeqrf, scalings are in TAU
-  int k = n;
+  int4 k = n;
   lapack::xxxgqr(&m, &n, &k, Acpy, &m, TAU, &INFO);
 
   EXPECT_TRUE(ArrayFuzzyEquals(expected,Acpy,m*n,1e-13,1e-13));
@@ -1259,10 +1259,10 @@ TEST(LAPACKTest_xxxgqr, dorgqr) {
 
 TEST(LAPACKTest_xxxgqr, zunrgqr) {
 
-  int m = 5;
-  int n = 4;
-  int INFO = 0;
-  int minmn = m > n ? n : m;
+  int4 m = 5;
+  int4 n = 4;
+  int4 INFO = 0;
+  int4 minmn = m > n ? n : m;
 
   complex16 * TAU = new complex16[minmn];
 
@@ -1275,7 +1275,7 @@ TEST(LAPACKTest_xxxgqr, zunrgqr) {
   lapack::xgeqrf(&m, &n, Acpy, &m, TAU, &INFO);
 
   // extract Q from packed form of xgeqrf, scalings are in TAU
-  int k = n;
+  int4 k = n;
   lapack::xxxgqr(&m, &n, &k, Acpy, &m, TAU, &INFO);
 
   EXPECT_TRUE(ArrayFuzzyEquals(expected,Acpy,m*n,1e-13,1e-13));

--- a/src/librdag/test/check_lapack.cc
+++ b/src/librdag/test/check_lapack.cc
@@ -735,7 +735,6 @@ TEST(LAPACKTest_xpotrs, zpotrs) {
   lapack::xpotrs(lapack::U, &n, lapack::ione, A, &n, RHS, &n, &INFO);
   complex16 expected[4] =  {{-1.0063762794655238,-1.5989977364878503}, {0.8869421128000980,0.5966984611395660}, {-0.1560914405265542,0.1826679640758723}, {-0.0562376225820731,0.1501070660620698}};
   EXPECT_TRUE(ArrayFuzzyEquals(expected,RHS,n, 1e-14, 1e-14));
-  cout << RHS[0] << " " << RHS[1] << " " << RHS[2] << " " << RHS[3] << std::endl;
   // check throw on bad arg
   n=-1;
   EXPECT_THROW(lapack::xpotrs(lapack::U, &n, lapack::ione, A, &n, RHS, &n, &INFO), rdag_error);
@@ -743,3 +742,550 @@ TEST(LAPACKTest_xpotrs, zpotrs) {
   delete [] A;
   delete [] RHS;
 }
+
+
+TEST(LAPACKTest_xlange, dlange) {
+  int n = 4;
+  real8 * A = new real8[16];
+  std::copy(rspd,rspd+n*n,A);
+  real8 answer = lapack::xlange(lapack::O, &n, &n, A, &n);
+  EXPECT_TRUE(answer == 79);
+  // check throw on bad arg
+  n=-1;
+  EXPECT_THROW(lapack::xlange(lapack::O, &n, &n, A, &n), rdag_error);
+  delete[] A;
+}
+
+TEST(LAPACKTest_xlange, zlange) {
+  int n = 4;
+  complex16 * A = new complex16[16];
+  std::copy(cspd,cspd+n*n,A);
+  real8 answer = lapack::xlange(lapack::O, &n, &n, A, &n);
+  EXPECT_TRUE(SingleValueFuzzyEquals(answer,792.493781056045));
+  // check throw on bad arg
+  n=-1;
+  EXPECT_THROW(lapack::xlange(lapack::O, &n, &n, A, &n), rdag_error);
+  delete[] A;
+}
+
+TEST(LAPACKTest_xgecon, dgecon) {
+  int m = 5;
+  int n = 4;
+  const int minmn = m > n ? n : m;
+  int INFO = 0;
+
+  real8 * Acpy = new real8[20];
+  std::copy(rcondok5x4,rcondok5x4+m*n,Acpy);
+
+  // need a 1 norm
+  real8 anorm = lapack::xlange(lapack::O, &m, &n, Acpy, &m);
+  // check it
+  EXPECT_TRUE(anorm==82.e0);
+
+  // need a LU decomp
+  int * ipiv = new int[minmn]();
+  lapack::xgetrf(&m,&n,Acpy,&m,ipiv,&INFO);
+
+  // make the call
+  real8 rcond = 0;
+  lapack::xgecon(lapack::O, &n, Acpy, &m, &anorm, &rcond, &INFO);
+  EXPECT_TRUE(SingleValueFuzzyEquals(rcond,1.8369021718386168e-3));
+
+  // check throw on bad arg, malloc guard test
+  n=-1;
+  EXPECT_THROW(lapack::xgecon(lapack::O, &n, Acpy, &m, &anorm, &rcond, &INFO), rdag_error);
+  // xerbla test
+  n=5; m=-1;
+  EXPECT_THROW(lapack::xgecon(lapack::O, &n, Acpy, &m, &anorm, &rcond, &INFO), rdag_error);
+
+  // clean up
+  delete [] ipiv;
+  delete [] Acpy;
+}
+
+
+TEST(LAPACKTest_xgecon, zgecon) {
+  int m = 5;
+  int n = 4;
+  const int minmn = m > n ? n : m;
+  int INFO = 0;
+
+  complex16 * Acpy = new complex16[20];
+  std::copy(ccondok5x4,ccondok5x4+m*n,Acpy);
+
+  // need a 1 norm
+  real8 anorm = lapack::xlange(lapack::O, &m, &n, Acpy, &m);
+
+  // check it
+  EXPECT_TRUE(SingleValueFuzzyEquals(anorm,183.35757415498276e0));
+
+  // need a LU decomp
+  int * ipiv = new int[minmn]();
+  lapack::xgetrf(&m,&n,Acpy,&m,ipiv,&INFO);
+
+  // make the call
+  real8 rcond = 0;
+  lapack::xgecon(lapack::O, &n, Acpy, &m, &anorm, &rcond, &INFO);
+  EXPECT_TRUE(SingleValueFuzzyEquals(rcond,1.8369021718386248e-3));
+
+  // check throw on bad arg, malloc guard test
+  n=-1;
+  EXPECT_THROW(lapack::xgecon(lapack::O, &n, Acpy, &m, &anorm, &rcond, &INFO), rdag_error);
+  // xerbla test
+  n=5; m=-1;
+  EXPECT_THROW(lapack::xgecon(lapack::O, &n, Acpy, &m, &anorm, &rcond, &INFO), rdag_error);
+  // clean up
+  delete [] ipiv;
+  delete [] Acpy;
+}
+
+
+TEST(LAPACKTest_xgetrs, dgetrs) {
+  int m = 5;
+  int n = 4;
+  const int minmn = m > n ? n : m;
+  int INFO = 0;
+
+  real8 * Acpy = new real8[20];
+  std::copy(rcondok5x4,rcondok5x4+m*n,Acpy);
+
+  // need a LU decomp
+  int * ipiv = new int[minmn]();
+  lapack::xgetrf(&m,&n,Acpy,&m,ipiv,&INFO);
+
+  // need an RHS
+  real8 * rhs = new real8[8]{1,2,3,4,1,2,3,4};
+
+  // expected
+  real8 * expected = new real8[8]{-0.2831168831168828,0.1194805194805193,0.0155844155844156,0.1480519480519481,
+   -0.2831168831168828,0.1194805194805193,0.0155844155844156,0.1480519480519481
+  };
+
+  // make the call
+  int two = 2;
+  lapack::xgetrs(lapack::N, &n, &two, Acpy, &m, ipiv, rhs, &n, &INFO);
+
+  EXPECT_TRUE(ArrayFuzzyEquals(expected,rhs,8,1e-14,1e-14));
+
+  // xerbla test
+  n=-1;
+  EXPECT_THROW(lapack::xgetrs(lapack::N, &n, &two, Acpy, &m, ipiv, rhs, &n, &INFO),rdag_error);
+
+  // clean up
+  delete [] ipiv;
+  delete [] Acpy;
+  delete [] expected;
+  delete [] rhs;
+}
+
+TEST(LAPACKTest_xgetrs, zgetrs) {
+  int m = 5;
+  int n = 4;
+  const int minmn = m > n ? n : m;
+  int INFO = 0;
+
+  complex16 * Acpy = new complex16[20];
+  std::copy(ccondok5x4,ccondok5x4+m*n,Acpy);
+
+  // need a LU decomp
+  int * ipiv = new int[minmn]();
+  lapack::xgetrf(&m,&n,Acpy,&m,ipiv,&INFO);
+
+  // need an RHS
+  complex16 * rhs = new complex16[8]{{1.,10.}, {2.,20.}, {3.,30.}, {4.,40.},{1.,10.}, {2.,20.}, {3.,30.}, {4.,40.}};
+
+  // expected
+  complex16 * expected = new complex16[8]{{      1.0758441558441547,      -0.6794805194805187}, {     -0.4540259740259733,       0.2867532467532462}, {     -0.0592207792207793,       0.0374025974025975}, {     -0.5625974025974027,       0.3553246753246754}, {      1.0758441558441547,      -0.6794805194805187}, {     -0.4540259740259733,       0.2867532467532462}, {     -0.0592207792207793,       0.0374025974025975}, {     -0.5625974025974027,       0.3553246753246754}};
+
+  // make the call
+  int two = 2;
+  lapack::xgetrs(lapack::N, &n, &two, Acpy, &m, ipiv, rhs, &n, &INFO);
+
+  EXPECT_TRUE(ArrayFuzzyEquals(expected,rhs,8,1e-14,1e-14));
+
+  // xerbla test
+  n=-1;
+  EXPECT_THROW(lapack::xgetrs(lapack::N, &n, &two, Acpy, &m, ipiv, rhs, &n, &INFO),rdag_error);
+
+  // clean up
+  delete [] ipiv;
+  delete [] Acpy;
+  delete [] expected;
+  delete [] rhs;
+}
+
+TEST(LAPACKTest_xgels, dgels) {
+  int m = 5;
+  int n = 4;
+  int INFO = 0;
+
+  real8 * Acpy = new real8[20];
+  std::copy(rcondok5x4,rcondok5x4+m*n,Acpy);
+
+  // need an RHS
+  real8 * rhs = new real8[10]{1,2,3,4,5,1,2,3,4,5};
+
+  // expected
+  real8 * expected = new real8[8]{-6.1464892723569555,3.3470608493900018,-0.1305926637544035,0.2247336970641731,-6.1464892723569555,3.3470608493900018,-0.1305926637544035,0.2247336970641731};
+
+  // make the call
+  int two = 2;
+  lapack::xgels(lapack::N, &m, &n, &two, Acpy, &m, rhs, &m, &INFO);
+
+  // answers are striped in "n" length columns in RHS
+  EXPECT_TRUE(ArrayFuzzyEquals(expected,rhs,n,1e-13,1e-13));
+  EXPECT_TRUE(ArrayFuzzyEquals(&expected[4],&rhs[5],n,1e-13,1e-13));
+
+  // xerbla test
+  n=-1;
+  EXPECT_THROW(lapack::xgels(lapack::N, &m, &n, &two, Acpy, &m, rhs, &m, &INFO),rdag_error);
+
+  // clean up
+  delete [] Acpy;
+  delete [] expected;
+  delete [] rhs;
+}
+
+
+TEST(LAPACKTest_xgels, zgels) {
+  int m = 5;
+  int n = 4;
+  int INFO = 0;
+
+  complex16 * Acpy = new complex16[20];
+  std::copy(ccondok5x4,ccondok5x4+m*n,Acpy);
+
+  // need an RHS
+  complex16 * rhs = new complex16[10]{{1.,10.}, {2.,20.}, {3.,30.}, {4.,40.}, {5., 50.},{1.,10.}, {2.,20.}, {3.,30.}, {4.,40.}, {5.,50.}};
+
+  // expected
+  complex16 * expected = new complex16[8]{{     23.3566592349563571,     -14.7515742536566901}, {    -12.7188312276819353,       8.0329460385359930}, {      0.4962521222667151,      -0.3134223930105628}, {     -0.8539880488438545,       0.5393608729540187}, {     23.3566592349563571,     -14.7515742536566901}, {    -12.7188312276819353,       8.0329460385359930}, {      0.4962521222667151,      -0.3134223930105628}, {     -0.8539880488438545,       0.5393608729540187}};
+
+  // make the call
+  int two = 2;
+  lapack::xgels(lapack::N, &m, &n, &two, Acpy, &m, rhs, &m, &INFO);
+
+  // answers are striped in "n" length columns in RHS
+  EXPECT_TRUE(ArrayFuzzyEquals(expected,rhs,n,1e-13,1e-13));
+  EXPECT_TRUE(ArrayFuzzyEquals(&expected[4],&rhs[5],n,1e-13,1e-13));
+
+  // xerbla test
+  n=-1;
+  EXPECT_THROW(lapack::xgels(lapack::N, &m, &n, &two, Acpy, &m, rhs, &m, &INFO),rdag_error);
+
+  // clean up
+  delete [] Acpy;
+  delete [] expected;
+  delete [] rhs;
+}
+
+
+TEST(LAPACKTest_xgelsd, dgelsd) {
+  int m = 5;
+  int n = 4;
+  int INFO = 0;
+  int minmn = m > n ? n : m;
+
+  real8 * Acpy = new real8[20];
+  std::copy(rcondok5x4,rcondok5x4+m*n,Acpy);
+
+  // need an RHS
+  real8 * rhs = new real8[10]{1,2,3,4,5,1,2,3,4,5};
+
+  // expected
+  real8 * expected = new real8[8]{-6.1464892723569555,3.3470608493900018,-0.1305926637544035,0.2247336970641731,-6.1464892723569555,3.3470608493900018,-0.1305926637544035,0.2247336970641731};
+  real8 * expected_S = new real8[4] {66.4703325718839153,9.0396484167794604,3.5978090226222377,0.1881874621350516};
+
+  // need somewhere to write S
+  real8 * S = new real8[minmn];
+  // condition and rank
+  real8 RCOND = - 1; // -1 so rank is computed wrt machine precision
+  int RANK;
+
+  // make the call
+  int two = 2;
+  lapack::xgelsd(&m, &n, &two, Acpy, &m, rhs, &m, S, &RCOND, &RANK, &INFO);
+
+  // answers are striped in "n" length columns in RHS
+  EXPECT_TRUE(ArrayFuzzyEquals(expected,rhs,n,1e-13,1e-13));
+  EXPECT_TRUE(ArrayFuzzyEquals(&expected[4],&rhs[5],n,1e-13,1e-13));
+
+  EXPECT_TRUE(ArrayFuzzyEquals(expected_S,S,minmn,1e-13,1e-13));
+
+  EXPECT_TRUE(RANK==n);
+
+  // xerbla test
+  n=-1;
+  EXPECT_THROW(lapack::xgelsd(&m, &n, &two, Acpy, &m, rhs, &m, S, &RCOND, &RANK, &INFO),rdag_error);
+
+
+  // clean up
+  delete [] Acpy;
+  delete [] expected;
+  delete [] rhs;
+  delete [] S;
+  delete [] expected_S;
+}
+
+
+TEST(LAPACKTest_xgelsd, zgelsd) {
+  int m = 5;
+  int n = 4;
+  int INFO = 0;
+  int minmn = m > n ? n : m;
+
+  complex16 * Acpy = new complex16[20];
+  std::copy(ccondok5x4,ccondok5x4+m*n,Acpy);
+
+  // need an RHS
+  complex16 * rhs = new complex16[10]{{1.,10.}, {2.,20.}, {3.,30.}, {4.,40.}, {5., 50.},{1.,10.}, {2.,20.}, {3.,30.}, {4.,40.}, {5.,50.}};
+
+  // expected
+  complex16 * expected = new complex16[8]{{     23.3566592349563571,     -14.7515742536566901}, {    -12.7188312276819353,       8.0329460385359930}, {      0.4962521222667151,      -0.3134223930105628}, {     -0.8539880488438545,       0.5393608729540187}, {     23.3566592349563571,     -14.7515742536566901}, {    -12.7188312276819353,       8.0329460385359930}, {      0.4962521222667151,      -0.3134223930105628}, {     -0.8539880488438545,       0.5393608729540187}};
+  real8 * expected_S = new real8[4]{148.6321821177508014,20.2132683526172237,8.0449455446454117,0.4207999578471437};
+
+  // need somewhere to write S
+  real8 * S = new real8[minmn];
+  // condition and rank
+  real8 RCOND = - 1; // -1 so rank is computed wrt machine precision
+  int RANK;
+
+  // make the call
+  int two = 2;
+  lapack::xgelsd(&m, &n, &two, Acpy, &m, rhs, &m, S, &RCOND, &RANK, &INFO);
+
+  // answers are striped in "n" length columns in RHS
+  EXPECT_TRUE(ArrayFuzzyEquals(expected,rhs,n,1e-13,1e-13));
+  EXPECT_TRUE(ArrayFuzzyEquals(&expected[4],&rhs[5],n,1e-13,1e-13));
+
+  EXPECT_TRUE(ArrayFuzzyEquals(expected_S,S,minmn,1e-13,1e-13));
+
+  EXPECT_TRUE(RANK==n);
+
+  // xerbla test
+  n=-1;
+  EXPECT_THROW(lapack::xgelsd(&m, &n, &two, Acpy, &m, rhs, &m, S, &RCOND, &RANK, &INFO),rdag_error);
+
+  // clean up
+  delete [] Acpy;
+  delete [] expected;
+  delete [] rhs;
+  delete [] S;
+  delete [] expected_S;
+}
+
+
+TEST(LAPACKTest_xgeev, dgeev) {
+  int m = 4;
+  int n = 4;
+  int minmn = m > n ? n : m;
+  int INFO = 0;
+
+  real8 * A = new real8[16] {1.,3.,10.,-2.,3.,6.,-1.,-1.,4.,4.,4.,6.,5.,-5.,7.,-10.};
+
+  // expected
+  complex16 * expected_W = new complex16[4]{{-9.6888202793819147,0},{-7.1209208815126370,0},{11.5341107067997743,0},{6.2756304540948005,0}};
+
+  real8 * expected_VL = new real8[16] {0.5674175178806528,-0.0926660731685940,-0.4408469400904874,0.6892781257943167,-0.7391126256525055,0.1682952376639553,0.4565908903993675,-0.4657402692327615,-0.6308032002519173,-0.1585352980899745,-0.6832883559806681,-0.3317693542096654,0.2418102871777062,-0.7172636824241223,0.4394794928726053,0.4836510831527837};
+  real8 * expected_VR = new real8[16]{-0.4604743713776651,0.3593615791115275,-0.0515866317850007,0.8100379177445289,-0.6283589719101941,0.3481029226389141,0.1720238421645797,0.6740898718992491,-0.4636997919781236,-0.6132122861110744,-0.6309391734073038,-0.1042542782910278,-0.1550485207601204,-0.9326141205284221,0.2734940465430895,0.1771774954856935};
+
+  // need somewhere to write W, VL and VR
+  complex16 * W = new complex16[minmn];
+  real8 * VL = new real8[n*n];
+  real8 * VR = new real8[n*n];
+
+  // make the call
+  lapack::xgeev(lapack::V, lapack::V, &n, A, &m, W, VL, &n, VR, &n, &INFO);
+
+  // check
+  EXPECT_TRUE(ArrayFuzzyEquals(expected_W,W,n,1e-14,1e-14));
+  EXPECT_TRUE(ArrayFuzzyEquals(expected_VL,VL,n*n,1e-14,1e-14));
+  EXPECT_TRUE(ArrayFuzzyEquals(expected_VR,VR,n*n,1e-14,1e-14));
+
+  // xerbla test
+  n=-1;
+  EXPECT_THROW(lapack::xgeev(lapack::V, lapack::V, &n, A, &m, W, VL, &n, VR, &n, &INFO),rdag_error);
+
+  // clean up
+  delete [] A;
+  delete [] expected_W;
+  delete [] expected_VL;
+  delete [] expected_VR;
+  delete [] VL;
+  delete [] VR;
+  delete [] W;
+}
+
+TEST(LAPACKTest_xgeev, zgeev) {
+  int m = 4;
+  int n = 4;
+  int minmn = m > n ? n : m;
+  int INFO = 0;
+
+  complex16 * A = new complex16[16] {{1.,10.}, {3.,30.}, {10.,100.}, {-2.,-20.}, {3.,30.}, {6.,60.}, {-1.,-10.}, {-1.,-10.}, {4.,40.}, {4.,40.}, {4.,40.}, {6.,60.}, {5.,50.}, {-5.,-50.}, {7.,70.}, {-10.,-100.}};
+
+  // expected
+  complex16 * expected_W = new complex16[4]{{     -9.6888202793818152,     -96.8882027938191897}, {     -7.1209208815127178,     -71.2092088151264164}, {     11.5341107067997406,     115.3411070679975126}, {      6.2756304540948138,      62.7563045409480083}};
+
+  complex16 * expected_VL = new complex16[16] {{      0.5674175178806546,      -0.0000000000000009}, {     -0.0926660731685946,       0.0000000000000003}, {     -0.4408469400904876,       0.0000000000000004}, 0.6892781257943149,0.7391126256525051,{     -0.1682952376639549,      -0.0000000000000000}, {     -0.4565908903993674,       0.0000000000000004}, {      0.4657402692327622,      -0.0000000000000014}, {      0.6308032002519175,      -0.0000000000000002}, {      0.1585352980899743,      -0.0000000000000000}, 0.6832883559806681,{      0.3317693542096652,       0.0000000000000002}, {     -0.2418102871777065,      -0.0000000000000001}, 0.7172636824241221,{     -0.4394794928726055,       0.0000000000000002}, {     -0.4836510831527837,       0.0000000000000003}};
+  complex16 * expected_VR = new complex16[16]{{     -0.4604743713776652,       0.0000000000000003}, {      0.3593615791115276,       0.0000000000000002}, {     -0.0515866317850003,      -0.0000000000000004}, 0.8100379177445289,{     -0.6283589719101929,      -0.0000000000000011}, {      0.3481029226389143,       0.0000000000000005}, {      0.1720238421645784,       0.0000000000000010}, 0.6740898718992501,{      0.4636997919781238,      -0.0000000000000001}, 0.6132122861110739,0.6309391734073042,{      0.1042542782910277,       0.0000000000000001}, {      0.1550485207601204,      -0.0000000000000000}, 0.9326141205284220,{     -0.2734940465430895,       0.0000000000000002}, {     -0.1771774954856937,       0.0000000000000001}};
+
+  // need somewhere to write W, VL and VR
+  complex16 * W = new complex16[minmn];
+  complex16 * VL = new complex16[n*n];
+  complex16 * VR = new complex16[n*n];
+
+  // make the call
+  lapack::xgeev(lapack::V, lapack::V, &n, A, &m, W, VL, &n, VR, &n, &INFO);
+
+  // check
+  EXPECT_TRUE(ArrayFuzzyEquals(expected_W,W,n,1e-13,1e-13));
+  EXPECT_TRUE(ArrayFuzzyEquals(expected_VL,VL,n*n,1e-14,1e-14));
+  EXPECT_TRUE(ArrayFuzzyEquals(expected_VR,VR,n*n,1e-14,1e-14));
+
+  // xerbla test
+  n=-1;
+  EXPECT_THROW(lapack::xgeev(lapack::V, lapack::V, &n, A, &m, W, VL, &n, VR, &n, &INFO),rdag_error);
+
+  // clean up
+  delete [] A;
+  delete [] expected_W;
+  delete [] expected_VL;
+  delete [] expected_VR;
+  delete [] VL;
+  delete [] VR;
+  delete [] W;
+}
+
+
+TEST(LAPACKTest_xgeqrf, dgeqrf) {
+
+  int m = 5;
+  int n = 4;
+  int INFO = 0;
+  int minmn = m > n ? n : m;
+
+  real8 * TAU = new real8[minmn];
+
+  real8 * Acpy = new real8[20];
+  std::copy(rcondok5x4,rcondok5x4+m*n,Acpy);
+
+  real8 * expected = new real8[20] {-16.4620776331543297,0.4193443036519876,0.4659381151688751,0.3727504921351001,0.0465938115168875,-30.9802937007701331,-0.4705339669164644,0.5271543871195484,0.1380458452882069,0.1945542709156689,-41.4285496155396729,-3.2545266045055365,-5.0083264004388974,0.1791773291023356,0.0485226775213250,-37.2370981148472424,-0.8155922093218853,-5.7238016005016057,-10.4867263038294549,0.1036735557501358};
+
+  real8 * expected_TAU = new real8[4]{1.3037283696153934,1.4983520738901965,1.9333778010585592,1.9787321786052121};
+
+  lapack::xgeqrf(&m, &n, Acpy, &m, TAU, &INFO);
+
+  EXPECT_TRUE(ArrayFuzzyEquals(expected,Acpy,m*n,1e-13,1e-13));
+  EXPECT_TRUE(ArrayFuzzyEquals(expected_TAU,TAU,n,1e-13,1e-13));
+
+  // xerbla test
+  n=-1;
+  EXPECT_THROW(lapack::xgeqrf(&m, &n, Acpy, &m, TAU, &INFO),rdag_error);
+
+  delete [] TAU;
+  delete [] Acpy;
+  delete [] expected;
+  delete [] expected_TAU;
+
+}
+
+TEST(LAPACKTest_xgeqrf, zgeqrf) {
+
+  int m = 5;
+  int n = 4;
+  int INFO = 0;
+  int minmn = m > n ? n : m;
+
+  complex16 * TAU = new complex16[minmn];
+
+  complex16 * Acpy = new complex16[20];
+  std::copy(ccondok5x4,ccondok5x4+m*n,Acpy);
+
+  complex16 * expected = new complex16[20] {{    -36.8103246386119238,       0.0000000000000000}, {      0.3010074912401742,      -0.3585220927405818}, {      0.3344527680446380,      -0.3983578808228687}, {      0.2675622144357104,      -0.3186863046582949}, {      0.0334452768044638,      -0.0398357880822869}, {    -69.2740426778305647,      -0.0000000000000106}, {      1.0521459357478518,       0.0000000000000000}, {      0.2628571444550748,       0.5711000051181361}, {      0.2254041184152971,       0.1052355328720274}, {      0.0187265130198877,       0.2329322361230564}, {    -92.6370531495694678,       0.0000000000000142}, {      7.2773427222559253,       0.0000000000000258}, {    -11.1989582848882208,       0.0000000000000000}, {      0.1933057235253725,      -0.1432100966228572}, {      0.0646250639237787,       0.0899178386939252}, {    -83.2646826696277031,       0.0000000000000000}, {      1.8237196219630949,      -0.0000000000000391}, {    -12.7988094684436007,      -0.0000000000000080}, {    -23.4490328767978156,       0.0000000000000000}, {      0.1118475673158655,      -0.0377993268530200}};
+
+  complex16 * expected_TAU = new complex16[4]{{1.1358314562310403,-0.27166291246208063},{1.1023389842523179,0.49317452258808697},{1.7631082023084017,-0.43191932046510112},{1.3367239865466765,-0.92188119028587789}};
+
+  lapack::xgeqrf(&m, &n, Acpy, &m, TAU, &INFO);
+
+  EXPECT_TRUE(ArrayFuzzyEquals(expected,Acpy,m*n,1e-13,1e-13));
+  EXPECT_TRUE(ArrayFuzzyEquals(expected_TAU,TAU,n,1e-13,1e-13));
+
+  // xerbla test
+  n=-1;
+  EXPECT_THROW(lapack::xgeqrf(&m, &n, Acpy, &m, TAU, &INFO),rdag_error);
+
+  delete [] TAU;
+  delete [] Acpy;
+  delete [] expected;
+  delete [] expected_TAU;
+
+}
+
+
+TEST(LAPACKTest_xxxgqr, dorgqr) {
+
+  int m = 5;
+  int n = 4;
+  int INFO = 0;
+  int minmn = m > n ? n : m;
+
+  real8 * TAU = new real8[minmn];
+
+  real8 * Acpy = new real8[20];
+  std::copy(rcondok5x4,rcondok5x4+m*n,Acpy);
+
+  real8 * expected = new real8[20] {-0.3037283696153934,-0.5467110653077083,-0.6074567392307869,-0.4859653913846296,-0.0607456739230787,0.8704878387954510,-0.1333179572929945,-0.3842694063151109,0.1176334917291140,-0.2509514490221096,-0.0499168744229821,0.8153089489086596,-0.5158077023707830,-0.2495843721148959,0.0665558325639719,0.2751778011656992,0.0762869151746490,0.4658950891023217,-0.8173598054426700,-0.1825436898821958};
+
+  // create a packed QR form with elementary reflectors in lower part
+  lapack::xgeqrf(&m, &n, Acpy, &m, TAU, &INFO);
+
+  // extract Q from packed form of xgeqrf, scalings are in TAU
+  int k = n;
+  lapack::xxxgqr(&m, &n, &k, Acpy, &m, TAU, &INFO);
+
+  EXPECT_TRUE(ArrayFuzzyEquals(expected,Acpy,m*n,1e-13,1e-13));
+
+  // xerbla test
+  n=-1;
+  EXPECT_THROW(lapack::xxxgqr(&m, &n, &k, Acpy, &m, TAU, &INFO),rdag_error);
+
+
+  delete [] TAU;
+  delete [] Acpy;
+  delete [] expected;
+}
+
+
+TEST(LAPACKTest_xxxgqr, zunrgqr) {
+
+  int m = 5;
+  int n = 4;
+  int INFO = 0;
+  int minmn = m > n ? n : m;
+
+  complex16 * TAU = new complex16[minmn];
+
+  complex16 * Acpy = new complex16[20];
+  std::copy(ccondok5x4,ccondok5x4+m*n,Acpy);
+
+  complex16 * expected = new complex16[20] {{     -0.1358314562310403,       0.2716629124620806}, {     -0.2444966212158725,       0.4889932424317451}, {     -0.2716629124620806,       0.5433258249241611}, {     -0.2173303299696644,       0.4346606599393290}, {     -0.0271662912462081,       0.0543325824924161}, {     -0.3892939962266967,       0.7785879924534080}, {      0.0596216030257065,      -0.1192432060514235}, {      0.1718505028388125,      -0.3437010056776262}, {     -0.0526072967873878,       0.1052145935747794}, {      0.1122288998131025,      -0.2244577996262045}, {     -0.0223235048868174,       0.0446470097736447}, {      0.3646172464847307,      -0.7292344929694671}, {     -0.2306762171638115,       0.4613524343276225}, {     -0.1116175244341002,       0.2232350488682011}, {      0.0297646731824274,      -0.0595293463648534}, {      0.1230632538610821,      -0.2461265077221643}, {      0.0341165456248574,      -0.0682330912497137}, {      0.2083546179232226,      -0.4167092358464459}, {     -0.3655344174091633,       0.7310688348183267}, {     -0.0816360198880458,       0.1632720397760899}};
+
+  // create a packed QR form with elementary reflectors in lower part
+  lapack::xgeqrf(&m, &n, Acpy, &m, TAU, &INFO);
+
+  // extract Q from packed form of xgeqrf, scalings are in TAU
+  int k = n;
+  lapack::xxxgqr(&m, &n, &k, Acpy, &m, TAU, &INFO);
+
+  EXPECT_TRUE(ArrayFuzzyEquals(expected,Acpy,m*n,1e-13,1e-13));
+
+  // xerbla test
+  n=-1;
+  EXPECT_THROW(lapack::xxxgqr(&m, &n, &k, Acpy, &m, TAU, &INFO),rdag_error);
+
+  delete [] TAU;
+  delete [] Acpy;
+  delete [] expected;
+}
+


### PR DESCRIPTION
Ticket [[MAT-355]](http://jira.opengamma.com/browse/MAT-355) is to write the super solver, this PR is part way there and is with view of adding in the LAPACK functions needed to do the heavy lifting. It:
- Adds a load more functions from LAPACK in templated form.
- Switches to use `unique_ptr<>` for memory management for templated LAPACK internals.
- Does the double rebase on type changes and incorporates new `real8` and `int4` types.
- Adds end to end tests to make sure the templates fire and clean up correctly.
- Fixes a bug in error reporting, bad arg is always at `-(*INFO)`.

The patches look at bit messy and fiddly, partly because of the rebase, partly because of the switch to `unique_ptr<>` and partly because LAPACK is fiddly, apologies!

**Coverage**
Java: (no change)
build/include 58.7% (no change)
build/src/jshim     0.8% (no change)
build/src/librdag 16.4% (no change)
src/jshim   54.3% (no change)
src/librdag 94.3% (down 0.5%, exceptions in LAPACK templates for things like failed convergence not covered).
src/librdag/runners     95.7% (no change)
src/librdag/test/nodes 96.9% (no change)
