### PR TITLE
Mat 437 - implement the mldivide operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<--!
+<!--
  Copyright (C) 2013 - present by OpenGamma Inc. and the OpenGamma group of companies
 
  Please see distribution for license.

--- a/include/expressionbase.hh
+++ b/include/expressionbase.hh
@@ -197,6 +197,19 @@ class LU: public OGUnaryExpr
     LU(const OGNumeric::Ptr& arg);
 };
 
+class MLDIVIDE: public OGBinaryExpr
+{
+  public:
+    typedef std::shared_ptr<const MLDIVIDE> Ptr;
+    static MLDIVIDE::Ptr create(const OGNumeric::Ptr& arg0, const OGNumeric::Ptr& arg1);
+    virtual OGNumeric::Ptr copy() const override;
+    virtual MLDIVIDE::Ptr asMLDIVIDE() const override;
+    virtual void debug_print() const override;
+    virtual ExprType_t getType() const override;
+  private:
+    MLDIVIDE(const OGNumeric::Ptr& arg0, const OGNumeric::Ptr& arg1);
+};
+
 } // namespace librdag
 
 #endif // _EXPRESSIONBASE_HH

--- a/include/exprtypeenum.h
+++ b/include/exprtypeenum.h
@@ -50,6 +50,7 @@ typedef enum
   CTRANSPOSE_ENUM      = 0x0137L ,
   LU_ENUM              = 0x0139L ,
   INV_ENUM             = 0x013DL ,
+  MLDIVIDE_ENUM        = 0x014BL ,
 
 #include "exprenum.hh"
 } ExprType_t;

--- a/include/terminal.hh
+++ b/include/terminal.hh
@@ -140,7 +140,7 @@ class OGTerminal: public OGNumeric
      * @return true if \a this is considered mathematically equal to \a term, false else
      */
     virtual bool mathsequals(const OGTerminal::Ptr& term, real8 maxabserror, real8 maxrelerror)const;
-    
+
     virtual bool operator==(const OGTerminal::Ptr&) const;
     virtual bool operator!=(const OGTerminal::Ptr&) const;
     virtual bool operator%(const OGTerminal::Ptr&) const;
@@ -304,6 +304,8 @@ template <typename T> class OGMatrix: public OGArray<T>
   public:
     typedef std::shared_ptr<const OGMatrix<T>> Ptr;
     static OGMatrix<T>::Ptr create(T* data, size_t rows, size_t cols, DATA_ACCESS access_spec=VIEWER);
+    static OGMatrix<T>::Ptr create(T** data, size_t rows, size_t cols);
+    static OGMatrix<T>::Ptr create(std::initializer_list<std::initializer_list<T>> list);
     virtual void debug_print() const override;
     virtual OGNumeric::Ptr copy() const override;
     virtual OGTerminal::Ptr createOwningCopy() const override;
@@ -314,6 +316,8 @@ template <typename T> class OGMatrix: public OGArray<T>
     T** toArrayOfArrays() const;
   protected:
     OGMatrix(T * data, size_t rows, size_t cols, DATA_ACCESS access_spec=VIEWER);
+    OGMatrix(T ** data, size_t rows, size_t cols);
+    OGMatrix(std::initializer_list<std::initializer_list<T>> list);
 };
 
 template<> real8 ** OGMatrix<real8>::toReal8ArrayOfArrays() const;
@@ -333,6 +337,8 @@ class OGRealDenseMatrix: public OGMatrix<real8>
      */
     typedef std::shared_ptr<const OGRealDenseMatrix> Ptr;
     static OGRealDenseMatrix::Ptr create(real8* data, size_t rows, size_t cols, DATA_ACCESS access_spec=VIEWER);
+    static OGRealDenseMatrix::Ptr create(real8** data, size_t rows, size_t cols);
+    static OGRealDenseMatrix::Ptr create(std::initializer_list<std::initializer_list<real8>> list);
     virtual OGNumeric::Ptr copy() const override;
     virtual OGRealDenseMatrix::Ptr asOGRealDenseMatrix() const override;
     virtual ExprType_t getType() const override;
@@ -353,6 +359,8 @@ class OGComplexDenseMatrix: public OGMatrix<complex16>
      */
     typedef std::shared_ptr<const OGComplexDenseMatrix> Ptr;
     static OGComplexDenseMatrix::Ptr create(complex16* data, size_t rows, size_t cols, DATA_ACCESS access_spec=VIEWER);
+    static OGComplexDenseMatrix::Ptr create(complex16** data, size_t rows, size_t cols);
+    static OGComplexDenseMatrix::Ptr create(std::initializer_list<std::initializer_list<complex16>> list);
     virtual complex16 ** toComplex16ArrayOfArrays() const override;
     virtual OGNumeric::Ptr copy() const override;
     virtual OGComplexDenseMatrix::Ptr asOGComplexDenseMatrix() const override;
@@ -375,6 +383,7 @@ class OGLogicalMatrix: public OGRealDenseMatrix
     typedef std::shared_ptr<const OGLogicalMatrix> Ptr;
     // TODO: range limit inputs
     static OGLogicalMatrix::Ptr create(real8* data, size_t rows, size_t cols, DATA_ACCESS access_spec=VIEWER);
+    static OGLogicalMatrix::Ptr create(real8** data, size_t rows, size_t cols);
     virtual OGLogicalMatrix::Ptr asOGLogicalMatrix() const override;
   protected:
     using OGRealDenseMatrix::OGRealDenseMatrix;

--- a/include/test/test_utils.hh
+++ b/include/test/test_utils.hh
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+#ifndef _TEST_UTILS_H
+#define _TEST_UTILS_H
+
+#include <cstddef>
+#include <memory>
+
+namespace testutils {
+
+/**
+ * Wraps a stack allocated 2D array of any type in a unique_ptr containing an on heap 
+ * reference to the stack allocated array that is plumbed in to the stack data.
+ * The purpose of this is so that stack allocated data in row major form can be
+ * transformed to a \a T** with minimal effort.
+ * @param T the type of the stack alocated array.
+ * @param S1 the number of "rows" in the stack allocated array.
+ * @param S2 the number of "columns" in the stack allocated array.
+ * @param foo a stack allocated 2D array.
+ * @return a unique_ptr to an on heap T*[] wired up for 2D array access to \a foo
+ */
+template<typename T, std::size_t S1, std::size_t S2> std::unique_ptr<T*[]> stack2heap(T foo[S1][S2] )
+{
+  std::unique_ptr<T*[]> up (new T*[S1]);
+  T ** bar = up.get();
+  for(size_t i = 0; i < S1; i++)
+  {
+    bar[i] = foo[i];
+  }
+  return up;
+}
+
+}
+
+#endif

--- a/src/generator/enumtemplates.py
+++ b/src/generator/enumtemplates.py
@@ -52,6 +52,7 @@ public enum ExprEnum {
   CTRANSPOSE_ENUM   (0x0137L),
   LU_ENUM           (0x0139L),
   INV_ENUM          (0x013DL),
+  MLDIVIDE_ENUM     (0x014BL),
 
   // Unary expression nodes - start at 175 to leave room for extra non-generated nodes
 %(generated_nodes)s;

--- a/src/generator/exprtemplates.py
+++ b/src/generator/exprtemplates.py
@@ -202,6 +202,7 @@ class CTRANSPOSE;
 class SVD;
 class MTIMES;
 class LU;
+class MLDIVIDE;
 
 class ConvertTo;
 
@@ -228,6 +229,7 @@ class OGNumeric: private Uncopyable, public std::enable_shared_from_this<OGNumer
     virtual std::shared_ptr<const SVD> asSVD() const;
     virtual std::shared_ptr<const MTIMES> asMTIMES() const;
     virtual std::shared_ptr<const LU> asLU() const;
+    virtual std::shared_ptr<const MLDIVIDE> asMLDIVIDE() const;
 %(cast_methods)s
     virtual std::shared_ptr<const OGTerminal> asOGTerminal() const;
     virtual std::shared_ptr<const OGRealScalar> asOGRealScalar() const;

--- a/src/generator/generator.py
+++ b/src/generator/generator.py
@@ -51,7 +51,6 @@ nodes = [ UnimplementedUnary('ABS'),
           UnimplementedUnary('TAN'),
           UnimplementedUnary('WILKINSON'),
           UnimplementedBinary('HORZCAT'),
-          UnimplementedBinary('MLDIVIDE'),
           InfixOpRunner('PLUS', 'PLUS_ENUM', '+'),
           UnimplementedBinary('POWER'),
           UnimplementedBinary('RDIVIDE'),
@@ -70,6 +69,7 @@ custom_nodes = [
                 UnaryExpressionRunner('TRANSPOSE','TRANSPOSE_ENUM'),
                 UnaryExpressionRunner('CTRANSPOSE','CTRANSPOSE_ENUM'),
                 UnaryExpressionRunner('LU','LU_ENUM'),
+                BinaryExpressionRunner('MLDIVIDE','MLDIVIDE_ENUM'),
                ]
 
 # The list of terminals

--- a/src/java/src/main/CMakeLists.txt
+++ b/src/java/src/main/CMakeLists.txt
@@ -25,6 +25,7 @@ set(JAVA_FILES
     nodes/INV.java
     nodes/LU.java
     nodes/MTIMES.java
+    nodes/MLDIVIDE.java
     nodes/NEGATE.java
     nodes/NODE.java
     nodes/NORM2.java

--- a/src/java/src/main/java/com/opengamma/maths/DOGMA.java
+++ b/src/java/src/main/java/com/opengamma/maths/DOGMA.java
@@ -19,6 +19,7 @@ import com.opengamma.maths.nativeloader.NativeLibraries;
 import com.opengamma.maths.nodes.CTRANSPOSE;
 import com.opengamma.maths.nodes.INV;
 import com.opengamma.maths.nodes.LU;
+import com.opengamma.maths.nodes.MLDIVIDE;
 import com.opengamma.maths.nodes.MTIMES;
 import com.opengamma.maths.nodes.NEGATE;
 import com.opengamma.maths.nodes.NORM2;
@@ -120,6 +121,17 @@ public final class DOGMA {
     return ret;
   }
 
+  public static OGNumeric mldivide(final OGNumeric... args) {
+    if (args.length < 2) {
+      throw new MathsExceptionIllegalArgument("Cannot use mldivide() with just one argument.");
+    }
+    OGNumeric ret = args[0];
+    for (int i = 1; i < args.length; i++) {
+      ret = new MLDIVIDE(ret, args[i]);
+    }
+    return ret;
+  }
+  
   // variadic results
 
   public static OGSVDResult svd(OGNumeric arg0) {

--- a/src/java/src/main/java/com/opengamma/maths/datacontainers/ExprEnum.java
+++ b/src/java/src/main/java/com/opengamma/maths/datacontainers/ExprEnum.java
@@ -23,7 +23,7 @@ public enum ExprEnum {
   OGRealScalar            (0x0002L),
   OGComplexScalar         (0x0003L),
   OGRealDenseMatrix       (0x0005L),
-  OGComplexDenseMatrix         (0x0007L),
+  OGComplexDenseMatrix    (0x0007L),
   OGRealSparseMatrix      (0x000BL),
   OGComplexSparseMatrix   (0x000DL),
   OGRealDiagonalMatrix    (0x0011L),

--- a/src/java/src/main/java/com/opengamma/maths/datacontainers/ExprEnum.java
+++ b/src/java/src/main/java/com/opengamma/maths/datacontainers/ExprEnum.java
@@ -23,7 +23,7 @@ public enum ExprEnum {
   OGRealScalar            (0x0002L),
   OGComplexScalar         (0x0003L),
   OGRealDenseMatrix       (0x0005L),
-  OGComplexDenseMatrix    (0x0007L),
+  OGComplexDenseMatrix         (0x0007L),
   OGRealSparseMatrix      (0x000BL),
   OGComplexSparseMatrix   (0x000DL),
   OGRealDiagonalMatrix    (0x0011L),
@@ -45,6 +45,7 @@ public enum ExprEnum {
   CTRANSPOSE_ENUM   (0x0137L),
   LU_ENUM           (0x0139L),
   INV_ENUM          (0x013DL),
+  MLDIVIDE_ENUM     (0x014BL),
 
   // Unary expression nodes - start at 175 to leave room for extra non-generated nodes
   ABS_ENUM (0X0175L),
@@ -80,13 +81,12 @@ public enum ExprEnum {
   TAN_ENUM (0X0239L),
   WILKINSON_ENUM (0X023BL),
   HORZCAT_ENUM (0X0241L),
-  MLDIVIDE_ENUM (0X024BL),
-  PLUS_ENUM (0X0251L),
-  POWER_ENUM (0X0257L),
-  RDIVIDE_ENUM (0X0259L),
-  TIMES_ENUM (0X025FL),
-  VERTCAT_ENUM (0X0265L),
-  DOT_ENUM (0X0269L);
+  PLUS_ENUM (0X024BL),
+  POWER_ENUM (0X0251L),
+  RDIVIDE_ENUM (0X0257L),
+  TIMES_ENUM (0X0259L),
+  VERTCAT_ENUM (0X025FL),
+  DOT_ENUM (0X0265L);
 
   //CSON
   //@formatter:on

--- a/src/java/src/main/java/com/opengamma/maths/nodes/MLDIVIDE.java
+++ b/src/java/src/main/java/com/opengamma/maths/nodes/MLDIVIDE.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+package com.opengamma.maths.nodes;
+
+import com.opengamma.maths.datacontainers.ExprEnum;
+import com.opengamma.maths.datacontainers.OGNumeric;
+import com.opengamma.maths.datacontainers.lazy.OGExpr;
+
+/**
+ * Mldivide class
+ */
+public class MLDIVIDE extends OGExpr {
+
+  @Override
+  public ExprEnum getType() {
+    return ExprEnum.MLDIVIDE_ENUM;
+  }
+
+  public MLDIVIDE(OGNumeric arg0, OGNumeric arg1) {
+    super(arg0, arg1);
+  }
+
+
+}

--- a/src/java/src/test/java/com/opengamma/maths/DOGMATest.java
+++ b/src/java/src/test/java/com/opengamma/maths/DOGMATest.java
@@ -13,6 +13,7 @@ import static com.opengamma.maths.DOGMA.disp;
 import static com.opengamma.maths.DOGMA.inv;
 import static com.opengamma.maths.DOGMA.lu;
 import static com.opengamma.maths.DOGMA.minus;
+import static com.opengamma.maths.DOGMA.mldivide;
 import static com.opengamma.maths.DOGMA.mtimes;
 import static com.opengamma.maths.DOGMA.norm2;
 import static com.opengamma.maths.DOGMA.pinv;
@@ -142,7 +143,7 @@ public class DOGMATest {
     mat = new OGComplexDenseMatrix(new double[][] { { 1, 2, 3 }, { 1, 2, 3 }, { -4, -5, 6 } }, new double[][] { { 10, 20, 30 }, { 10, 20, 30 }, { -40, -50, 60 } });
     // TODO: assert warn raised on singular
     toOGTerminal(inv(mat));
-    
+
   }
 
   @Test
@@ -231,6 +232,21 @@ public class DOGMATest {
     assertTrue(D(1e10).mathsequals(toOGTerminal(TenTimes)));
     TenTimes = mtimes(cmat, cmat, cmat, cmat, cmat, cmat, cmat, cmat, cmat, cmat);
     assertTrue(C(72306229251e0, 12853399300e0).mathsequals(toOGTerminal(TenTimes)));
+  }
+
+  @Test
+  public void MldivideTest() {
+    OGTerminal rmat, cmat;
+    rmat = new OGRealDenseMatrix(new double[][] { { 10., 2., 3. }, { 4., 50., 6. }, { 7., 8., 9. } });
+    cmat = new OGComplexDenseMatrix(new double[][] { { 1 }, { 2 }, { 3 } }, new double[][] { { 10 }, { 20 }, { 30 } });
+    OGTerminal expected = new OGComplexDenseMatrix(new double[][] { { 0.0000000000000000 }, { 0.0000000000000000 }, { 0.3333333333333333 } }, new double[][] { { 0.0000000000000000 },
+      { 0.0000000000000000 }, { 3.3333333333333335 } });
+    assertTrue(expected.mathsequals(toOGTerminal(mldivide(rmat, cmat))));
+  }
+
+  @Test(expectedExceptions = MathsExceptionIllegalArgument.class)
+  public void MldivideBadDataTest() {
+    mldivide(D(10));
   }
 
   @Test

--- a/src/java/src/test/java/com/opengamma/maths/testnodes/TestMldivideMaterialise.java
+++ b/src/java/src/test/java/com/opengamma/maths/testnodes/TestMldivideMaterialise.java
@@ -1,0 +1,475 @@
+/**
+ * Copyright (C) 2012 - present by OpenGamma Inc. and the OpenGamma group of companies
+ * 
+ * Please see distribution for license.
+ */
+package com.opengamma.maths.testnodes;
+
+import static org.testng.Assert.assertTrue;
+
+import java.util.Arrays;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.opengamma.maths.DOGMA;
+import com.opengamma.maths.datacontainers.OGNumeric;
+import com.opengamma.maths.datacontainers.OGTerminal;
+import com.opengamma.maths.datacontainers.lazy.OGExpr;
+import com.opengamma.maths.datacontainers.matrix.OGArray;
+import com.opengamma.maths.datacontainers.matrix.OGRealDenseMatrix;
+import com.opengamma.maths.datacontainers.other.ComplexArrayContainer;
+import com.opengamma.maths.exceptions.MathsException;
+import com.opengamma.maths.exceptions.MathsExceptionIllegalArgument;
+import com.opengamma.maths.exceptions.MathsExceptionNonConformance;
+import com.opengamma.maths.helpers.FuzzyEquals;
+import com.opengamma.maths.materialisers.Materialisers;
+import com.opengamma.maths.nodes.MLDIVIDE;
+import com.opengamma.maths.nodes.MTIMES;
+import com.opengamma.maths.nodes.NEGATE;
+import com.opengamma.maths.nodes.PLUS;
+
+/**
+ * Test for mldivide()
+ */
+@Test
+public class TestMldivideMaterialise {
+  boolean debugStatements = false; // eyeballable output switch
+
+  private double[][] A_square_singular = new double[][] { { 1.00, 2.00, 3.00 }, { 1.00, 2.00, 3.00 }, { 1.00, 2.00, 3.00 } };
+  private double[][] A_square_symmetric_positive_definite = new double[][] { { 123.00, 23.00, 23.00 }, { 23.00, 123.00, 23.00 }, { 23.00, 23.00, 123.00 } };
+  private double[][] A_square_non_symmetric_well_conditioned = new double[][] { { 10.00, 2.00, 1.00 }, { 2.00, 3.00, 10.00 }, { 4.00, 10.00, 1.00 } };
+  private double[][] A_rectangular = new double[][] { { 1.00, 2.00, 3.00, 4.00 }, { 5.00, 6.00, 7.00, 8.00 }, { 9.00, 10.00, 11.00, 12.00 }, { 13.00, 14.00, 15.00, 16.00 },
+    { 17.00, 18.00, 19.00, 20.00 } };
+  private double[][] A_square_non_symmetric_condition_bad_for_lu_ok_for_qr = new double[][] { { 1.0000000000000009, 2., 20. }, { 1., 2., 0. }, { 1., 2., 40. } };
+  private double[][] A_upper_triangular = new double[][] { { 1., 2., 3. }, { 0., 5., 6. }, { 0., 0., 9. } };;
+  private double[][] A_unit_upper_triangular = new double[][] { { 1., 2., 3. }, { 0., 1., 6. }, { 0., 0., 1. } };
+  private double[][] A_lower_triangular = new double[][] { { 1., 0., 0. }, { 4., 5., 0. }, { 7., 8., 9. } };
+  private double[][] A_unit_lower_triangular = new double[][] { { 1., 0., 0. }, { 4., 1., 0. }, { 7., 8., 1. } };
+  private double[][] A_lower_triangular_singular_zero_on_diag = new double[][] { { 1., 0., 0. }, { 4., 0., 0. }, { 7., 8., 1. } };
+  private double[][] A_lower_triangular_singular_near_zero_on_diag = new double[][] { { 1., 0., 0. }, { 4., 0.0000000000000001, 0. }, { 7., 8., 1. } };
+  private double[][] A_square_spd_near_singular = new double[][] { { 2.0000e+00, 1.0000e+150, 2.0000e+00 }, { 1.0000e+150, 1.0000e+300, 2.0000e+150 }, { 2.0000e+00, 2.0000e+150, 5.0000e+00 } };
+  private double[][] A_square_symmetric_not_spd = new double[][] { { 54., 2., 3. }, { 2., 10., 6. }, { 3., 6., -120. } };
+  private double[][] A_rectangular_with_inf = new double[][] { { Double.POSITIVE_INFINITY, 2.00, 3.00, 4.00 }, { 5.00, 6.00, 7.00, 8.00 }, { 9.00, 10.00, 11.00, 12.00 },
+    { 13.00, 14.00, 15.00, 16.00 },
+    { 17.00, 18.00, 19.00, 20.00 } };
+  private double[][] A_square_permuted_upper_triangular = new double[][] { { 0., 0., 13., 14., 15. }, { 1., 2., 3., 4., 5. }, { 0., 7., 8., 9., 10. }, { 0., 0., 0., 0., 25. },
+    { 0., 0., 0., 19., 20. } };;
+  private double[][] A_square_permuted_upper_triangular_zero_on_diag = new double[][] { { 0., 6., 7., 8. }, { 0., 0., 0., 16. }, { 1., 2., 3., 4. }, { 0., 0., 0., 12. } };
+  private double[][] A_square_almost_permuted_upper_triangular = new double[][] { { 0., 12., 13., 14., 15. }, { 1., 2., 3., 4., 5. }, { 0., 7., 8., 9., 10. }, { 0., 0., 0., 0., 25. },
+    { 0., 0., 0., 19., 20. } };;
+  private double[][] A_square_permuted_upper_triangular_singular_to_mach_prech = new double[][] { { 0., 0., 1.e-300, 14., 15. }, { 1., 2., 3., 4., 5. }, { 0., 7., 8., 9., 10. },
+    { 0., 0., 0., 0., 25. },
+    { 0., 0., 0., 19., 20. } };;
+  private double[][] A_short_row = new double[][] { { 2, 3, 4 } };
+
+  private double[][] B_rectangular = new double[][] { { 1.00, 2.00, 3.00 }, { 1.00, 2.00, 3.00 }, { 1.00, 2.00, 3.00 }, { 1.00, 2.00, 3.00 }, { 1.00, 2.00, 3.00 } };
+
+  private double[] C_4len_col_vector = new double[] { 1, 2, 3, 4 };
+  private double[] C_5len__shuffled_col_matrix = new double[] { 3, 1, 2, 5, 4, 10, 20, 30, 40, 50 };
+
+  OGTerminal A1 = new OGRealDenseMatrix(A_square_singular);
+  OGTerminal A2 = new OGRealDenseMatrix(A_square_symmetric_positive_definite);
+  OGTerminal A3 = new OGRealDenseMatrix(A_square_non_symmetric_well_conditioned);
+  OGTerminal A4 = new OGRealDenseMatrix(A_rectangular);
+  OGTerminal A5 = new OGRealDenseMatrix(A_square_non_symmetric_condition_bad_for_lu_ok_for_qr);
+  OGTerminal A6 = new OGRealDenseMatrix(A_upper_triangular);
+  OGTerminal A7 = new OGRealDenseMatrix(A_unit_upper_triangular);
+  OGTerminal A8 = new OGRealDenseMatrix(A_lower_triangular);
+  OGTerminal A9 = new OGRealDenseMatrix(A_unit_lower_triangular);
+  OGTerminal A10 = new OGRealDenseMatrix(A_lower_triangular_singular_zero_on_diag);
+  OGTerminal A11 = new OGRealDenseMatrix(A_lower_triangular_singular_near_zero_on_diag);
+  OGTerminal A12 = new OGRealDenseMatrix(A_square_spd_near_singular);
+  OGTerminal A13 = new OGRealDenseMatrix(A_square_symmetric_not_spd);
+  OGTerminal A14 = new OGRealDenseMatrix(A_rectangular_with_inf);
+  OGTerminal A15 = new OGRealDenseMatrix(A_square_permuted_upper_triangular);
+  OGTerminal A16 = new OGRealDenseMatrix(A_square_permuted_upper_triangular_zero_on_diag);
+  OGTerminal A17 = new OGRealDenseMatrix(A_square_almost_permuted_upper_triangular);
+  OGTerminal A18 = new OGRealDenseMatrix(A_square_permuted_upper_triangular_singular_to_mach_prech);
+  OGTerminal A19 = new OGRealDenseMatrix(A_short_row);
+
+  OGTerminal B1 = new OGRealDenseMatrix(B_rectangular);
+  OGTerminal C1 = new OGRealDenseMatrix(C_4len_col_vector, 4, 1);
+  OGTerminal C2 = new OGRealDenseMatrix(C_5len__shuffled_col_matrix, 5, 2);
+
+  @Test(expectedExceptions = MathsExceptionNonConformance.class)
+  public void testNonConformance() {
+    DOGMA.toDoubleArrayOfArrays(new MLDIVIDE(A1, B1));
+  }
+
+  // valid ops for which we have answers
+  @DataProvider
+  public Object[][] realDataContainer() {
+    Object[][] obj = new Object[18][2];
+
+    //test UpperTri Branch
+    obj[0][0] = new MLDIVIDE(A6, A1);
+    obj[0][1] = new OGRealDenseMatrix(new double[][] { { 0.5333333333333334, 1.0666666666666669, 1.6000000000000001 }, { 0.0666666666666667, 0.1333333333333334, 0.2000000000000000 },
+      { 0.1111111111111111, 0.2222222222222222, 0.3333333333333333 } });
+
+    // test Unit UpperTri Branch
+    obj[1][0] = new MLDIVIDE(A7, A1);
+    obj[1][1] = new OGRealDenseMatrix(new double[][] { { 8.0000000000000000, 16.0000000000000000, 24.0000000000000000 },
+      { -5.0000000000000000, -10.0000000000000000, -15.0000000000000000 },
+      { 1.0000000000000000, 2.0000000000000000, 3.0000000000000000 } });
+
+    // test LowerTri Branch
+    obj[2][0] = new MLDIVIDE(A8, A1);
+    obj[2][1] = new OGRealDenseMatrix(new double[][] { { 1.0000000000000000, 2.0000000000000000, 3.0000000000000000 },
+      { -0.6000000000000000, -1.2000000000000000, -1.8000000000000000 },
+      { -0.1333333333333334, -0.2666666666666667, -0.4000000000000000 } });
+
+    // test Unit LowerTri Branch
+    obj[3][0] = new MLDIVIDE(A9, A1);
+    obj[3][1] = new OGRealDenseMatrix(new double[][] { { 1.0000000000000000, 2.0000000000000000, 3.0000000000000000 },
+      { -3.0000000000000000, -6.0000000000000000, -9.0000000000000000 },
+      { 18.0000000000000000, 36.0000000000000000, 54.0000000000000000 } });
+
+    // test Permuted Upper Triangular Branch
+    obj[4][0] = new MLDIVIDE(A15, C2);
+    obj[4][1] = new OGRealDenseMatrix(new double[][] { { 0.0000000000000000, 8.1445922498554086 }, { 0.0000000000000000, 3.1787160208212839 },
+      { 0.0000000000000000, -2.0971659919028340 },
+      { 0.0000000000000000, 0.9473684210526315 }, { 0.2000000000000000, 1.6000000000000001 } });
+
+    // test Almost Permuted Upper Triangular Branch
+    obj[5][0] = new MLDIVIDE(A17, C2);
+    obj[5][1] = new OGRealDenseMatrix(new double[][] { { 0.0000000000000002, -29.9999999999998650 }, { 0.0000000000000004, -57.8526315789472108 },
+      { -0.0000000000000004, 51.3052631578945864 },
+      { 0.0000000000000000, 0.9473684210526315 }, { 0.2000000000000000, 1.6000000000000001 } });
+
+    // test Permuted Upper Triangular Zero On Diag Branch
+    obj[6][0] = new MLDIVIDE(A16, C1);
+    obj[6][1] = new OGRealDenseMatrix(new double[][] { { 2.0475247524752480 }, { -0.7168316831683170 }, { 0.5287128712871273 }, { 0.2000000000000003 } });
+
+    // test Permuted Upper Triangular Singular To Mach Prec Branch
+    obj[7][0] = new MLDIVIDE(A18, C2);
+    obj[7][1] = new OGRealDenseMatrix(new double[][] { { -0.0000000000000001, 5.7657712505229739 }, { -0.0000000000000001, -1.3196460795883791 },
+      { -0.0000000000000001, 2.6102410879868061 },
+      { 0.0000000000000000, 0.2699985638374270 }, { 0.2000000000000001, 1.5925606778687353 } });
+
+    // test Tri Defined Singular Branch
+    obj[8][0] = new MLDIVIDE(A10, A1);
+    obj[8][1] = new OGRealDenseMatrix(new double[][] { { 0.2941176470588236, 0.5882352941176472, 0.8823529411764708 },
+      { -0.1303167420814479, -0.2606334841628958, -0.3909502262443438 },
+      { -0.0162895927601810, -0.0325791855203620, -0.0488687782805430 } });
+
+    // test Tri Mach Prec Singular Branch
+    obj[9][0] = new MLDIVIDE(A11, A1);
+    obj[9][1] = new OGRealDenseMatrix(new double[][] { { 0.2941176470588236, 0.5882352941176472, 0.8823529411764708 },
+      { -0.1303167420814479, -0.2606334841628958, -0.3909502262443438 },
+      { -0.0162895927601810, -0.0325791855203620, -0.0488687782805430 } });
+
+    // test LUP Branch
+    obj[10][0] = new MLDIVIDE(A3, A1);
+    obj[10][1] = new OGRealDenseMatrix(new double[][] { { 0.0812641083521445, 0.1625282167042890, 0.2437923250564334 }, { 0.0609480812641084, 0.1218961625282167, 0.1828442437923251 },
+      { 0.0654627539503386, 0.1309255079006772, 0.1963882618510158 } });
+
+    // test LUP Branch Fall To LSQ() {
+    obj[11][0] = new MLDIVIDE(A5, A1);
+    obj[11][1] = new OGRealDenseMatrix(new double[][] { { 0.2000000000000003, 0.4000000000000006, 0.6000000000000013 }, { 0.4000000000000002, 0.8000000000000004, 1.2000000000000017 },
+      { -0.0000000000000001, -0.0000000000000001, 0.0000000000000000 } });
+
+    // test Chol Branch
+    obj[12][0] = new MLDIVIDE(A2, A1);
+    obj[12][1] = new OGRealDenseMatrix(new double[][] { { 0.0059171597633136, 0.0118343195266272, 0.0177514792899408 }, { 0.0059171597633136, 0.0118343195266272, 0.0177514792899408 },
+      { 0.0059171597633136, 0.0118343195266272, 0.0177514792899408 } });
+
+    // test Chol Not SPD Branch() {
+    obj[13][0] = new MLDIVIDE(A13, A1);
+    obj[13][1] = new OGRealDenseMatrix(new double[][] { { 0.0150267040825563, 0.0300534081651127, 0.0450801122476691 }, { 0.0988051054584955, 0.1976102109169910, 0.2964153163754866 },
+      { -0.0030174104583446, -0.0060348209166893, -0.0090522313750339 } });
+
+    // test Chol Singular Branch
+    obj[14][0] = new MLDIVIDE(A12, A1);
+    obj[14][1] = new OGRealDenseMatrix(new double[][] { { 0, 0, 0 }, { 1e-300, 2e-300, 3e-300 }, { 0, 0, 0 } });
+
+    // test QR Branch
+    // this is a right pain to test because its rank deficient the results are pulled about by floating point behaviour in deficient part of Q
+    // we test by reconstruction opposed to value
+    obj[15][0] = new PLUS(B1, new NEGATE(new MTIMES(A4, new MLDIVIDE(A4, B1))));
+    obj[15][1] = new OGRealDenseMatrix(new double[B_rectangular.length][B_rectangular[0].length]);
+
+    // test SVD Branch
+    obj[16][0] = new MLDIVIDE(A1, A2);
+    obj[16][1] = new OGRealDenseMatrix(new double[][] { { 4.0238095238095219, 4.0238095238095228, 4.0238095238095219 }, { 8.0476190476190457, 8.0476190476190474, 8.0476190476190457 },
+      { 12.0714285714285658, 12.0714285714285694, 12.0714285714285676 } });
+
+    // this branch tests the necessary expansion of the "B" matrix if the solution to the system is larger than the mallocd space
+    // test DGELS branch Expansion
+    obj[17][0] = new MLDIVIDE(A19, A19);
+    obj[17][1] = new OGRealDenseMatrix(new double[][] { { 0.1379310344827586, 0.2068965517241379, 0.2758620689655172 },
+      { 0.2068965517241379, 0.3103448275862069, 0.4137931034482758 }, { 0.2758620689655172, 0.4137931034482757, 0.5517241379310344 } });
+
+    return obj;
+  }
+
+  //  @Test
+  //  public void testUpperTriBranch() {
+  //    OGTerminal answer = new MLDIVIDE(A6, A1);
+  //    OGRealDenseMatrix expected = new OGRealDenseMatrix(new double[][] { {0.5333333333333334, 1.0666666666666669, 1.6000000000000001 }, {0.0666666666666667, 0.1333333333333334, 0.2000000000000000 },
+  //      {0.1111111111111111, 0.2222222222222222, 0.3333333333333333 } });
+  //    assertTrue(answer.fuzzyequals(expected, 10 * D1mach.four()));
+  //    if (debugStatements) {
+  //      System.out.println(A6.toString());
+  //      System.out.println(A1.toString());
+  //      System.out.println(answer.toString());
+  //    }
+  //  }
+
+  //  @Test
+  //  public void testUnitUpperTriBranch() {
+  //    OGNumeric answer = new MLDIVIDE(A7, A1);
+  //    OGRealDenseMatrix expected = new OGRealDenseMatrix(new double[][] { { 8.0000000000000000, 16.0000000000000000, 24.0000000000000000 },
+  //      { -5.0000000000000000, -10.0000000000000000, -15.0000000000000000 },
+  //      { 1.0000000000000000, 2.0000000000000000, 3.0000000000000000 } });
+  //    assertTrue(answer.fuzzyequals(expected, 10 * D1mach.four()));
+  //    if (debugStatements) {
+  //      System.out.println(A7.toString());
+  //      System.out.println(A1.toString());
+  //      System.out.println(answer.toString());
+  //    }
+  //  }
+
+  //  @Test
+  //  public void testLowerTriBranch() {
+  //    OGNumeric answer = new MLDIVIDE(A8, A1);
+  //    OGRealDenseMatrix expected = new OGRealDenseMatrix(new double[][] { { 1.0000000000000000, 2.0000000000000000, 3.0000000000000000 },
+  //      { -0.6000000000000000, -1.2000000000000000, -1.8000000000000000 },
+  //      { -0.1333333333333334, -0.2666666666666667, -0.4000000000000000 } });
+  //    assertTrue(answer.fuzzyequals(expected, 10 * D1mach.four()));
+  //    if (debugStatements) {
+  //      System.out.println(A8.toString());
+  //      System.out.println(A1.toString());
+  //      System.out.println(answer.toString());
+  //    }
+  //  }
+
+  //  @Test
+  //  public void testUnitLowerTriBranch() {
+  //    OGNumeric answer = new MLDIVIDE(A9, A1);
+  //    OGRealDenseMatrix expected = new OGRealDenseMatrix(new double[][] { { 1.0000000000000000, 2.0000000000000000, 3.0000000000000000 },
+  //      { -3.0000000000000000, -6.0000000000000000, -9.0000000000000000 },
+  //      { 18.0000000000000000, 36.0000000000000000, 54.0000000000000000 } });
+  //    assertTrue(answer.fuzzyequals(expected, 10 * D1mach.four()));
+  //    if (debugStatements) {
+  //      System.out.println(A9.toString());
+  //      System.out.println(A1.toString());
+  //      System.out.println(answer.toString());
+  //    }
+  //  }
+
+  //  @Test
+  //  public void testPermutedUpperTriangularBranch() {
+  //    OGNumeric answer = new MLDIVIDE(A15, C2);
+  //    OGRealDenseMatrix expected = new OGRealDenseMatrix(new double[][] { { 0.0000000000000000, 8.1445922498554086 }, { 0.0000000000000000, 3.1787160208212839 },
+  //      { 0.0000000000000000, -2.0971659919028340 },
+  //      { 0.0000000000000000, 0.9473684210526315 }, { 0.2000000000000000, 1.6000000000000001 } });
+  //    assertTrue(answer.fuzzyequals(expected, 10 * D1mach.four()));
+  //    if (debugStatements) {
+  //      System.out.println("A15" + A15.toString());
+  //      System.out.println("C2" + C2.toString());
+  //      System.out.println(answer.toString());
+  //    }
+  //  }
+
+  //  @Test
+  //  public void testAlmostPermutedUpperTriangularBranch() {
+  //    OGNumeric answer = new MLDIVIDE(A17, C2);
+  //    OGRealDenseMatrix expected = new OGRealDenseMatrix(new double[][] { { 0.0000000000000002, -29.9999999999998650 }, { 0.0000000000000004, -57.8526315789472108 },
+  //      { -0.0000000000000004, 51.3052631578945864 },
+  //      { 0.0000000000000000, 0.9473684210526315 }, { 0.2000000000000000, 1.6000000000000001 } });
+  //    assertTrue(answer.fuzzyequals(expected, 100 * D1mach.four()));
+  //    if (debugStatements) {
+  //      System.out.println("A17" + A17.toString());
+  //      System.out.println("C2" + C2.toString());
+  //      System.out.println(answer.toString());
+  //    }
+  //  }
+
+  //  @Test
+  //  public void testPermutedUpperTriangularZeroOnDiagBranch() {
+  //    OGNumeric answer = new MLDIVIDE(A16, C1);
+  //    OGRealDenseMatrix expected = new OGRealDenseMatrix(new double[][] { { 2.0475247524752480 }, { -0.7168316831683170 }, { 0.5287128712871273 }, { 0.2000000000000003 } });
+  //    assertTrue(answer.fuzzyequals(expected, 10 * D1mach.four()));
+  //    if (debugStatements) {
+  //      System.out.println(A16.toString());
+  //      System.out.println(C1.toString());
+  //      System.out.println(answer.toString());
+  //    }
+  //  }
+
+  //  @Test
+  //  public void testPermutedUpperTriangularSingularToMachPrecBranch() {
+  //    OGNumeric answer = new MLDIVIDE(A18, C2);
+  //    OGRealDenseMatrix expected = new OGRealDenseMatrix(new double[][] { { -0.0000000000000001, 5.7657712505229739 }, { -0.0000000000000001, -1.3196460795883791 },
+  //      { -0.0000000000000001, 2.6102410879868061 },
+  //      { 0.0000000000000000, 0.2699985638374270 }, { 0.2000000000000001, 1.5925606778687353 } });
+  //    assertTrue(answer.fuzzyequals(expected, 100 * D1mach.four()));
+  //    if (debugStatements) {
+  //      System.out.println(A18.toString());
+  //      System.out.println(C2.toString());
+  //      System.out.println(answer.toString());
+  //    }
+  //  }
+
+  //  @Test
+  //  public void testTriDefinedSingularBranch() {
+  //    OGNumeric answer = new MLDIVIDE(A10, A1);
+  //    OGRealDenseMatrix expected = new OGRealDenseMatrix(new double[][] { { 0.2941176470588236, 0.5882352941176472, 0.8823529411764708 },
+  //      { -0.1303167420814479, -0.2606334841628958, -0.3909502262443438 },
+  //      { -0.0162895927601810, -0.0325791855203620, -0.0488687782805430 } });
+  //    assertTrue(answer.fuzzyequals(expected, 10 * D1mach.four()));
+  //    if (debugStatements) {
+  //      System.out.println(A10.toString());
+  //      System.out.println(A1.toString());
+  //      System.out.println(answer.toString());
+  //    }
+  //  }
+
+  //  @Test
+  //  public void testTriMachPrecSingularBranch() {
+  //    OGNumeric answer = new MLDIVIDE(A11, A1);
+  //    OGRealDenseMatrix expected = new OGRealDenseMatrix(new double[][] { { 0.2941176470588236, 0.5882352941176472, 0.8823529411764708 },
+  //      { -0.1303167420814479, -0.2606334841628958, -0.3909502262443438 },
+  //      { -0.0162895927601810, -0.0325791855203620, -0.0488687782805430 } });
+  //    assertTrue(answer.fuzzyequals(expected, 10 * D1mach.four()));
+  //    if (debugStatements) {
+  //      System.out.println(A11.toString());
+  //      System.out.println(A1.toString());
+  //      System.out.println(answer.toString());
+  //    }
+  //  }
+  //
+  //  @Test
+  //  public void testLUPBranch() {
+  //    OGNumeric answer = new MLDIVIDE(A3, A1);
+  //    OGRealDenseMatrix expected = new OGRealDenseMatrix(new double[][] { { 0.0812641083521445, 0.1625282167042890, 0.2437923250564334 }, { 0.0609480812641084, 0.1218961625282167, 0.1828442437923251 },
+  //      { 0.0654627539503386, 0.1309255079006772, 0.1963882618510158 } });
+  //    assertTrue(answer.fuzzyequals(expected, 10 * D1mach.four()));
+  //    if (debugStatements) {
+  //      System.out.println(A3.toString());
+  //      System.out.println(A1.toString());
+  //      System.out.println(answer.toString());
+  //    }
+  //  }
+
+  //  @Test
+  //  public void testLUPBranchFallToLSQ() {
+  //    OGNumeric answer = new MLDIVIDE(A5, A1);
+  //    OGRealDenseMatrix expected = new OGRealDenseMatrix(new double[][] { { 0.2000000000000003, 0.4000000000000006, 0.6000000000000013 }, { 0.4000000000000002, 0.8000000000000004, 1.2000000000000017 },
+  //      { -0.0000000000000001, -0.0000000000000001, 0.0000000000000000 } });
+  //    assertTrue(answer.fuzzyequals(expected, 10 * D1mach.four()));
+  //    if (debugStatements) {
+  //      System.out.println(A5.toString());
+  //      System.out.println(A1.toString());
+  //      System.out.println(answer.toString());
+  //    }
+  //  }
+  //
+  //  @Test
+  //  public void testCholBranch() {
+  //    OGNumeric answer = new MLDIVIDE(A2, A1);
+  //    OGRealDenseMatrix expected = new OGRealDenseMatrix(new double[][] { { 0.0059171597633136, 0.0118343195266272, 0.0177514792899408 }, { 0.0059171597633136, 0.0118343195266272, 0.0177514792899408 },
+  //      { 0.0059171597633136, 0.0118343195266272, 0.0177514792899408 } });
+  //    assertTrue(answer.fuzzyequals(expected, 10 * D1mach.four()));
+  //    if (debugStatements) {
+  //      System.out.println(A1.toString());
+  //      System.out.println(A1.toString());
+  //      System.out.println(answer.toString());
+  //    }
+  //  }
+
+  //  @Test
+  //  public void testCholNotSPDBranch() {
+  //    OGNumeric answer = new MLDIVIDE(A13, A1);
+  //    OGRealDenseMatrix expected = new OGRealDenseMatrix(new double[][] { { 0.0150267040825563, 0.0300534081651127, 0.0450801122476691 }, { 0.0988051054584955, 0.1976102109169910, 0.2964153163754866 },
+  //      { -0.0030174104583446, -0.0060348209166893, -0.0090522313750339 } });
+  //    assertTrue(answer.fuzzyequals(expected, 10 * D1mach.four()));
+  //    if (debugStatements) {
+  //      System.out.println(A13.toString());
+  //      System.out.println(A1.toString());
+  //      System.out.println(answer.toString());
+  //    }
+  //  }
+
+  //  @Test
+  //  public void testCholSingularBranch() {
+  //    OGNumeric answer = new MLDIVIDE(A12, A1);
+  //    OGRealDenseMatrix expected = new OGRealDenseMatrix(new double[][] { { 0, 0, 0 }, { 1e-300, 2e-300, 3e-300 }, { 0, 0, 0 } });
+  //    assertTrue(answer.fuzzyequals(expected, 10 * D1mach.four()));
+  //    if (debugStatements) {
+  //      System.out.println(A12.toString());
+  //      System.out.println(A1.toString());
+  //      System.out.println(answer.toString());
+  //    }
+  //  }
+
+  // this is a right pain to test because its rank deficient the results are pulled about by floating point behaviour in deficient part of Q
+  // we test by reconstruction opposed to absolute value
+  //  @Test
+  //  public void testQRBranch() {
+  //    OGNumeric answer = new MLDIVIDE(A4, B1);
+  //    OGArray<? extends Number> zeros = DOGMA.zeros(B1.getNumberOfRows(), B1.getNumberOfColumns());
+  //    OGArray<? extends Number> reconstruct = DOGMA.minus(B1, DOGMA.mtimes(A4, answer));
+  //    assertTrue(reconstruct.fuzzyequals(zeros, 100 * D1mach.four()));
+  //    if (debugStatements) {
+  //      System.out.println(answer.toString());
+  //    }
+  //  }
+
+  //  @Test
+  //  public void testSVDBranch() {
+  //    OGNumeric answer = new MLDIVIDE(A1, A2);
+  //    OGRealDenseMatrix expected = new OGRealDenseMatrix(new double[][] { { 4.0238095238095219, 4.0238095238095228, 4.0238095238095219 }, { 8.0476190476190457, 8.0476190476190474, 8.0476190476190457 },
+  //      { 12.0714285714285658, 12.0714285714285694, 12.0714285714285676 } });
+  //    assertTrue(answer.fuzzyequals(expected, 10 * D1mach.four()));
+  //    if (debugStatements) {
+  //      System.out.println(answer.toString());
+  //    }
+  //  }
+
+  //  @Test
+  //  // this branch tests the necessary expansion of the "B" matrix if the solution to the system is larger than the mallocd space
+  //  public void testDGELSbranchExpansion() {
+  //    OGNumeric answer = new MLDIVIDE(A19, A19);
+  //    OGRealDenseMatrix expected = new OGRealDenseMatrix(new double[][] { { 0.1379310344827586, 0.2068965517241379, 0.2758620689655172 },
+  //      { 0.2068965517241379, 0.3103448275862069, 0.4137931034482758 }, { 0.2758620689655172, 0.4137931034482757, 0.5517241379310344 } });
+  //    assertTrue(answer.fuzzyequals(expected, 10 * D1mach.four()));
+  //    if (debugStatements) {
+  //      System.out.println(answer.toString());
+  //    }
+  //  }
+
+  @Test(dataProvider = "realDataContainer")
+  public void materialiseToJDoubleArray(OGNumeric input, OGTerminal expected) {
+    double[][] answer = Materialisers.toDoubleArrayOfArrays(input);
+    if (!FuzzyEquals.ArrayFuzzyEquals(Materialisers.toDoubleArrayOfArrays(expected), answer)) {
+      throw new MathsException("Arrays not equal. Got: " + new OGRealDenseMatrix(answer).toString() + " Expected: " + expected.toString());
+    }
+  }
+
+  @Test(dataProvider = "complexDataContainer")
+  public void materialiseToComplexArrayContainer(OGNumeric input, OGTerminal expected) {
+    ComplexArrayContainer answer = Materialisers.toComplexArrayContainer(input);
+    if (!FuzzyEquals.ArrayFuzzyEquals(Materialisers.toComplexArrayContainer(expected).getReal(), answer.getReal())) {
+      throw new MathsException("Arrays not equal. Got: " + new OGRealDenseMatrix(answer.getReal()).toString() + " Expected: " + Arrays.toString(expected.getData()));
+    }
+    if (!FuzzyEquals.ArrayFuzzyEquals(Materialisers.toComplexArrayContainer(expected).getImag(), answer.getImag())) {
+      throw new MathsException("Arrays not equal. Got: " + new OGRealDenseMatrix(answer.getImag()).toString() + " Expected: " + Arrays.toString(expected.getData()));
+    }
+  }
+
+  @Test(dataProvider = "jointdataContainer")
+  public void materialiseToOGTerminal(OGNumeric input, OGTerminal expected) {
+    OGTerminal answer = Materialisers.toOGTerminal(input);
+    if (!expected.mathsequals(answer)) {
+      throw new MathsException("Terminals not equal. Got: " + answer.toString() + " Expected: " + expected.toString());
+    }
+  }
+
+  @Test(dataProvider = "jointdataContainer", expectedExceptions = MathsExceptionIllegalArgument.class)
+  public void outsideArgBound(OGExpr input, OGTerminal expected) {
+    input.getArg(1);
+  }
+
+}

--- a/src/java/src/test/java/com/opengamma/maths/testnodes/TestMldivideMaterialise.java
+++ b/src/java/src/test/java/com/opengamma/maths/testnodes/TestMldivideMaterialise.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2012 - present by OpenGamma Inc. and the OpenGamma group of companies
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
  * 
  * Please see distribution for license.
  */
@@ -7,469 +7,60 @@ package com.opengamma.maths.testnodes;
 
 import static org.testng.Assert.assertTrue;
 
-import java.util.Arrays;
-
-import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import com.opengamma.maths.DOGMA;
-import com.opengamma.maths.datacontainers.OGNumeric;
 import com.opengamma.maths.datacontainers.OGTerminal;
-import com.opengamma.maths.datacontainers.lazy.OGExpr;
-import com.opengamma.maths.datacontainers.matrix.OGArray;
 import com.opengamma.maths.datacontainers.matrix.OGRealDenseMatrix;
-import com.opengamma.maths.datacontainers.other.ComplexArrayContainer;
-import com.opengamma.maths.exceptions.MathsException;
-import com.opengamma.maths.exceptions.MathsExceptionIllegalArgument;
-import com.opengamma.maths.exceptions.MathsExceptionNonConformance;
-import com.opengamma.maths.helpers.FuzzyEquals;
+import com.opengamma.maths.exceptions.MathsExceptionNativeComputation;
 import com.opengamma.maths.materialisers.Materialisers;
 import com.opengamma.maths.nodes.MLDIVIDE;
-import com.opengamma.maths.nodes.MTIMES;
-import com.opengamma.maths.nodes.NEGATE;
-import com.opengamma.maths.nodes.PLUS;
 
 /**
  * Test for mldivide()
  */
 @Test
 public class TestMldivideMaterialise {
-  boolean debugStatements = false; // eyeballable output switch
 
-  private double[][] A_square_singular = new double[][] { { 1.00, 2.00, 3.00 }, { 1.00, 2.00, 3.00 }, { 1.00, 2.00, 3.00 } };
-  private double[][] A_square_symmetric_positive_definite = new double[][] { { 123.00, 23.00, 23.00 }, { 23.00, 123.00, 23.00 }, { 23.00, 23.00, 123.00 } };
-  private double[][] A_square_non_symmetric_well_conditioned = new double[][] { { 10.00, 2.00, 1.00 }, { 2.00, 3.00, 10.00 }, { 4.00, 10.00, 1.00 } };
-  private double[][] A_rectangular = new double[][] { { 1.00, 2.00, 3.00, 4.00 }, { 5.00, 6.00, 7.00, 8.00 }, { 9.00, 10.00, 11.00, 12.00 }, { 13.00, 14.00, 15.00, 16.00 },
-    { 17.00, 18.00, 19.00, 20.00 } };
-  private double[][] A_square_non_symmetric_condition_bad_for_lu_ok_for_qr = new double[][] { { 1.0000000000000009, 2., 20. }, { 1., 2., 0. }, { 1., 2., 40. } };
-  private double[][] A_upper_triangular = new double[][] { { 1., 2., 3. }, { 0., 5., 6. }, { 0., 0., 9. } };;
-  private double[][] A_unit_upper_triangular = new double[][] { { 1., 2., 3. }, { 0., 1., 6. }, { 0., 0., 1. } };
-  private double[][] A_lower_triangular = new double[][] { { 1., 0., 0. }, { 4., 5., 0. }, { 7., 8., 9. } };
-  private double[][] A_unit_lower_triangular = new double[][] { { 1., 0., 0. }, { 4., 1., 0. }, { 7., 8., 1. } };
-  private double[][] A_lower_triangular_singular_zero_on_diag = new double[][] { { 1., 0., 0. }, { 4., 0., 0. }, { 7., 8., 1. } };
-  private double[][] A_lower_triangular_singular_near_zero_on_diag = new double[][] { { 1., 0., 0. }, { 4., 0.0000000000000001, 0. }, { 7., 8., 1. } };
-  private double[][] A_square_spd_near_singular = new double[][] { { 2.0000e+00, 1.0000e+150, 2.0000e+00 }, { 1.0000e+150, 1.0000e+300, 2.0000e+150 }, { 2.0000e+00, 2.0000e+150, 5.0000e+00 } };
-  private double[][] A_square_symmetric_not_spd = new double[][] { { 54., 2., 3. }, { 2., 10., 6. }, { 3., 6., -120. } };
-  private double[][] A_rectangular_with_inf = new double[][] { { Double.POSITIVE_INFINITY, 2.00, 3.00, 4.00 }, { 5.00, 6.00, 7.00, 8.00 }, { 9.00, 10.00, 11.00, 12.00 },
-    { 13.00, 14.00, 15.00, 16.00 },
-    { 17.00, 18.00, 19.00, 20.00 } };
-  private double[][] A_square_permuted_upper_triangular = new double[][] { { 0., 0., 13., 14., 15. }, { 1., 2., 3., 4., 5. }, { 0., 7., 8., 9., 10. }, { 0., 0., 0., 0., 25. },
-    { 0., 0., 0., 19., 20. } };;
-  private double[][] A_square_permuted_upper_triangular_zero_on_diag = new double[][] { { 0., 6., 7., 8. }, { 0., 0., 0., 16. }, { 1., 2., 3., 4. }, { 0., 0., 0., 12. } };
-  private double[][] A_square_almost_permuted_upper_triangular = new double[][] { { 0., 12., 13., 14., 15. }, { 1., 2., 3., 4., 5. }, { 0., 7., 8., 9., 10. }, { 0., 0., 0., 0., 25. },
-    { 0., 0., 0., 19., 20. } };;
-  private double[][] A_square_permuted_upper_triangular_singular_to_mach_prech = new double[][] { { 0., 0., 1.e-300, 14., 15. }, { 1., 2., 3., 4., 5. }, { 0., 7., 8., 9., 10. },
-    { 0., 0., 0., 0., 25. },
-    { 0., 0., 0., 19., 20. } };;
-  private double[][] A_short_row = new double[][] { { 2, 3, 4 } };
-
-  private double[][] B_rectangular = new double[][] { { 1.00, 2.00, 3.00 }, { 1.00, 2.00, 3.00 }, { 1.00, 2.00, 3.00 }, { 1.00, 2.00, 3.00 }, { 1.00, 2.00, 3.00 } };
-
-  private double[] C_4len_col_vector = new double[] { 1, 2, 3, 4 };
-  private double[] C_5len__shuffled_col_matrix = new double[] { 3, 1, 2, 5, 4, 10, 20, 30, 40, 50 };
-
-  OGTerminal A1 = new OGRealDenseMatrix(A_square_singular);
-  OGTerminal A2 = new OGRealDenseMatrix(A_square_symmetric_positive_definite);
-  OGTerminal A3 = new OGRealDenseMatrix(A_square_non_symmetric_well_conditioned);
-  OGTerminal A4 = new OGRealDenseMatrix(A_rectangular);
-  OGTerminal A5 = new OGRealDenseMatrix(A_square_non_symmetric_condition_bad_for_lu_ok_for_qr);
-  OGTerminal A6 = new OGRealDenseMatrix(A_upper_triangular);
-  OGTerminal A7 = new OGRealDenseMatrix(A_unit_upper_triangular);
-  OGTerminal A8 = new OGRealDenseMatrix(A_lower_triangular);
-  OGTerminal A9 = new OGRealDenseMatrix(A_unit_lower_triangular);
-  OGTerminal A10 = new OGRealDenseMatrix(A_lower_triangular_singular_zero_on_diag);
-  OGTerminal A11 = new OGRealDenseMatrix(A_lower_triangular_singular_near_zero_on_diag);
-  OGTerminal A12 = new OGRealDenseMatrix(A_square_spd_near_singular);
-  OGTerminal A13 = new OGRealDenseMatrix(A_square_symmetric_not_spd);
-  OGTerminal A14 = new OGRealDenseMatrix(A_rectangular_with_inf);
-  OGTerminal A15 = new OGRealDenseMatrix(A_square_permuted_upper_triangular);
-  OGTerminal A16 = new OGRealDenseMatrix(A_square_permuted_upper_triangular_zero_on_diag);
-  OGTerminal A17 = new OGRealDenseMatrix(A_square_almost_permuted_upper_triangular);
-  OGTerminal A18 = new OGRealDenseMatrix(A_square_permuted_upper_triangular_singular_to_mach_prech);
-  OGTerminal A19 = new OGRealDenseMatrix(A_short_row);
-
-  OGTerminal B1 = new OGRealDenseMatrix(B_rectangular);
-  OGTerminal C1 = new OGRealDenseMatrix(C_4len_col_vector, 4, 1);
-  OGTerminal C2 = new OGRealDenseMatrix(C_5len__shuffled_col_matrix, 5, 2);
-
-  @Test(expectedExceptions = MathsExceptionNonConformance.class)
-  public void testNonConformance() {
-    DOGMA.toDoubleArrayOfArrays(new MLDIVIDE(A1, B1));
+  // NOTE: test written under new guidelines.
+  // 1 Test for expected exception
+  // 2 Test for expected warn
+  // 3 Test for real space
+  // 4 Test for complex space
+  
+  @Test(expectedExceptions = MathsExceptionNativeComputation.class)
+  public void checkThrowOnNonCommute() {
+    OGRealDenseMatrix A = new OGRealDenseMatrix(new double[] { 1, 2, 3, 4, 5, 6 }, 3, 2);
+    OGRealDenseMatrix B = new OGRealDenseMatrix(new double[] { 1, 2, 3, 4, 5, 6 }, 2, 3);
+    MLDIVIDE mldivide = new MLDIVIDE(A, B);
+    Materialisers.toOGTerminal(mldivide);
   }
 
-  // valid ops for which we have answers
-  @DataProvider
-  public Object[][] realDataContainer() {
-    Object[][] obj = new Object[18][2];
-
-    //test UpperTri Branch
-    obj[0][0] = new MLDIVIDE(A6, A1);
-    obj[0][1] = new OGRealDenseMatrix(new double[][] { { 0.5333333333333334, 1.0666666666666669, 1.6000000000000001 }, { 0.0666666666666667, 0.1333333333333334, 0.2000000000000000 },
-      { 0.1111111111111111, 0.2222222222222222, 0.3333333333333333 } });
-
-    // test Unit UpperTri Branch
-    obj[1][0] = new MLDIVIDE(A7, A1);
-    obj[1][1] = new OGRealDenseMatrix(new double[][] { { 8.0000000000000000, 16.0000000000000000, 24.0000000000000000 },
-      { -5.0000000000000000, -10.0000000000000000, -15.0000000000000000 },
-      { 1.0000000000000000, 2.0000000000000000, 3.0000000000000000 } });
-
-    // test LowerTri Branch
-    obj[2][0] = new MLDIVIDE(A8, A1);
-    obj[2][1] = new OGRealDenseMatrix(new double[][] { { 1.0000000000000000, 2.0000000000000000, 3.0000000000000000 },
-      { -0.6000000000000000, -1.2000000000000000, -1.8000000000000000 },
-      { -0.1333333333333334, -0.2666666666666667, -0.4000000000000000 } });
-
-    // test Unit LowerTri Branch
-    obj[3][0] = new MLDIVIDE(A9, A1);
-    obj[3][1] = new OGRealDenseMatrix(new double[][] { { 1.0000000000000000, 2.0000000000000000, 3.0000000000000000 },
-      { -3.0000000000000000, -6.0000000000000000, -9.0000000000000000 },
-      { 18.0000000000000000, 36.0000000000000000, 54.0000000000000000 } });
-
-    // test Permuted Upper Triangular Branch
-    obj[4][0] = new MLDIVIDE(A15, C2);
-    obj[4][1] = new OGRealDenseMatrix(new double[][] { { 0.0000000000000000, 8.1445922498554086 }, { 0.0000000000000000, 3.1787160208212839 },
-      { 0.0000000000000000, -2.0971659919028340 },
-      { 0.0000000000000000, 0.9473684210526315 }, { 0.2000000000000000, 1.6000000000000001 } });
-
-    // test Almost Permuted Upper Triangular Branch
-    obj[5][0] = new MLDIVIDE(A17, C2);
-    obj[5][1] = new OGRealDenseMatrix(new double[][] { { 0.0000000000000002, -29.9999999999998650 }, { 0.0000000000000004, -57.8526315789472108 },
-      { -0.0000000000000004, 51.3052631578945864 },
-      { 0.0000000000000000, 0.9473684210526315 }, { 0.2000000000000000, 1.6000000000000001 } });
-
-    // test Permuted Upper Triangular Zero On Diag Branch
-    obj[6][0] = new MLDIVIDE(A16, C1);
-    obj[6][1] = new OGRealDenseMatrix(new double[][] { { 2.0475247524752480 }, { -0.7168316831683170 }, { 0.5287128712871273 }, { 0.2000000000000003 } });
-
-    // test Permuted Upper Triangular Singular To Mach Prec Branch
-    obj[7][0] = new MLDIVIDE(A18, C2);
-    obj[7][1] = new OGRealDenseMatrix(new double[][] { { -0.0000000000000001, 5.7657712505229739 }, { -0.0000000000000001, -1.3196460795883791 },
-      { -0.0000000000000001, 2.6102410879868061 },
-      { 0.0000000000000000, 0.2699985638374270 }, { 0.2000000000000001, 1.5925606778687353 } });
-
-    // test Tri Defined Singular Branch
-    obj[8][0] = new MLDIVIDE(A10, A1);
-    obj[8][1] = new OGRealDenseMatrix(new double[][] { { 0.2941176470588236, 0.5882352941176472, 0.8823529411764708 },
-      { -0.1303167420814479, -0.2606334841628958, -0.3909502262443438 },
-      { -0.0162895927601810, -0.0325791855203620, -0.0488687782805430 } });
-
-    // test Tri Mach Prec Singular Branch
-    obj[9][0] = new MLDIVIDE(A11, A1);
-    obj[9][1] = new OGRealDenseMatrix(new double[][] { { 0.2941176470588236, 0.5882352941176472, 0.8823529411764708 },
-      { -0.1303167420814479, -0.2606334841628958, -0.3909502262443438 },
-      { -0.0162895927601810, -0.0325791855203620, -0.0488687782805430 } });
-
-    // test LUP Branch
-    obj[10][0] = new MLDIVIDE(A3, A1);
-    obj[10][1] = new OGRealDenseMatrix(new double[][] { { 0.0812641083521445, 0.1625282167042890, 0.2437923250564334 }, { 0.0609480812641084, 0.1218961625282167, 0.1828442437923251 },
-      { 0.0654627539503386, 0.1309255079006772, 0.1963882618510158 } });
-
-    // test LUP Branch Fall To LSQ() {
-    obj[11][0] = new MLDIVIDE(A5, A1);
-    obj[11][1] = new OGRealDenseMatrix(new double[][] { { 0.2000000000000003, 0.4000000000000006, 0.6000000000000013 }, { 0.4000000000000002, 0.8000000000000004, 1.2000000000000017 },
-      { -0.0000000000000001, -0.0000000000000001, 0.0000000000000000 } });
-
-    // test Chol Branch
-    obj[12][0] = new MLDIVIDE(A2, A1);
-    obj[12][1] = new OGRealDenseMatrix(new double[][] { { 0.0059171597633136, 0.0118343195266272, 0.0177514792899408 }, { 0.0059171597633136, 0.0118343195266272, 0.0177514792899408 },
-      { 0.0059171597633136, 0.0118343195266272, 0.0177514792899408 } });
-
-    // test Chol Not SPD Branch() {
-    obj[13][0] = new MLDIVIDE(A13, A1);
-    obj[13][1] = new OGRealDenseMatrix(new double[][] { { 0.0150267040825563, 0.0300534081651127, 0.0450801122476691 }, { 0.0988051054584955, 0.1976102109169910, 0.2964153163754866 },
-      { -0.0030174104583446, -0.0060348209166893, -0.0090522313750339 } });
-
-    // test Chol Singular Branch
-    obj[14][0] = new MLDIVIDE(A12, A1);
-    obj[14][1] = new OGRealDenseMatrix(new double[][] { { 0, 0, 0 }, { 1e-300, 2e-300, 3e-300 }, { 0, 0, 0 } });
-
-    // test QR Branch
-    // this is a right pain to test because its rank deficient the results are pulled about by floating point behaviour in deficient part of Q
-    // we test by reconstruction opposed to value
-    obj[15][0] = new PLUS(B1, new NEGATE(new MTIMES(A4, new MLDIVIDE(A4, B1))));
-    obj[15][1] = new OGRealDenseMatrix(new double[B_rectangular.length][B_rectangular[0].length]);
-
-    // test SVD Branch
-    obj[16][0] = new MLDIVIDE(A1, A2);
-    obj[16][1] = new OGRealDenseMatrix(new double[][] { { 4.0238095238095219, 4.0238095238095228, 4.0238095238095219 }, { 8.0476190476190457, 8.0476190476190474, 8.0476190476190457 },
-      { 12.0714285714285658, 12.0714285714285694, 12.0714285714285676 } });
-
-    // this branch tests the necessary expansion of the "B" matrix if the solution to the system is larger than the mallocd space
-    // test DGELS branch Expansion
-    obj[17][0] = new MLDIVIDE(A19, A19);
-    obj[17][1] = new OGRealDenseMatrix(new double[][] { { 0.1379310344827586, 0.2068965517241379, 0.2758620689655172 },
-      { 0.2068965517241379, 0.3103448275862069, 0.4137931034482758 }, { 0.2758620689655172, 0.4137931034482757, 0.5517241379310344 } });
-
-    return obj;
+  @Test
+  public void expectWarnOnSingular() {
+    // TODO: assert warn occurs when we have such a mechanism of checking!
+    OGRealDenseMatrix A = new OGRealDenseMatrix(new double[] { 1, 1, 1, 2, 2, 2, 3, 3, 3 }, 3, 3);
+    OGRealDenseMatrix B = new OGRealDenseMatrix(new double[] { 1, 2, 3, 4, 5, 6 }, 3, 2);
+    MLDIVIDE mldivide = new MLDIVIDE(A, B);
+    Materialisers.toOGTerminal(mldivide);
   }
 
-  //  @Test
-  //  public void testUpperTriBranch() {
-  //    OGTerminal answer = new MLDIVIDE(A6, A1);
-  //    OGRealDenseMatrix expected = new OGRealDenseMatrix(new double[][] { {0.5333333333333334, 1.0666666666666669, 1.6000000000000001 }, {0.0666666666666667, 0.1333333333333334, 0.2000000000000000 },
-  //      {0.1111111111111111, 0.2222222222222222, 0.3333333333333333 } });
-  //    assertTrue(answer.fuzzyequals(expected, 10 * D1mach.four()));
-  //    if (debugStatements) {
-  //      System.out.println(A6.toString());
-  //      System.out.println(A1.toString());
-  //      System.out.println(answer.toString());
-  //    }
-  //  }
-
-  //  @Test
-  //  public void testUnitUpperTriBranch() {
-  //    OGNumeric answer = new MLDIVIDE(A7, A1);
-  //    OGRealDenseMatrix expected = new OGRealDenseMatrix(new double[][] { { 8.0000000000000000, 16.0000000000000000, 24.0000000000000000 },
-  //      { -5.0000000000000000, -10.0000000000000000, -15.0000000000000000 },
-  //      { 1.0000000000000000, 2.0000000000000000, 3.0000000000000000 } });
-  //    assertTrue(answer.fuzzyequals(expected, 10 * D1mach.four()));
-  //    if (debugStatements) {
-  //      System.out.println(A7.toString());
-  //      System.out.println(A1.toString());
-  //      System.out.println(answer.toString());
-  //    }
-  //  }
-
-  //  @Test
-  //  public void testLowerTriBranch() {
-  //    OGNumeric answer = new MLDIVIDE(A8, A1);
-  //    OGRealDenseMatrix expected = new OGRealDenseMatrix(new double[][] { { 1.0000000000000000, 2.0000000000000000, 3.0000000000000000 },
-  //      { -0.6000000000000000, -1.2000000000000000, -1.8000000000000000 },
-  //      { -0.1333333333333334, -0.2666666666666667, -0.4000000000000000 } });
-  //    assertTrue(answer.fuzzyequals(expected, 10 * D1mach.four()));
-  //    if (debugStatements) {
-  //      System.out.println(A8.toString());
-  //      System.out.println(A1.toString());
-  //      System.out.println(answer.toString());
-  //    }
-  //  }
-
-  //  @Test
-  //  public void testUnitLowerTriBranch() {
-  //    OGNumeric answer = new MLDIVIDE(A9, A1);
-  //    OGRealDenseMatrix expected = new OGRealDenseMatrix(new double[][] { { 1.0000000000000000, 2.0000000000000000, 3.0000000000000000 },
-  //      { -3.0000000000000000, -6.0000000000000000, -9.0000000000000000 },
-  //      { 18.0000000000000000, 36.0000000000000000, 54.0000000000000000 } });
-  //    assertTrue(answer.fuzzyequals(expected, 10 * D1mach.four()));
-  //    if (debugStatements) {
-  //      System.out.println(A9.toString());
-  //      System.out.println(A1.toString());
-  //      System.out.println(answer.toString());
-  //    }
-  //  }
-
-  //  @Test
-  //  public void testPermutedUpperTriangularBranch() {
-  //    OGNumeric answer = new MLDIVIDE(A15, C2);
-  //    OGRealDenseMatrix expected = new OGRealDenseMatrix(new double[][] { { 0.0000000000000000, 8.1445922498554086 }, { 0.0000000000000000, 3.1787160208212839 },
-  //      { 0.0000000000000000, -2.0971659919028340 },
-  //      { 0.0000000000000000, 0.9473684210526315 }, { 0.2000000000000000, 1.6000000000000001 } });
-  //    assertTrue(answer.fuzzyequals(expected, 10 * D1mach.four()));
-  //    if (debugStatements) {
-  //      System.out.println("A15" + A15.toString());
-  //      System.out.println("C2" + C2.toString());
-  //      System.out.println(answer.toString());
-  //    }
-  //  }
-
-  //  @Test
-  //  public void testAlmostPermutedUpperTriangularBranch() {
-  //    OGNumeric answer = new MLDIVIDE(A17, C2);
-  //    OGRealDenseMatrix expected = new OGRealDenseMatrix(new double[][] { { 0.0000000000000002, -29.9999999999998650 }, { 0.0000000000000004, -57.8526315789472108 },
-  //      { -0.0000000000000004, 51.3052631578945864 },
-  //      { 0.0000000000000000, 0.9473684210526315 }, { 0.2000000000000000, 1.6000000000000001 } });
-  //    assertTrue(answer.fuzzyequals(expected, 100 * D1mach.four()));
-  //    if (debugStatements) {
-  //      System.out.println("A17" + A17.toString());
-  //      System.out.println("C2" + C2.toString());
-  //      System.out.println(answer.toString());
-  //    }
-  //  }
-
-  //  @Test
-  //  public void testPermutedUpperTriangularZeroOnDiagBranch() {
-  //    OGNumeric answer = new MLDIVIDE(A16, C1);
-  //    OGRealDenseMatrix expected = new OGRealDenseMatrix(new double[][] { { 2.0475247524752480 }, { -0.7168316831683170 }, { 0.5287128712871273 }, { 0.2000000000000003 } });
-  //    assertTrue(answer.fuzzyequals(expected, 10 * D1mach.four()));
-  //    if (debugStatements) {
-  //      System.out.println(A16.toString());
-  //      System.out.println(C1.toString());
-  //      System.out.println(answer.toString());
-  //    }
-  //  }
-
-  //  @Test
-  //  public void testPermutedUpperTriangularSingularToMachPrecBranch() {
-  //    OGNumeric answer = new MLDIVIDE(A18, C2);
-  //    OGRealDenseMatrix expected = new OGRealDenseMatrix(new double[][] { { -0.0000000000000001, 5.7657712505229739 }, { -0.0000000000000001, -1.3196460795883791 },
-  //      { -0.0000000000000001, 2.6102410879868061 },
-  //      { 0.0000000000000000, 0.2699985638374270 }, { 0.2000000000000001, 1.5925606778687353 } });
-  //    assertTrue(answer.fuzzyequals(expected, 100 * D1mach.four()));
-  //    if (debugStatements) {
-  //      System.out.println(A18.toString());
-  //      System.out.println(C2.toString());
-  //      System.out.println(answer.toString());
-  //    }
-  //  }
-
-  //  @Test
-  //  public void testTriDefinedSingularBranch() {
-  //    OGNumeric answer = new MLDIVIDE(A10, A1);
-  //    OGRealDenseMatrix expected = new OGRealDenseMatrix(new double[][] { { 0.2941176470588236, 0.5882352941176472, 0.8823529411764708 },
-  //      { -0.1303167420814479, -0.2606334841628958, -0.3909502262443438 },
-  //      { -0.0162895927601810, -0.0325791855203620, -0.0488687782805430 } });
-  //    assertTrue(answer.fuzzyequals(expected, 10 * D1mach.four()));
-  //    if (debugStatements) {
-  //      System.out.println(A10.toString());
-  //      System.out.println(A1.toString());
-  //      System.out.println(answer.toString());
-  //    }
-  //  }
-
-  //  @Test
-  //  public void testTriMachPrecSingularBranch() {
-  //    OGNumeric answer = new MLDIVIDE(A11, A1);
-  //    OGRealDenseMatrix expected = new OGRealDenseMatrix(new double[][] { { 0.2941176470588236, 0.5882352941176472, 0.8823529411764708 },
-  //      { -0.1303167420814479, -0.2606334841628958, -0.3909502262443438 },
-  //      { -0.0162895927601810, -0.0325791855203620, -0.0488687782805430 } });
-  //    assertTrue(answer.fuzzyequals(expected, 10 * D1mach.four()));
-  //    if (debugStatements) {
-  //      System.out.println(A11.toString());
-  //      System.out.println(A1.toString());
-  //      System.out.println(answer.toString());
-  //    }
-  //  }
-  //
-  //  @Test
-  //  public void testLUPBranch() {
-  //    OGNumeric answer = new MLDIVIDE(A3, A1);
-  //    OGRealDenseMatrix expected = new OGRealDenseMatrix(new double[][] { { 0.0812641083521445, 0.1625282167042890, 0.2437923250564334 }, { 0.0609480812641084, 0.1218961625282167, 0.1828442437923251 },
-  //      { 0.0654627539503386, 0.1309255079006772, 0.1963882618510158 } });
-  //    assertTrue(answer.fuzzyequals(expected, 10 * D1mach.four()));
-  //    if (debugStatements) {
-  //      System.out.println(A3.toString());
-  //      System.out.println(A1.toString());
-  //      System.out.println(answer.toString());
-  //    }
-  //  }
-
-  //  @Test
-  //  public void testLUPBranchFallToLSQ() {
-  //    OGNumeric answer = new MLDIVIDE(A5, A1);
-  //    OGRealDenseMatrix expected = new OGRealDenseMatrix(new double[][] { { 0.2000000000000003, 0.4000000000000006, 0.6000000000000013 }, { 0.4000000000000002, 0.8000000000000004, 1.2000000000000017 },
-  //      { -0.0000000000000001, -0.0000000000000001, 0.0000000000000000 } });
-  //    assertTrue(answer.fuzzyequals(expected, 10 * D1mach.four()));
-  //    if (debugStatements) {
-  //      System.out.println(A5.toString());
-  //      System.out.println(A1.toString());
-  //      System.out.println(answer.toString());
-  //    }
-  //  }
-  //
-  //  @Test
-  //  public void testCholBranch() {
-  //    OGNumeric answer = new MLDIVIDE(A2, A1);
-  //    OGRealDenseMatrix expected = new OGRealDenseMatrix(new double[][] { { 0.0059171597633136, 0.0118343195266272, 0.0177514792899408 }, { 0.0059171597633136, 0.0118343195266272, 0.0177514792899408 },
-  //      { 0.0059171597633136, 0.0118343195266272, 0.0177514792899408 } });
-  //    assertTrue(answer.fuzzyequals(expected, 10 * D1mach.four()));
-  //    if (debugStatements) {
-  //      System.out.println(A1.toString());
-  //      System.out.println(A1.toString());
-  //      System.out.println(answer.toString());
-  //    }
-  //  }
-
-  //  @Test
-  //  public void testCholNotSPDBranch() {
-  //    OGNumeric answer = new MLDIVIDE(A13, A1);
-  //    OGRealDenseMatrix expected = new OGRealDenseMatrix(new double[][] { { 0.0150267040825563, 0.0300534081651127, 0.0450801122476691 }, { 0.0988051054584955, 0.1976102109169910, 0.2964153163754866 },
-  //      { -0.0030174104583446, -0.0060348209166893, -0.0090522313750339 } });
-  //    assertTrue(answer.fuzzyequals(expected, 10 * D1mach.four()));
-  //    if (debugStatements) {
-  //      System.out.println(A13.toString());
-  //      System.out.println(A1.toString());
-  //      System.out.println(answer.toString());
-  //    }
-  //  }
-
-  //  @Test
-  //  public void testCholSingularBranch() {
-  //    OGNumeric answer = new MLDIVIDE(A12, A1);
-  //    OGRealDenseMatrix expected = new OGRealDenseMatrix(new double[][] { { 0, 0, 0 }, { 1e-300, 2e-300, 3e-300 }, { 0, 0, 0 } });
-  //    assertTrue(answer.fuzzyequals(expected, 10 * D1mach.four()));
-  //    if (debugStatements) {
-  //      System.out.println(A12.toString());
-  //      System.out.println(A1.toString());
-  //      System.out.println(answer.toString());
-  //    }
-  //  }
-
-  // this is a right pain to test because its rank deficient the results are pulled about by floating point behaviour in deficient part of Q
-  // we test by reconstruction opposed to absolute value
-  //  @Test
-  //  public void testQRBranch() {
-  //    OGNumeric answer = new MLDIVIDE(A4, B1);
-  //    OGArray<? extends Number> zeros = DOGMA.zeros(B1.getNumberOfRows(), B1.getNumberOfColumns());
-  //    OGArray<? extends Number> reconstruct = DOGMA.minus(B1, DOGMA.mtimes(A4, answer));
-  //    assertTrue(reconstruct.fuzzyequals(zeros, 100 * D1mach.four()));
-  //    if (debugStatements) {
-  //      System.out.println(answer.toString());
-  //    }
-  //  }
-
-  //  @Test
-  //  public void testSVDBranch() {
-  //    OGNumeric answer = new MLDIVIDE(A1, A2);
-  //    OGRealDenseMatrix expected = new OGRealDenseMatrix(new double[][] { { 4.0238095238095219, 4.0238095238095228, 4.0238095238095219 }, { 8.0476190476190457, 8.0476190476190474, 8.0476190476190457 },
-  //      { 12.0714285714285658, 12.0714285714285694, 12.0714285714285676 } });
-  //    assertTrue(answer.fuzzyequals(expected, 10 * D1mach.four()));
-  //    if (debugStatements) {
-  //      System.out.println(answer.toString());
-  //    }
-  //  }
-
-  //  @Test
-  //  // this branch tests the necessary expansion of the "B" matrix if the solution to the system is larger than the mallocd space
-  //  public void testDGELSbranchExpansion() {
-  //    OGNumeric answer = new MLDIVIDE(A19, A19);
-  //    OGRealDenseMatrix expected = new OGRealDenseMatrix(new double[][] { { 0.1379310344827586, 0.2068965517241379, 0.2758620689655172 },
-  //      { 0.2068965517241379, 0.3103448275862069, 0.4137931034482758 }, { 0.2758620689655172, 0.4137931034482757, 0.5517241379310344 } });
-  //    assertTrue(answer.fuzzyequals(expected, 10 * D1mach.four()));
-  //    if (debugStatements) {
-  //      System.out.println(answer.toString());
-  //    }
-  //  }
-
-  @Test(dataProvider = "realDataContainer")
-  public void materialiseToJDoubleArray(OGNumeric input, OGTerminal expected) {
-    double[][] answer = Materialisers.toDoubleArrayOfArrays(input);
-    if (!FuzzyEquals.ArrayFuzzyEquals(Materialisers.toDoubleArrayOfArrays(expected), answer)) {
-      throw new MathsException("Arrays not equal. Got: " + new OGRealDenseMatrix(answer).toString() + " Expected: " + expected.toString());
-    }
+  public void checkRealSpaceResult() {
+    OGRealDenseMatrix A = new OGRealDenseMatrix(new double[] { 1, 1, 1, 2, 2, 2, 3, 3, 3 }, 3, 3);
+    OGRealDenseMatrix B = new OGRealDenseMatrix(new double[] { 1, 2, 3, 4, 5, 6 }, 3, 2);
+    MLDIVIDE mldivide = new MLDIVIDE(A, B);
+    OGTerminal answer = Materialisers.toOGTerminal(mldivide);
+    OGTerminal expected = new OGRealDenseMatrix(new double[][] { { 0.1428571428571428, 0.3571428571428570 }, { 0.2857142857142857, 0.7142857142857144 }, { 0.4285714285714285, 1.0714285714285712 } });
+    assertTrue(expected.mathsequals(answer));
   }
 
-  @Test(dataProvider = "complexDataContainer")
-  public void materialiseToComplexArrayContainer(OGNumeric input, OGTerminal expected) {
-    ComplexArrayContainer answer = Materialisers.toComplexArrayContainer(input);
-    if (!FuzzyEquals.ArrayFuzzyEquals(Materialisers.toComplexArrayContainer(expected).getReal(), answer.getReal())) {
-      throw new MathsException("Arrays not equal. Got: " + new OGRealDenseMatrix(answer.getReal()).toString() + " Expected: " + Arrays.toString(expected.getData()));
-    }
-    if (!FuzzyEquals.ArrayFuzzyEquals(Materialisers.toComplexArrayContainer(expected).getImag(), answer.getImag())) {
-      throw new MathsException("Arrays not equal. Got: " + new OGRealDenseMatrix(answer.getImag()).toString() + " Expected: " + Arrays.toString(expected.getData()));
-    }
-  }
-
-  @Test(dataProvider = "jointdataContainer")
-  public void materialiseToOGTerminal(OGNumeric input, OGTerminal expected) {
-    OGTerminal answer = Materialisers.toOGTerminal(input);
-    if (!expected.mathsequals(answer)) {
-      throw new MathsException("Terminals not equal. Got: " + answer.toString() + " Expected: " + expected.toString());
-    }
-  }
-
-  @Test(dataProvider = "jointdataContainer", expectedExceptions = MathsExceptionIllegalArgument.class)
-  public void outsideArgBound(OGExpr input, OGTerminal expected) {
-    input.getArg(1);
+  public void checkComplexSpaceResult() {
+    OGRealDenseMatrix A = new OGRealDenseMatrix(new double[][] { { 10.0000000000000000, 2.0000000000000000, 3.0000000000000000 }, { 4.0000000000000000, 50.0000000000000000, 6.0000000000000000 },
+      { 7.0000000000000000, 8.0000000000000000, 9.0000000000000000 } });
+    OGRealDenseMatrix B = new OGRealDenseMatrix(new double[][] { { 1.0000000000000000, 4.0000000000000000 }, { 2.0000000000000000, 5.0000000000000000 }, { 3.0000000000000000, 6.0000000000000000 } });
+    MLDIVIDE mldivide = new MLDIVIDE(A, B);
+    OGTerminal answer = Materialisers.toOGTerminal(mldivide);
+    OGTerminal expected = new OGRealDenseMatrix(new double[][] { { 0.0000000000000001, 1.1052631578947369 }, { 0.0000000000000000, 0.1105263157894738 }, { 1.3999999999999997, 1.8421052631578940 } });
+    assertTrue(expected.mathsequals(answer,1e-15,1e-15));
   }
 
 }

--- a/src/librdag/CMakeLists.txt
+++ b/src/librdag/CMakeLists.txt
@@ -28,13 +28,14 @@ set(RDAG_SOURCES convertto.cc
                  terminal.cc
                  runners/ctransposerunner.cc
                  runners/invrunner.cc
+                 runners/lurunner.cc
+                 runners/mldividerunner.cc
                  runners/mtimesrunner.cc
                  runners/norm2runner.cc
                  runners/pinvrunner.cc
                  runners/selectresultrunner.cc
                  runners/svdrunner.cc
                  runners/transposerunner.cc
-                 runners/lurunner.cc
                  ${RDAG_GENERATED})
 
 include(${LAPACK_BUILDINFO})

--- a/src/librdag/expressionbase.cc
+++ b/src/librdag/expressionbase.cc
@@ -470,4 +470,42 @@ MTIMES::getType() const
   return MTIMES_ENUM;
 }
 
+
+/**
+ * MLDIVIDE node
+ */
+
+MLDIVIDE::MLDIVIDE(const OGNumeric::Ptr& arg0, const OGNumeric::Ptr& arg1): OGBinaryExpr{arg0, arg1} {}
+
+MLDIVIDE::Ptr
+MLDIVIDE::create(const OGNumeric::Ptr& arg0, const OGNumeric::Ptr& arg1)
+{
+  return MLDIVIDE::Ptr{new MLDIVIDE{arg0, arg1}};
+}
+
+
+OGNumeric::Ptr
+MLDIVIDE::copy() const
+{
+  return OGNumeric::Ptr{new MLDIVIDE(_args[0]->copy(), _args[1]->copy())};
+}
+
+MLDIVIDE::Ptr
+MLDIVIDE::asMLDIVIDE() const
+{
+  return static_pointer_cast<const MLDIVIDE, const OGNumeric>(shared_from_this());
+}
+
+void
+MLDIVIDE::debug_print() const
+{
+        cout << "MLDIVIDE base class" << endl;
+}
+
+ExprType_t
+MLDIVIDE::getType() const
+{
+  return MLDIVIDE_ENUM;
+}
+
 } // namespace librdag

--- a/src/librdag/numericbase.cc
+++ b/src/librdag/numericbase.cc
@@ -82,6 +82,12 @@ OGNumeric::asLU() const
   return LU::Ptr{};
 }
 
+MLDIVIDE::Ptr
+OGNumeric::asMLDIVIDE() const
+{
+  return MLDIVIDE::Ptr{};
+}
+
 OGExpr::Ptr
 OGNumeric::asOGExpr() const
 {

--- a/src/librdag/runners/mldividerunner.cc
+++ b/src/librdag/runners/mldividerunner.cc
@@ -1,0 +1,881 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for licence.
+ *
+ */
+
+#include "dispatch.hh"
+#include "runners.hh"
+#include "expression.hh"
+#include "iss.hh"
+#include "terminal.hh"
+#include "uncopyable.hh"
+#include "lapack.hh"
+#include "equals.hh"
+
+#include <stdio.h>
+#include <complex>
+#include <sstream>
+
+using namespace std;
+
+/*
+ * Unit contains code for MLDIVIDE node runners
+ */
+
+namespace librdag
+{
+
+/**
+ * Local implementation details.
+ */
+namespace detail
+{
+
+/**
+ * Template to create a "real" number in a given domain.
+ */
+template<typename T> T ndm(real8 val) {}
+
+template<> real8 ndm(real8 val)
+{
+  return val;
+}
+
+template<> complex16 ndm(real8 val)
+{
+  return complex16(val, 0.e0);
+}
+
+/**
+ * Casts a value to a char
+ * @param the value to cast
+ * @return the char representation of the value
+ */
+template<typename T> char asChar(T value)
+{
+  return static_cast<char>(value);
+}
+
+// Auxiliary structs for holding intermediary guiding data
+
+
+// NOTE: The following enums are used in some cases to pass flags to lapack.
+// Ideally lapack:: members holding `char *` would be used, but these are
+// declared extern which conflicts with the constexpr needed in the following.
+// At some point, for completeness, this could be fixed.
+
+/**
+ * UPLO flags upper or lower triangular matrix.
+ */
+enum class UPLO: char
+{
+  /**
+   * Flags neither upper or lower.
+   */
+  NEITHER = 'N',
+  /**
+   * Flags an upper triangular matrix.
+   */
+  UPPER = 'U',
+  /**
+   * Flags a lower triangular matrix.
+   */
+  LOWER = 'L'
+};
+
+/**
+ * UNITDIAG flags if a triangular matrix has a unit diagonal.
+ */
+enum class UNITDIAG: char
+{
+  /**
+   * Flags a unit diagonal.
+   */
+  UNIT    = 'U',
+  /**
+   * Flags a non-unit diagonal.
+   */
+  NONUNIT = 'N'
+};
+
+/**
+ * PERMUTATION flags the possible permutation type identifiable in a triangular matrix.
+ */
+enum class PERMUTATION: char
+{
+  /**
+   * Flags as standard, no permutation present.
+   */
+  STANDARD = 'S',
+  /**
+   * Flags as a row permutation.
+   */
+  ROW      = 'R',
+  /**
+   * Flags as a column permutation.
+   */
+  COLUMN   = 'C',
+  /**
+   * Flags as not triangular.
+   */
+  NOTTRIANGULAR = 'N'
+};
+
+/**
+ * This struct holds the state from deciding if a matrix is in some way triangular.
+ */
+struct TriangularStruct
+{
+  UPLO flagUPLO = UPLO::NEITHER;
+  UNITDIAG flagDiag = UNITDIAG::NONUNIT;
+  PERMUTATION flagPerm = PERMUTATION::STANDARD;
+  unique_ptr<size_t[]> perm = nullptr;
+ /**
+  * Flags are based on LAPACK chars
+  * @param flagUPLO is it upper or lower
+  * @param flagDiag is it diagonal
+  * @param flagPerm is it permuted
+  * @param perm the permutation applied, can be null if \a flagPerm is \a PERMUTATION::STANDARD
+  */
+};
+
+// These are helper routines
+
+/**
+ * Checks if a matrix is symmetric.
+ * @param data the data from the matrix, column major
+ * @param rows the number of rows
+ * @param cols the number of columns
+ * @return true if symmetric false else.
+ */
+template<typename T>
+bool isSymmetric(T * data, size_t rows, size_t cols)
+{
+  size_t ir;
+  for (size_t i = 0; i < cols; i++)
+  {
+    ir = i * rows;
+    for (size_t j = 0; j < rows; j++)
+    {
+      if (data[ir + j] != data[j * rows + i])
+      {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+
+/**
+ * Checks if a matrix is lower triangular
+ */
+template<typename T>
+void checkIfLowerTriangular(T * data, size_t rows, size_t cols, UPLO* tri, UNITDIAG* diag)
+{
+  // check lower
+  size_t ir;
+  *tri = UPLO::LOWER;
+  *diag = UNITDIAG::UNIT;
+  bool isUnit = true;
+  if (!SingleValueFuzzyEquals(data[0],ndm<T>(1.e0),std::numeric_limits<real8>::epsilon(),std::numeric_limits<real8>::epsilon()))
+  {
+    *diag = UNITDIAG::NONUNIT;
+  }
+  for (size_t  i = 1; i < cols; i++)
+  {
+    ir = i * rows;
+    // check if diag == 1
+    if (isUnit)
+    {
+      if(!SingleValueFuzzyEquals(data[ir +i],1.e0,std::numeric_limits<real8>::epsilon(),std::numeric_limits<real8>::epsilon()))
+      {
+        cout << "13. checking lower:: not unit diag at element [" << i << "," << i << "]" << "found value = "<< data[ir + i] << std::endl;
+        *diag = UNITDIAG::NONUNIT;
+        isUnit = false;
+      }
+    }
+    for (size_t j = 0; j < i; j++)  // check if upper triangle is empty
+    {
+      if (!SingleValueFuzzyEquals(data[ir + j],0.e0,std::numeric_limits<real8>::epsilon(),std::numeric_limits<real8>::epsilon()))
+      {
+        cout << "14. checking lower:: returning as nonzero in upper triangle at [" << j << "," << i << "]" << "found value = "<< data[ir + j] << std::endl;
+        SingleValueFuzzyEquals(data[ir +j],0.e0,std::numeric_limits<real8>::epsilon(),std::numeric_limits<real8>::epsilon());
+        *tri = UPLO::NEITHER;
+        return;
+      }
+    }
+  }
+}
+
+/**
+ * Checks if a square matrix contains an upper triangular matrix or row permutation of
+ */
+template<typename T>
+void checkIfUpperTriangularPermuteRows(T * data, size_t rows, size_t cols,  TriangularStruct * ret)
+{
+  unique_ptr<size_t[]> rowStarts (new size_t[rows]);
+  std::fill(rowStarts.get(), rowStarts.get() + rows, -1);// -1 is our flag
+
+  std::unique_ptr<bool[]> rowTagPtr (new bool[rows]);
+  bool * rowTag = rowTagPtr.get();
+  std::fill(rowTag,rowTag+rows,false);
+
+  ret->flagDiag = UNITDIAG::UNIT;
+  bool upperTriangleIfValidIspermuted = false;
+  bool validPermutation = true;
+  bool isUDswitch = true; // is unit diag
+
+  // Check if its lower all 0
+  // walk rows to look for when number appears in [0...0, Number....]
+  for (size_t i = 0; i < cols; i++)
+  {
+    for (size_t j = 0; j < rows; j++)
+    {
+      if (
+        rowStarts.get()[j] == -1 // we've not seen this row before
+        && // AND
+        // it's not got a zero at location j.
+        !SingleValueFuzzyEquals(data[i * rows + j],0.e0,std::numeric_limits<real8>::epsilon(),std::numeric_limits<real8>::epsilon())
+      )
+      {
+        if (isUDswitch && !SingleValueFuzzyEquals(data[i * rows + j],1.e0,std::numeric_limits<real8>::epsilon(),std::numeric_limits<real8>::epsilon()))
+        {
+          cout << "16. checking upper:: not unit diag at element [" << i << "," << j << "]" << std::endl;
+          ret->flagDiag = UNITDIAG::NONUNIT; // not unit diagonal
+          isUDswitch = false;
+        }
+        rowStarts.get()[j] = i;
+      }
+    }
+  }
+  // Check to see if the matrix is a permutation of an upper triangle
+  // Do this by checking that the claimed start of rows cover all columns
+  // first set flags, then check flags, complete set needed to assess whether the perm is present
+  for (size_t i = 0; i < rows; i++)
+  {
+    if (!rowTag[rowStarts.get()[i]])
+    {
+      rowTag[rowStarts.get()[i]] = true;
+    }
+    if (!upperTriangleIfValidIspermuted && rowStarts.get()[i] != i)
+    {
+      upperTriangleIfValidIspermuted = true;
+    }
+  }
+  for (size_t i = 0; i < rows; i++)
+  {
+    if (!rowTag[i])
+    {
+      validPermutation = false;
+      break;
+    }
+  }
+  if (!validPermutation)
+  {
+    cout << "17. checking upper:: not upper triangular, permuted or otherwise" << std::endl;
+    ret->flagPerm = PERMUTATION::NOTTRIANGULAR;
+    ret->flagDiag = UNITDIAG::NONUNIT;
+  }
+  else
+  {
+    if(upperTriangleIfValidIspermuted)
+    {
+      // permutation is valid, update struct. foo(rowStarts) = 1: length(rowStarts) gives direct perm
+      cout << "18. checking upper:: Row permutation spotted" << std::endl;
+      ret->flagPerm = PERMUTATION::ROW;
+      ret->perm = std::move(rowStarts);
+    }
+    else
+    {
+      cout << "19. checking upper:: standard upper triangle" << std::endl;
+      ret->flagPerm = PERMUTATION::STANDARD;
+    }
+  }
+  return;
+}
+
+
+template<typename T>
+std::unique_ptr<TriangularStruct> isTriangular(T * data, size_t rows, size_t cols)
+{
+  std::unique_ptr<TriangularStruct> tptr (new TriangularStruct());
+  TriangularStruct * ref = tptr.get();
+
+  // See if it's lower triangular
+  checkIfLowerTriangular(data, rows, cols, &(ref->flagUPLO), &(ref->flagDiag));
+  if (ref->flagUPLO != UPLO::NEITHER)
+  {
+    return tptr;
+  }
+
+  // See if it's Upper or permuted upper
+  checkIfUpperTriangularPermuteRows(data, rows, cols, ref);
+  if (ref->flagPerm == PERMUTATION::ROW || ref->flagPerm == PERMUTATION::STANDARD )
+  {
+    ref->flagUPLO = UPLO::UPPER;
+    return tptr;
+  }
+
+  // DEFAULT, not triangular in any way
+  return tptr;
+
+}
+
+
+} // end namespace detail
+
+// This is a rough translation of OG mldivide from OG-Maths_Legacy ~2012,
+//  which in turn is based on my libllsq from ~2011
+template<typename T>
+void*
+mldivide_dense_runner(RegContainer& reg0, shared_ptr<const OGMatrix<T>> arg0, shared_ptr<const OGMatrix<T>> arg1)
+{
+
+  // data from array 1 (A)
+  T * ptrdata1 = arg0->getData();
+  std::size_t rows1 = arg0->getRows();
+  std::size_t cols1 = arg0->getCols();
+  int4 int4rows1 = rows1;
+  int4 int4cols1 = cols1;
+  std::size_t len1 = rows1 * cols1;
+  std::unique_ptr<T[]> data1Ptr (new T[len1]);
+  T * data1 = data1Ptr.get();
+  std::copy(ptrdata1,ptrdata1+len1,data1);
+
+  // data from array 2 (B)
+  T * ptrdata2 = arg1->getData();
+  std::size_t rows2 = arg1->getRows();
+  std::size_t cols2 = arg1->getCols();
+  int4 int4rows2 = rows2;
+  int4 int4cols2 = cols2;
+  std::size_t len2 = rows2 * cols2;
+  std::unique_ptr<T[]> data2Ptr (new T[len2]);
+  T * data2 = data2Ptr.get();
+  std::copy(ptrdata2,ptrdata2+len2,data2);
+
+  // useful vars
+  real8 rcond = 0; // estimate of reciprocal condition number
+  real8 anorm = 0; // the 1 norm of a matrix
+  bool singular = false; // is the matrix identified as singular
+  bool attemptQR = true; // should QR decomposition be attempted for singular/over determined systems prior to using SVD?
+
+  //auxiallary vars
+
+  // for pointer switching if a perm is needed but system is bad and needs resetting
+  unique_ptr<T[]> triPtr1Ptr = nullptr;
+  unique_ptr<T[]> triPtr2Ptr = nullptr;
+  T * triPtr1 = nullptr;
+  T * triPtr2 = nullptr;
+
+  // pointer switching for case when xgels creates a bigger system than for which there's space
+  unique_ptr<T[]> bdata2Ptr = nullptr;
+
+  // the permutation vector, if needed
+//   std::size_t * permuteV = nullptr;
+
+  // flow control
+  // set if matrix is triangular and singular so that other standard decompositions are skipped and a least squares result is attempted immediately
+  bool jmp = false;
+
+  // return item
+  OGNumeric::Ptr ret;
+
+  // Approx alg: This is based loosely on my llsq library, see internal OG C code.
+  // 1) check if system commutes
+  // 2) check if square ? goto 3) : goto 6)
+  // 3) check if triangular (or perm of), if so compute rcond, if rcond ok solve else goto 6), if solve fails goto 6)
+  // 4) check if symmetric, if so, try cholesky, if decomp fails it's not s.p.d. If decomp succeeds, try solve, if fails, compute rcond and goto 6)
+  // 5) Try LUP. If decomp succeeds, try solve, if fails, compute rcond and goto 6)
+  // 6) rcond+1!=1 ? try QR based llsq : goto 8)
+  // 7) if QR decomp succeeds return, else goto 8)
+  // 8) run svd based llsq
+  // 9) if svd llsq fails warn always return.
+
+  // First...
+
+  // LAPACK info
+  int4 info = 0;
+
+  // check if the system is sane
+  if(rows1!=rows2)
+  {
+    stringstream msg;
+    msg << "System does not commute. Rows in arg0: " << rows1 << ". Rows in arg1 " << rows2 << std::endl;
+    throw rdag_error(msg.str());
+  }
+
+  bool debug_ = true;
+
+  // Do the alg above:
+  // is it square?
+  if (rows1 == cols1)
+  {
+    if (debug_)
+    {
+      cout << "10. Matrix is square"  << std::endl;
+    }
+
+    // is the array1 triangular or permuted triangular
+    unique_ptr<detail::TriangularStruct> tptr = detail::isTriangular(data1, rows1, cols1);
+    detail::UPLO UPLO = tptr->flagUPLO;
+    detail::UNITDIAG DIAG = tptr->flagDiag;
+    if (UPLO != detail::UPLO::NEITHER)  // i.e. this is some breed of triangular
+    {
+      if (debug_)
+      {
+        cout << "20. Matrix is " << (UPLO == detail::UPLO::UPPER ? "upper" : "lower") << " triangular, " << (DIAG == detail::UNITDIAG::NONUNIT ? "non-unit" : "unit") << " diagonal." << std::endl;
+      }
+      detail::PERMUTATION DATA_PERMUTATION = tptr->flagPerm;
+      if (DATA_PERMUTATION != detail::PERMUTATION::STANDARD)   // we have a permutation of the data, rewrite
+      {
+        if (debug_)
+        {
+          cout << "25. Matrix is " << (DATA_PERMUTATION == detail::PERMUTATION::ROW ? "row" : "column") << " permuted triangular." << std::endl;
+        }
+//         permuteV = tptr->perm.get(); // the permutation
+        if (DATA_PERMUTATION == detail::PERMUTATION::ROW)
+        {
+          triPtr1Ptr = unique_ptr<T[]>(new T[len1]());
+          triPtr1Ptr.swap(data1Ptr); // triPtr1Ptr now points to original data
+          // assign pointers for read/write ops
+          triPtr1  = triPtr1Ptr.get();
+          data1 = data1Ptr.get();
+          std::fill(data1,data1+len1,0e0);
+          for (size_t i = 0; i < cols1; i++)
+          {
+            for (size_t j = 0; j < rows1; j++)
+            {
+              data1[i * rows1 + tptr->perm.get()[j]] = triPtr1[i * rows1 + j];
+            }
+          }
+          triPtr2Ptr = unique_ptr<T[]>(new T[len2]());
+          triPtr2Ptr.swap(data2Ptr); // triPtr2Ptr now points to original data
+          // assign pointers for read/write ops
+          triPtr2  = triPtr2Ptr.get();
+          data2 = data2Ptr.get();
+          std::fill(data2,data2+len2,0e0);
+          for (size_t i = 0; i < cols2; i++)
+          {
+            for (size_t j = 0; j < rows2; j++)
+            {
+              data2[i * rows2 + tptr->perm.get()[j]] = triPtr2[i * rows2 + j];
+            }
+          }
+        }
+      } // end permutation branch
+
+
+      cout << "28. Hitting lapack tri routines with UPLO = " << (UPLO == detail::UPLO::UPPER ? "upper" : "lower") << " DIAG = " << (DIAG == detail::UNITDIAG::NONUNIT ? "non-unit" : "unit") << std::endl;
+
+      // compute reciprocal condition number, if it's bad say so and least squares solve
+//       _lapack.dtrcon('1', UPLO, DIAG, rows1, data1, rows1, rcond, work, iwork, info);
+      auto lapack_uplo = asChar(UPLO);
+      auto lapack_diag = asChar(DIAG);
+      lapack::xtrcon(lapack::ONE, &lapack_uplo, &lapack_diag, &int4rows1, data1, &int4rows1, &rcond, &info);
+
+      if (rcond + 1.e0 != 1.e0)// rcond ~< D1mach(4)
+      {
+//         _lapack.dtrtrs(UPLO, 'N', DIAG, rows1, cols2, data1, rows1, data2, rows2, info);
+        info = 0;
+        try
+        {
+          lapack::xtrtrs(&lapack_uplo, lapack::N, &lapack_diag, &int4rows1, &int4cols2, data1, &int4rows1, data2, &int4rows2, &info);
+        }
+        catch (rdag_error& e)
+        {
+          if(info<0) // caught a xerbla error, rethrow
+          {
+            throw;
+          }
+          if (debug_)
+          {
+            cout<<("40. Triangular solve fail. Mark as singular.");
+          }
+          singular = true;
+        }
+
+        if (debug_)
+        {
+          cout << "30. Triangular solve success, returning";
+        }
+        ret = makeConcreteDenseMatrix(data2Ptr.release(), rows2, cols2, OWNER);
+        reg0.push_back(ret);
+        return nullptr;
+      }
+      else
+      {
+        if (debug_)
+        {
+          cout << "43. Triangular condition was computed as too bad to attempt solve." << std::endl;
+        }
+        singular = true;
+      }
+
+      // reset permutation, just a pointer switch, not doing so might influence results from
+      // iterative llsq solvers
+      if (DATA_PERMUTATION != detail::PERMUTATION::STANDARD)
+      {
+        if(debug_)
+        {
+          cout << "45. Resetting permutation." << std::endl;
+        }
+
+        // swap back pointers
+        data1Ptr.swap(triPtr1Ptr);
+        data2Ptr.swap(triPtr2Ptr);
+        data1 = data1Ptr.get();
+        data2 = data2Ptr.get();
+      }
+      jmp = true; // nmatrix is singular, jump to least squares logic
+
+    } // end "this matrix is triangular"
+
+    // if it's triangular and it failed, then it's singular and a condition number is already computed and this can be jumped!
+    if (!jmp)
+    {
+      if (debug_)
+      {
+        cout << "50. Not triangular" << std::endl;
+      }
+      // see if it's Hermitian (symmetric in the real case)
+      // stu - this needs looking at, complex case could be symmetric or Hermitian, in which case
+      // different specialisations are available, template in a thing to deal with this...
+      if (detail::isSymmetric(data1, rows1, cols1))
+      {
+        if (debug_)
+        {
+          cout << "60. Is Hermitian" << std::endl;
+        }
+        // cholesky decompose, shove in lower triangle
+//         _lapack.dpotrf('L', rows1, data1, rows1, info);
+        info = 0;
+        try
+        {
+          lapack::xpotrf(lapack::L, &int4rows1, data1, &int4rows1, &info);
+        }
+        catch(rdag_error& e)
+        {
+          if(info < 0)
+          {
+            throw;
+          }
+        }
+
+        if(info == 0)
+        {
+          //         if (info[0] == 0) { // Cholesky factorisation was ok, matrix is s.p.d. Factorisation is in the lower triangle, back solve based on this
+          if (debug_)
+          {
+            cout << "70. Cholesky success.  Computing condition based on cholesky factorisation" << std::endl;
+          }
+          //           anorm = _lapack.dlansy('1', 'L', rows1, array1.getData(), rows1, work);
+          anorm = lapack::xlansy(lapack::ONE, lapack::L, &int4rows1, data1, &int4rows1);
+          // Cholesky condition estimate
+          lapack::xpocon(lapack::L, &int4rows1, data1, &int4rows1, &anorm, &rcond, &info);
+          if (debug_)
+          {
+            cout << "80. Cholesky condition estimate. " << rcond << std::endl;
+          }
+          if (1.e0 + rcond != 1.e0)
+          {
+            if (debug_)
+            {
+              cout << "90. Cholesky condition acceptable. Backsolve and return." << std::endl;
+            }
+            lapack::xpotrs(lapack::L, &int4rows1, &int4cols2, data1, &int4rows1, data2, &int4rows2, &info);
+            // info[0] will be zero. Any -ve info[0] will be handled by XERBLA
+            ret = makeConcreteDenseMatrix(data2Ptr.release(), rows2, cols2, OWNER);
+            reg0.push_back(ret);
+            return nullptr;
+          }
+          else
+          {
+            if (debug_)
+            {
+              cout << "100. Cholesky condition bad. Mark as singular." << std::endl;
+            }
+            singular = true;
+          }
+        }
+        // stu - this branch from "if (info[0] == 0)" following xpotrf call is now dead
+        // lapack will throw if there's a problem, it's an input error if {xerbla} or {not spd}
+//         } else { // factorisation failed
+//           if (debug_) {
+//            cout << "110. Cholesky factorisation failed. Matrix is not s.p.d." << std::endl;
+//           }
+//         } // end factorisation info==0
+      } // end symmetric branch
+
+      if (!singular)
+      {
+        if (debug_)
+        {
+          cout << "120. Non-symmetric OR not s.p.d." << std::endl;
+        }
+        //  we're here as matrix isn't s.p.d. as Cholesky failed. Get new copy of matrix
+//         System.arraycopy(array1.getData(), 0, data1, 0, array1.getData().length);
+        std::copy(arg0->getData(),arg0->getData()+len1,data1);
+        // try solving with generalised LUP solver
+//         int[] ipiv = new int[rows1];
+        unique_ptr<int[]> ipivPtr (new int4[rows1]);
+        // decompose
+        if (debug_)
+        {
+          cout << "130. LUP attempted" << std::endl;
+        }
+//         _lapack.dgetrf(rows1, cols1, data1, rows1, ipiv, info);
+        try
+        {
+          lapack::xgetrf(&int4rows1, &int4cols1, data1, &int4rows1, ipivPtr.get(), &info);
+        }
+        catch (rdag_error& e)
+        {
+          if(info<0) // caught a xerbla error, rethrow
+          {
+            throw;
+          }
+        }
+
+        if (info == 0)
+        {
+          if (debug_)
+          {
+            cout << "140. LUP success. Computing condition based on LUP factorisation." << std::endl;
+          }
+//           anorm = _lapack.dlange('1', rows1, cols1, array1.getData(), rows1, work);
+          anorm = lapack::xlange(lapack::ONE, &int4rows1, &int4cols1, arg0->getData(), &int4rows1);
+
+//           _lapack.dgecon('1', rows1, data1, rows1, anorm, rcond, work, iwork, info);
+          lapack::xgecon(lapack::ONE, &int4rows1, data1, &int4rows1, &anorm, &rcond, &info);
+
+          // if condition estimate isn't too bad then back solve
+          if (1.e0 + rcond != 1.e0)
+          {
+            // back solve dgetrs()
+//             _lapack.dgetrs('N', cols1, cols2, data1, cols1, ipiv, data2, cols1, info);
+            lapack::xgetrs(lapack::N, &int4cols1, &int4cols2, data1, &int4cols1, ipivPtr.get(), data2, &int4cols1, &info);
+            if (debug_)
+            {
+              cout << "150. LUP returning" << std::endl;
+            }
+//             return new OGMatrix(data2, rows2, cols2);
+            ret = makeConcreteDenseMatrix(data2Ptr.release(), rows2, cols2, OWNER);
+            reg0.push_back(ret);
+            return nullptr;
+          }
+          else     // condition bad, mark as singular
+          {
+            if (debug_)
+            {
+              cout << "160. LUP failed, condition too high" << std::endl;
+            }
+            singular = true;
+          }
+        }
+        else
+        {
+          if (debug_)
+          {
+            cout << "170. LUP factorisation failed. Mark as singular." << std::endl;
+          }
+          singular = true;
+        }
+      }
+    }
+  } // end if square branch
+
+  // branch on rcond if computed, if cond is sky high then rcond is near zero, we use 1 here so cutoff is near 1e-16
+  if (singular)
+  {
+    cout << "Square matrix is singular to machine precision. RCOND estimate = " << rcond << std::endl;
+    if (debug_)
+    {
+      cout << "190. Square matrix is singular." << std::endl;
+    }
+    if ((rcond + 1.e0) == 1.e0)
+    {
+      if (debug_)
+      {
+        cout << "200. Condition of square matrix is too bad for QR least squares." << std::endl;
+      }
+      attemptQR = false;
+    }
+    // take a copy of the original data as it will have been destroyed above
+//       System.arraycopy(array1.getData(), 0, data1, 0, array1.getData().length);
+    std::copy(arg0->getData(),arg0->getData()+len1,data1Ptr.get());
+  }
+
+  // needed for QR and SVD
+  int4 ldb = std::max(rows1, cols1);
+  if (attemptQR)
+  {
+    if (debug_)
+    {
+      cout << "210. Attempting QR solve." << std::endl;
+    }
+
+    // malloc some space for the solution as it will be rows1 * cols2 in size and data2 is rows2*cols2 which may not be big enough
+    if (rows1 < cols1)
+    {
+      bdata2Ptr = unique_ptr<T[]>(new T[ldb * cols2]);
+      T * b = bdata2Ptr.get();
+      //copy in data strips
+      for (size_t i = 0; i < cols2; i++)
+      {
+        std::copy(data2 + (i * rows2), data2 + ((i + 1)* rows2), b + i * ldb);
+      }
+      // switch pointers so data2 now points at a correct sized alloc
+      data2Ptr.swap(bdata2Ptr);
+      // reassign underlying data2 pointer
+      data2 = data2Ptr.get();
+    }
+
+    // copy in the data
+//       _lapack.dgels('N', rows1, cols1, cols2, data1, rows1, data2, ldb, dummywork, lwork, info);
+//       lwork = (int) dummywork[0];
+//       work = new double[lwork];
+//       _lapack.dgels('N', rows1, cols1, cols2, data1, rows1, data2, ldb, work, lwork, info);
+    try
+    {
+      lapack::xgels(lapack::N, &int4rows1, &int4cols1, &int4cols2, data1, &int4rows1, data2, &ldb, &info);
+    }
+    catch(rdag_error& e)
+    {
+      if (info < 0)
+      {
+        throw;
+      }
+    }
+
+    if (info > 0)
+    {
+      if (debug_)
+      {
+        cout <<  "220. QR solve failed" << std::endl;
+      }
+      cout <<  " WARN: Matrix of coefficients does not have full rank. Rank is " << info << "." << std::endl;
+      // switch back to original data if we created a "b"
+      if (rows1 < cols1)
+      {
+        data2Ptr.swap(bdata2Ptr);
+        // reassign underlying data2 pointer
+        data2 = data2Ptr.get();
+      }
+
+      // take a copy of the original data as it will have been destroyed above
+//         System.arraycopy(array1.getData(), 0, data1, 0, array1.getData().length);
+//         System.arraycopy(array2.getData(), 0, data2, 0, array2.getData().length);
+      std::copy(arg0->getData(),arg0->getData()+len1,data1);
+      std::copy(arg1->getData(),arg1->getData()+len2,data2);
+    }
+    else
+    {
+      if (debug_)
+      {
+        cout << "230. QR solve success, returning" << std::endl;
+      }
+      // 1:cols1 from each column of data2 needs to be returned
+      T * ref = data2;
+      data2 = new T[cols1 * cols2];
+      for (size_t i = 0; i < cols2; i++)
+      {
+//           System.arraycopy(ref, i * ldb, data2, i * cols1, cols1);
+        std::copy(ref + (i * ldb), ref + ((i * ldb)+cols1), data2 + (i * cols1));
+      }
+//         return new OGMatrix(data2, cols1, cols2);
+      ret = makeConcreteDenseMatrix(data2, cols1, cols2, OWNER);
+      reg0.push_back(ret);
+      return nullptr;
+    }
+  }
+
+  if (debug_)
+  {
+    cout <<  "240. Attempting SVD" << std::endl;
+  }
+
+  // so we attempt a general least squares solve
+  unique_ptr<real8[]> sPtr (new real8[std::min(rows1, cols1)]());
+  real8 moorePenroseRcond = -1; // this is the definition of singular in the Moore-Penrose sense, if set to -1 machine prec is used
+//     int[] rank = new int[1];
+//
+//     // internal calls in svd to ilaenv() to get parameters for svd call seems broken in netlib jars, will need to patch the byte code or override
+//     lwork = -1;
+//     _lapack.dgelsd(rows1, cols1, cols2, data1, Math.max(1, rows1), data2, Math.max(1, Math.max(rows1, cols1)), s, moorePenroseRcond, rank, dummywork, lwork, dummyiwork, info);
+//     lwork = (int) dummywork[0];
+//     work = new double[lwork];
+//     iwork = new int[dummyiwork[0]];
+//
+//     // make the call to the least squares solver
+//     _lapack.dgelsd(rows1, cols1, cols2, data1, Math.max(1, rows1), data2, Math.max(1, Math.max(rows1, cols1)), s, moorePenroseRcond, rank, work, lwork, iwork, info);
+
+  int4 rank=0;
+  try
+  {
+    lapack::xgelsd(&int4rows1, &int4cols1, &int4cols2, data1, &int4rows1, data2, &ldb, sPtr.get(), &moorePenroseRcond, &rank, &info);
+  }
+  catch (rdag_error& e)
+  {
+    if(info<0)
+    {
+      throw;
+    }
+  }
+
+  // handle fail on info
+  if (info != 0)
+  {
+    if (debug_)
+    {
+      cout << "250. SVD failed" << std::endl;
+    }
+    cout << "SVD Failed to converege. " << info << " out of " << std::max(rows1, cols1) << " off diagonals failed to converge to zero. RCOND = " << rcond << std::endl;
+  }
+  else
+  {
+    if (debug_)
+    {
+      cout << "260. SVD success" << std::endl;
+    }
+  }
+  if (debug_)
+  {
+    cout << "270. SVD returning" << std::endl;
+  }
+  //     return new OGMatrix(Arrays.copyOf(data2, cols1 * cols2), cols1, cols2);
+  // stu - technically the wrong size data *but* C just sees a pointer
+  ret = makeConcreteDenseMatrix(data2Ptr.release(), cols1, cols2, OWNER);
+  reg0.push_back(ret);
+  return nullptr;
+}
+
+
+// MLDIVIDE runner:
+void * MLDIVIDERunner::run(RegContainer& reg0, OGComplexDenseMatrix::Ptr arg0, OGComplexDenseMatrix::Ptr arg1) const
+{
+  mldivide_dense_runner<complex16>(reg0, arg0, arg1);
+  return nullptr;
+}
+
+
+void * MLDIVIDERunner::run(RegContainer& reg0, OGRealDenseMatrix::Ptr arg0, OGRealDenseMatrix::Ptr arg1) const
+{
+  mldivide_dense_runner<real8>(reg0, arg0, arg1);
+  return nullptr;
+}
+
+void *
+MLDIVIDERunner::run(RegContainer& reg0, OGRealScalar::Ptr arg0, OGRealScalar::Ptr arg1) const
+{
+  real8 data1 = arg0->getValue();
+  real8 data2 = arg1->getValue();
+  OGNumeric::Ptr ret = OGRealScalar::create(data1+data2);
+  reg0.push_back(ret);
+  return nullptr;
+}
+
+}
+

--- a/src/librdag/runners/mldividerunner.cc
+++ b/src/librdag/runners/mldividerunner.cc
@@ -185,7 +185,7 @@ void checkIfLowerTriangular(T * data, size_t rows, size_t cols, UPLO* tri, UNITD
     {
       if(!SingleValueFuzzyEquals(data[ir +i],1.e0,std::numeric_limits<real8>::epsilon(),std::numeric_limits<real8>::epsilon()))
       {
-        cout << "13. checking lower:: not unit diag at element [" << i << "," << i << "]" << "found value = "<< data[ir + i] << std::endl;
+        cerr << "13. checking lower:: not unit diag at element [" << i << "," << i << "]" << "found value = "<< data[ir + i] << std::endl;
         *diag = UNITDIAG::NONUNIT;
         isUnit = false;
       }
@@ -194,7 +194,7 @@ void checkIfLowerTriangular(T * data, size_t rows, size_t cols, UPLO* tri, UNITD
     {
       if (!SingleValueFuzzyEquals(data[ir + j],0.e0,std::numeric_limits<real8>::epsilon(),std::numeric_limits<real8>::epsilon()))
       {
-        cout << "14. checking lower:: returning as nonzero in upper triangle at [" << j << "," << i << "]" << "found value = "<< data[ir + j] << std::endl;
+        cerr << "14. checking lower:: returning as nonzero in upper triangle at [" << j << "," << i << "]" << "found value = "<< data[ir + j] << std::endl;
         SingleValueFuzzyEquals(data[ir +j],0.e0,std::numeric_limits<real8>::epsilon(),std::numeric_limits<real8>::epsilon());
         *tri = UPLO::NEITHER;
         return;
@@ -255,7 +255,7 @@ void checkIfUpperTriangularPermuteRows(T * data, size_t rows, size_t cols,  Tria
         // is a possible optimisation.
         if (isUDswitch && !SingleValueFuzzyEquals(data[i * rows + j],1.e0,std::numeric_limits<real8>::epsilon(),std::numeric_limits<real8>::epsilon()))
         {
-          cout << "16. checking upper:: not unit diag at element [" << i << "," << j << "]" << std::endl;
+          cerr << "16. checking upper:: not unit diag at element [" << i << "," << j << "]" << std::endl;
 
           // set as not unit diagonal
           ret->flagDiag = UNITDIAG::NONUNIT;
@@ -294,7 +294,7 @@ void checkIfUpperTriangularPermuteRows(T * data, size_t rows, size_t cols,  Tria
   if (!validPermutation)
   {
     // we don't have a valid upper permutation, return declaring so
-    cout << "17. checking upper:: not upper triangular, permuted or otherwise" << std::endl;
+    cerr << "17. checking upper:: not upper triangular, permuted or otherwise" << std::endl;
     ret->flagUPLO = UPLO::NEITHER;
   }
   else
@@ -302,14 +302,14 @@ void checkIfUpperTriangularPermuteRows(T * data, size_t rows, size_t cols,  Tria
     if(upperTriangleIfValidIspermuted)
     {
       // permutation is valid row, update struct. foo(rowStarts) = 1: length(rowStarts) gives direct perm
-      cout << "18. checking upper:: Row permutation spotted" << std::endl;
+      cerr << "18. checking upper:: Row permutation spotted" << std::endl;
       ret->flagPerm = PERMUTATION::ROW;
       ret->perm = std::move(rowStarts);
     }
     else
     {
       // permutation is in fact the 1:1 map, we have a triangle already
-      cout << "19. checking upper:: standard upper triangle" << std::endl;
+      cerr << "19. checking upper:: standard upper triangle" << std::endl;
       ret->flagPerm = PERMUTATION::STANDARD;
     }
   }
@@ -391,7 +391,7 @@ mldivide_dense_runner(RegContainer& reg0, shared_ptr<const OGMatrix<T>> arg0, sh
   T * data2 = data2Ptr.get();
   std::copy(ptrdata2,ptrdata2+len2,data2);
 
-  // Inveral variables signifcant in flow control.
+  // Internal variables signifcant in flow control.
   real8 rcond = 0; // estimate of reciprocal condition number
   real8 anorm = 0; // the 1 norm of a matrix
   bool singular = false; // is the matrix identified as singular
@@ -449,7 +449,7 @@ mldivide_dense_runner(RegContainer& reg0, shared_ptr<const OGMatrix<T>> arg0, sh
   {
     if (debug_)
     {
-      cout << "5. Matrix is all zeros, returning Inf"  << std::endl;
+      cerr << "5. Matrix is all zeros, returning Inf"  << std::endl;
     }
     unique_ptr<T[]> retData(new T[len2]);
     for(size_t i = 0; i < len2; i++)
@@ -467,7 +467,7 @@ mldivide_dense_runner(RegContainer& reg0, shared_ptr<const OGMatrix<T>> arg0, sh
   {
     if (debug_)
     {
-      cout << "10. Matrix is square"  << std::endl;
+      cerr << "10. Matrix is square"  << std::endl;
     }
 
     // Is the array1 triangular or permuted triangular, send probe and get back struct containing result
@@ -477,12 +477,12 @@ mldivide_dense_runner(RegContainer& reg0, shared_ptr<const OGMatrix<T>> arg0, sh
     detail::UPLO UPLO = tptr->flagUPLO;
     detail::UNITDIAG DIAG = tptr->flagDiag;
 
-    // Is this matrix layour some breed of triangular?
+    // Is this matrix layout some breed of triangular?
     if (UPLO != detail::UPLO::NEITHER)
     {
       if (debug_)
       {
-        cout << "20. Matrix is " << (UPLO == detail::UPLO::UPPER ? "upper" : "lower") << " triangular, " << (DIAG == detail::UNITDIAG::NONUNIT ? "non-unit" : "unit") << " diagonal." << std::endl;
+        cerr << "20. Matrix is " << (UPLO == detail::UPLO::UPPER ? "upper" : "lower") << " triangular, " << (DIAG == detail::UNITDIAG::NONUNIT ? "non-unit" : "unit") << " diagonal." << std::endl;
       }
 
       detail::PERMUTATION DATA_PERMUTATION = tptr->flagPerm;
@@ -492,7 +492,7 @@ mldivide_dense_runner(RegContainer& reg0, shared_ptr<const OGMatrix<T>> arg0, sh
         // we have a permutation of the data, so we'll rewire the system
         if (debug_)
         {
-          cout << "25. Matrix is " << (DATA_PERMUTATION == detail::PERMUTATION::ROW ? "row" : "column") << " permuted triangular." << std::endl;
+          cerr << "25. Matrix is " << (DATA_PERMUTATION == detail::PERMUTATION::ROW ? "row" : "column") << " permuted triangular." << std::endl;
         }
         // We have a row permutation... this gets a bit hairy pointer twiddling wise.
         // The idea is that it'd be nice when it comes to calling lapack to use the same set of
@@ -539,7 +539,7 @@ mldivide_dense_runner(RegContainer& reg0, shared_ptr<const OGMatrix<T>> arg0, sh
       } // end permutation branch
 
 
-      cout << "28. Hitting lapack tri routines with UPLO = " << (UPLO == detail::UPLO::UPPER ? "upper" : "lower") << " DIAG = " << (DIAG == detail::UNITDIAG::NONUNIT ? "non-unit" : "unit") << std::endl;
+      cerr << "28. Hitting lapack tri routines with UPLO = " << (UPLO == detail::UPLO::UPPER ? "upper" : "lower") << " DIAG = " << (DIAG == detail::UNITDIAG::NONUNIT ? "non-unit" : "unit") << std::endl;
 
       // Compute reciprocal condition number, if it's bad say so and least squares solve
 
@@ -563,7 +563,7 @@ mldivide_dense_runner(RegContainer& reg0, shared_ptr<const OGMatrix<T>> arg0, sh
           reg0.push_back(ret);
           if (debug_)
           {
-            cout << "30. Triangular solve success, returning" << std::endl;
+            cerr << "30. Triangular solve success, returning" << std::endl;
           }
           return nullptr;
         }
@@ -582,7 +582,7 @@ mldivide_dense_runner(RegContainer& reg0, shared_ptr<const OGMatrix<T>> arg0, sh
           // it is reversed.
           if (debug_)
           {
-            cout<< "40. Triangular solve fail. Mark as singular." << std::endl;
+            cerr<< "40. Triangular solve fail. Mark as singular." << std::endl;
           }
           // solve failed, system is singular so set the flag to skip doing anything else
           // in the "exact" solution regime
@@ -596,7 +596,7 @@ mldivide_dense_runner(RegContainer& reg0, shared_ptr<const OGMatrix<T>> arg0, sh
           {
             if(debug_)
             {
-              cout << "45. Resetting permutation." << std::endl;
+              cerr << "45. Resetting permutation." << std::endl;
             }
 
             // swap back pointers
@@ -615,7 +615,7 @@ mldivide_dense_runner(RegContainer& reg0, shared_ptr<const OGMatrix<T>> arg0, sh
         // and abandon any further attemps at exact solution.
         if (debug_)
         {
-          cout << "43. Triangular condition was computed as too bad to attempt solve." << std::endl;
+          cerr << "43. Triangular condition was computed as too bad to attempt solve." << std::endl;
         }
         singular = true;
       }
@@ -626,7 +626,7 @@ mldivide_dense_runner(RegContainer& reg0, shared_ptr<const OGMatrix<T>> arg0, sh
     {
       if (debug_)
       {
-        cout << "50. Not triangular" << std::endl;
+        cerr << "50. Not triangular" << std::endl;
       }
       bool cholesky_mangled_data = false;
       // See if it's Hermitian (symmetric in the real case)
@@ -634,7 +634,7 @@ mldivide_dense_runner(RegContainer& reg0, shared_ptr<const OGMatrix<T>> arg0, sh
       {
         if (debug_)
         {
-          cout << "60. Is Hermitian" << std::endl;
+          cerr << "60. Is Hermitian" << std::endl;
         }
         info = 0;
         // Attempt to compute a Cholesky factorisation
@@ -656,7 +656,7 @@ mldivide_dense_runner(RegContainer& reg0, shared_ptr<const OGMatrix<T>> arg0, sh
         {
           if (debug_)
           {
-            cout << "70. Cholesky success.  Computing condition based on cholesky factorisation" << std::endl;
+            cerr << "70. Cholesky success.  Computing condition based on cholesky factorisation" << std::endl;
           }
           // technically this should be zlanhe() in the complex case, but the 1 norm estimate is the same
           // as sum(abs(A)) == sum(abs(conj(A)))
@@ -666,14 +666,14 @@ mldivide_dense_runner(RegContainer& reg0, shared_ptr<const OGMatrix<T>> arg0, sh
           lapack::xpocon(lapack::L, &int4rows1, data1, &int4rows1, &anorm, &rcond, &info);
           if (debug_)
           {
-            cout << "80. Cholesky condition estimate. " << rcond << std::endl;
+            cerr << "80. Cholesky condition estimate. " << rcond << std::endl;
           }
           // again test if reciprocal condition is acceptable
           if (1.e0 + rcond != 1.e0)
           {
             if (debug_)
             {
-              cout << "90. Cholesky condition acceptable. Backsolve and return." << std::endl;
+              cerr << "90. Cholesky condition acceptable. Backsolve and return." << std::endl;
             }
             lapack::xpotrs(lapack::L, &int4rows1, &int4cols2, data1, &int4rows1, data2, &int4rows2, &info);
             // there is no possible numerical exception here, just input
@@ -686,10 +686,17 @@ mldivide_dense_runner(RegContainer& reg0, shared_ptr<const OGMatrix<T>> arg0, sh
             // Cholesky decomposition of matrix indicates condition is bad
             if (debug_)
             {
-              cout << "100. Cholesky condition bad. Mark as singular." << std::endl;
+              cerr << "100. Cholesky condition bad. Mark as singular." << std::endl;
             }
             singular = true;
           }
+        }
+        else
+        {
+            if (debug_)
+            {
+              cerr << "110. Cholesky decomposition failed." << std::endl;
+            }
         }
       } // end if Hermitian branch
 
@@ -698,7 +705,7 @@ mldivide_dense_runner(RegContainer& reg0, shared_ptr<const OGMatrix<T>> arg0, sh
         // We are here if the matrix is not singular, not triangular and not Hermitian.
         if (debug_)
         {
-          cout << "120. Non-Hermitian OR not s.p.d." << std::endl;
+          cerr << "120. Non-Hermitian OR not s.p.d." << std::endl;
         }
         //  we're here as matrix isn't s.p.d. as Cholesky failed. 
         // Get new copy of the matrix data if cholesky ran
@@ -712,7 +719,7 @@ mldivide_dense_runner(RegContainer& reg0, shared_ptr<const OGMatrix<T>> arg0, sh
 
         if (debug_)
         {
-          cout << "130. LUP attempted" << std::endl;
+          cerr << "130. LUP attempted" << std::endl;
         }
 
         // Try a LUP decomposition
@@ -733,7 +740,7 @@ mldivide_dense_runner(RegContainer& reg0, shared_ptr<const OGMatrix<T>> arg0, sh
           // LUP decomposition was successful, check 
           if (debug_)
           {
-            cout << "140. LUP success. Computing condition based on LUP factorisation." << std::endl;
+            cerr << "140. LUP success. Computing condition based on LUP factorisation." << std::endl;
           }
 
           // compute a reciprocal condition estimate based on decomposition
@@ -747,7 +754,7 @@ mldivide_dense_runner(RegContainer& reg0, shared_ptr<const OGMatrix<T>> arg0, sh
             lapack::xgetrs(lapack::N, &int4rows1, &int4cols2, data1, &int4rows1, ipivPtr.get(), data2, &int4rows2, &info);
             if (debug_)
             {
-              cout << "150. LUP returning" << std::endl;
+              cerr << "150. LUP returning" << std::endl;
             }
             // no throw possible unless on bad input, create return matrix 
             // freeing unique_ptr ref so shared_ptr in matrix type can have ownership on the way.
@@ -759,7 +766,7 @@ mldivide_dense_runner(RegContainer& reg0, shared_ptr<const OGMatrix<T>> arg0, sh
           {
             if (debug_)
             {
-              cout << "160. LUP failed, condition too high" << std::endl;
+              cerr << "160. LUP failed, condition too high" << std::endl;
             }
             singular = true;
           }
@@ -768,7 +775,7 @@ mldivide_dense_runner(RegContainer& reg0, shared_ptr<const OGMatrix<T>> arg0, sh
         {
           if (debug_)
           {
-            cout << "170. LUP factorisation failed. Mark as singular." << std::endl;
+            cerr << "170. LUP factorisation failed. Mark as singular." << std::endl;
           }
           singular = true;
         }
@@ -780,16 +787,16 @@ mldivide_dense_runner(RegContainer& reg0, shared_ptr<const OGMatrix<T>> arg0, sh
   // we use 1.e0 here againso cutoff is near machine precision
   if (singular)
   {
-    cout << "Square matrix is singular to machine precision. RCOND estimate = " << rcond << std::endl;
+    cerr << "Square matrix is singular to machine precision. RCOND estimate = " << rcond << std::endl;
     if (debug_)
     {
-      cout << "190. Square matrix is singular." << std::endl;
+      cerr << "190. Square matrix is singular." << std::endl;
     }
     if ((rcond + 1.e0) == 1.e0)
     {
       if (debug_)
       {
-        cout << "200. Condition of square matrix is too bad for QR least squares." << std::endl;
+        cerr << "200. Condition of square matrix is too bad for QR least squares." << std::endl;
       }
       // Condition is really bad so don't use QR
       attemptQR = false;
@@ -824,7 +831,7 @@ mldivide_dense_runner(RegContainer& reg0, shared_ptr<const OGMatrix<T>> arg0, sh
   {
     if (debug_)
     {
-      cout << "210. Attempting QR solve." << std::endl;
+      cerr << "210. Attempting QR solve." << std::endl;
     }
 
     // Attempt a least squares solve
@@ -845,9 +852,9 @@ mldivide_dense_runner(RegContainer& reg0, shared_ptr<const OGMatrix<T>> arg0, sh
       // It failed with a rank deficiency problem, clean up before moving on to SVD
       if (debug_)
       {
-        cout <<  "220. QR solve failed" << std::endl;
+        cerr <<  "220. QR solve failed" << std::endl;
       }
-      cout <<  " WARN: Matrix of coefficients does not have full rank. Rank is " << info << "." << std::endl;
+      cerr <<  " WARN: Matrix of coefficients does not have full rank. Rank is " << info << "." << std::endl;
 
       // copy back in data1 and strips of data2, both will be needed for svd
       // no point in freeing here
@@ -867,7 +874,7 @@ mldivide_dense_runner(RegContainer& reg0, shared_ptr<const OGMatrix<T>> arg0, sh
       // the QR solve was successful, pull out the solution data into a new allocation and return
       if (debug_)
       {
-        cout << "230. QR solve success, returning" << std::endl;
+        cerr << "230. QR solve success, returning" << std::endl;
       }
       // new alloc
       T * ref = data2;
@@ -888,7 +895,7 @@ mldivide_dense_runner(RegContainer& reg0, shared_ptr<const OGMatrix<T>> arg0, sh
   // If all else fails... we attempt a general least squares solve with SVD
   if (debug_)
   {
-    cout <<  "240. Attempting SVD" << std::endl;
+    cerr <<  "240. Attempting SVD" << std::endl;
   }
 
   // allocate space for the singular vectors
@@ -916,7 +923,7 @@ mldivide_dense_runner(RegContainer& reg0, shared_ptr<const OGMatrix<T>> arg0, sh
     // something went wrong in the solver, nothing we can do so throw...
     if (debug_)
     {
-      cout << "250. SVD failed" << std::endl;
+      cerr << "250. SVD failed" << std::endl;
     }
     stringstream msg;
     msg << "SVD Failed to converege. " << info << " out of " << std::max(rows1, cols1) << " off diagonals failed to converge to zero. RCOND = " << rcond << std::endl;
@@ -926,12 +933,12 @@ mldivide_dense_runner(RegContainer& reg0, shared_ptr<const OGMatrix<T>> arg0, sh
   { // dead branch, used for debug
     if (debug_)
     {
-      cout << "260. SVD success" << std::endl;
+      cerr << "260. SVD success" << std::endl;
     }
   }
   if (debug_)
   {
-    cout << "270. SVD returning" << std::endl;
+    cerr << "270. SVD returning" << std::endl;
   }
 
   // new alloc

--- a/src/librdag/test/check_terminals.cc
+++ b/src/librdag/test/check_terminals.cc
@@ -10,6 +10,7 @@
 #include "gtest/gtest.h"
 #include "warningmacros.h"
 #include "exprtypeenum.h"
+#include "test/test_utils.hh"
 
 using namespace std;
 using namespace librdag;
@@ -318,27 +319,50 @@ TEST(TerminalsTest, OGMatrix_T_complex16) {
   ASSERT_TRUE(*tmp==~*(copy->asOGTerminal()));
 }
 
+
 /*
  * Test OGRealDenseMatrix
  */
 TEST(TerminalsTest, OGRealDenseMatrixTest) {
   // data
   real8 data [12] = {1e0,2e0,3e0,4e0,5e0,6e0,7e0,8e0,9e0,10e0,11e0,12e0};
-  size_t rows = 3;
-  size_t cols = 4;
+  real8 arr_data[][4] = {{1e0,4e0,7e0,10e0},{2e0,5e0,8e0,11e0},{3e0,6e0,9e0,12e0}};
+
+  constexpr size_t rows = 3;
+  constexpr size_t cols = 4;
+
+  auto ptr = testutils::stack2heap<real8, rows, cols>(arr_data);
 
   // attempt construct from nullptr, should throw
   real8 * null = nullptr;
-  OGRealDenseMatrix::Ptr tmp;
+  real8 ** null2 = nullptr;
+  OGRealDenseMatrix::Ptr tmp, arr_ctor, init_ctor;
   ASSERT_THROW(OGRealDenseMatrix::create(null,rows,cols), rdag_error);
+  ASSERT_THROW(OGRealDenseMatrix::create(null2,rows,cols), rdag_error);
+
+  // attempt construct from bad init list
+  ASSERT_THROW(OGRealDenseMatrix::create({{1e0,4e0,7e0,10e0},{2e0,5e0,8e0},{3e0,6e0,9e0,12e0}}),rdag_error);
+
+  // attempt construct from init list
+  init_ctor = OGRealDenseMatrix::create({{1e0,4e0,7e0,10e0},{2e0,5e0,8e0,11e0},{3e0,6e0,9e0,12e0}});
 
   // attempt construct from ok data, own the data and delete it
   tmp = OGRealDenseMatrix::create(new real8[2]{10,20},1,2, OWNER);
   ASSERT_NE(tmp, OGRealDenseMatrix::Ptr{});
   ASSERT_TRUE(tmp->getDataAccess()==OWNER);
 
+  // attempt construct from real8[][]
+  arr_ctor = OGRealDenseMatrix::create(ptr.get(),rows,cols);
+
   // attempt construct from ok data
   tmp = OGRealDenseMatrix::create(data,rows,cols);
+
+  // attempt construct from init list
+  init_ctor = OGRealDenseMatrix::create({{1e0,4e0,7e0,10e0},{2e0,5e0,8e0,11e0},{3e0,6e0,9e0,12e0}});
+
+  // check ctors do the give same underlying representation
+  ASSERT_TRUE(*arr_ctor==~*tmp);
+  ASSERT_TRUE(*init_ctor==~*tmp);
 
   // check ctor worked
   ASSERT_NE(tmp, OGRealDenseMatrix::Ptr{});
@@ -433,21 +457,41 @@ TEST(TerminalsTest, OGRealDenseMatrixTest) {
 TEST(TerminalsTest, OGComplexDenseMatrixTest) {
   // data
   complex16 data [12] = {{1e0,10e0},{2e0,20e0},{3e0,30e0},{4e0,40e0},{5e0,50e0},{6e0,60e0},{7e0,70e0},{8e0,80e0},{9e0,90e0},{10e0,100e0},{11e0,110e0},{12e0,120e0}};
-  size_t rows = 3;
-  size_t cols = 4;
+  complex16 arr_data[][4] = {{{1e0,10e0},{4e0,40e0},{7e0,70e0},{10e0,100e0}},{{2e0,20e0},{5e0,50e0},{8e0,80e0},{11e0,110e0}},{{3e0,30e0},{6e0,60e0},{9e0,90e0},{12e0,120e0}}};
+
+  constexpr size_t rows = 3;
+  constexpr size_t cols = 4;
+
+  auto ptr = testutils::stack2heap<complex16, rows, cols>(arr_data);
 
   // attempt construct from nullptr, should throw
   complex16 * null = nullptr;
-  OGComplexDenseMatrix::Ptr tmp;
+  complex16 ** null2 = nullptr;
+  OGComplexDenseMatrix::Ptr tmp, arr_ctor, init_ctor;
   ASSERT_THROW(OGComplexDenseMatrix::create(null,rows,cols), rdag_error);
+  ASSERT_THROW(OGComplexDenseMatrix::create(null2,rows,cols), rdag_error);
+
+  // attempt construct from bad init list
+  ASSERT_THROW(OGComplexDenseMatrix::create({{{1e0,10e0},{4e0,40e0},{7e0,70e0},{10e0,100e0}},{{2e0,20e0},{5e0,50e0},{8e0,80e0}},{{3e0,30e0},{6e0,60e0},{9e0,90e0},{12e0,120e0}}}),rdag_error);
 
   // attempt construct from ok data, own the data and delete it
   tmp = OGComplexDenseMatrix::create(new complex16[2]{{10,20},{30,40}},1,2, OWNER);
   ASSERT_NE(tmp, OGComplexDenseMatrix::Ptr{});
   ASSERT_TRUE(tmp->getDataAccess()==OWNER);
 
+  // attempt construct from complex16[][]
+  arr_ctor = OGComplexDenseMatrix::create(ptr.get(),rows,cols);
+
   // attempt construct from ok data
   tmp = OGComplexDenseMatrix::create(data,rows,cols);
+
+  // attempt construct from init list
+  init_ctor = OGComplexDenseMatrix::create({{{1e0,10e0},{4e0,40e0},{7e0,70e0},{10e0,100e0}},{{2e0,20e0},{5e0,50e0},{8e0,80e0},{11e0,110e0}},{{3e0,30e0},{6e0,60e0},{9e0,90e0},{12e0,120e0}}});
+
+  // check ctors do the give same underlying representation
+  ASSERT_TRUE(*arr_ctor==~*tmp);
+  ASSERT_TRUE(*init_ctor==~*tmp);
+
   // check ctor worked
   ASSERT_NE(tmp, OGComplexDenseMatrix::Ptr{});
 

--- a/src/librdag/test/nodes/CMakeLists.txt
+++ b/src/librdag/test/nodes/CMakeLists.txt
@@ -25,6 +25,7 @@ set(TESTS
     check_ctranspose
     check_inv
     check_lu
+    check_mldivide
     check_mtimes
     check_norm2
     check_pinv

--- a/src/librdag/test/nodes/check_mldivide.cc
+++ b/src/librdag/test/nodes/check_mldivide.cc
@@ -1,0 +1,325 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+
+#include "gtest/gtest.h"
+#include "terminal.hh"
+#include "execution.hh"
+#include "dispatch.hh"
+#include "testnodes.hh"
+#include "runtree.hh"
+#include "test/test_utils.hh"
+
+using namespace std;
+using namespace librdag;
+using namespace testnodes;
+using ::testing::TestWithParam;
+using ::testing::Values;
+
+/*
+ * Check MLDIVIDE node behaves
+ */
+
+BINARY_NODE_TEST_SETUP(MLDIVIDE)
+
+// The mass of data cf. java unit tests
+
+// A_square_singular
+OGRealDenseMatrix::Ptr A1 = OGRealDenseMatrix::create({ { 1.00, 2.00, 3.00 }, { 1.00, 2.00, 3.00 }, { 1.00, 2.00, 3.00 } });
+
+// A_square_symmetric_positive_definite
+OGRealDenseMatrix::Ptr A2 = OGRealDenseMatrix::create({ { 123.00, 23.00, 23.00 }, { 23.00, 123.00, 23.00 }, { 23.00, 23.00, 123.00 } });
+
+// A_square_non_symmetric_well_conditioned 
+OGRealDenseMatrix::Ptr A3 = OGRealDenseMatrix::create({ { 10.00, 2.00, 1.00 }, { 2.00, 3.00, 10.00 }, { 4.00, 10.00, 1.00 } });
+
+// A_rectangular 
+OGRealDenseMatrix::Ptr A4 = OGRealDenseMatrix::create({ { 1.00, 2.00, 3.00, 4.00 }, { 5.00, 6.00, 7.00, 8.00 }, { 9.00, 10.00, 11.00, 12.00 }, { 13.00, 14.00, 15.00, 16.00 }, { 17.00, 18.00, 19.00, 20.00 } });
+
+// A_square_non_symmetric_condition_bad_for_lu_ok_for_qr
+OGRealDenseMatrix::Ptr A5 = OGRealDenseMatrix::create({ { 1.0000000000000009, 2., 20. }, { 1., 2., 0. }, { 1., 2., 40. } });
+
+// A_upper_triangular
+OGRealDenseMatrix::Ptr A6 = OGRealDenseMatrix::create({ { 1., 2., 3. }, { 0., 5., 6. }, { 0., 0., 9. } });
+
+// A_unit_upper_triangular
+OGRealDenseMatrix::Ptr A7 = OGRealDenseMatrix::create({ { 1., 2., 3. }, { 0., 1., 6. }, { 0., 0., 1. } });
+
+// A_lower_triangular
+OGRealDenseMatrix::Ptr A8 = OGRealDenseMatrix::create({ { 1., 0., 0. }, { 4., 5., 0. }, { 7., 8., 9. } });
+
+// A_unit_lower_triangular
+OGRealDenseMatrix::Ptr A9 = OGRealDenseMatrix::create({ { 1., 0., 0. }, { 4., 1., 0. }, { 7., 8., 1. } });
+
+// A_lower_triangular_singular_zero_on_diag 
+OGRealDenseMatrix::Ptr A10 = OGRealDenseMatrix::create({ { 1., 0., 0. }, { 4., 0., 0. }, { 7., 8., 1. } });
+
+// A_lower_triangular_singular_near_zero_on_diag 
+OGRealDenseMatrix::Ptr A11 = OGRealDenseMatrix::create(
+{ { 1., 0., 0. }, { 4., 1e-15, 0. }, { 7., 8., 1. } });
+
+// A_square_spd_near_singular 
+OGRealDenseMatrix::Ptr A12 = OGRealDenseMatrix::create({ { 2.0000e+00, 1.0000e+150, 2.0000e+00 }, { 1.0000e+150, 1.0000e+300, 2.0000e+150 }, { 2.0000e+00, 2.0000e+150, 5.0000e+00 } });
+
+// A_square_symmetric_not_spd 
+OGRealDenseMatrix::Ptr A13 = OGRealDenseMatrix::create({ { 54., 2., 3. }, { 2., 10., 6. }, { 3., 6., -120. } });
+
+// A_rectangular_with_inf
+OGRealDenseMatrix::Ptr A14 = OGRealDenseMatrix::create({ { std::numeric_limits<real8>::infinity(), 2.00, 3.00, 4.00 }, { 5.00, 6.00, 7.00, 8.00 }, { 9.00, 10.00, 11.00, 12.00 },{ 13.00, 14.00, 15.00, 16.00 }, { 17.00, 18.00, 19.00, 20.00 } });
+
+// A_square_permuted_upper_triangular 
+OGRealDenseMatrix::Ptr A15 = OGRealDenseMatrix::create({ { 0., 0., 13., 14., 15. }, { 1., 2., 3., 4., 5. }, { 0., 7., 8., 9., 10. }, { 0., 0., 0., 0., 25. }, { 0., 0., 0., 19., 20. } });
+
+// A_square_permuted_upper_triangular_zero_on_diag
+OGRealDenseMatrix::Ptr A16 = OGRealDenseMatrix::create({ { 0., 6., 7., 8. }, { 0., 0., 0., 16. }, { 1., 2., 3., 4. }, { 0., 0., 0., 12. } });
+
+// A_square_almost_permuted_upper_triangular
+OGRealDenseMatrix::Ptr A17 = OGRealDenseMatrix::create({ { 0., 12., 13., 14., 15. }, { 1., 2., 3., 4., 5. }, { 0., 7., 8., 9., 10. }, { 0., 0., 0., 0., 25. }, { 0., 0., 0., 19., 20. } });
+
+// A_square_permuted_upper_triangular_singular_to_mach_prec
+OGRealDenseMatrix::Ptr A18 = OGRealDenseMatrix::create({ { 0., 0., 1.e-300, 14., 15. }, { 1., 2., 3., 4., 5. }, { 0., 7., 8., 9., 10. },{ 0., 0., 0., 0., 25. },{ 0., 0., 0., 19., 20. } });
+
+// A_short_row
+OGRealDenseMatrix::Ptr A19 = OGRealDenseMatrix::create({ { 2, 3, 4 } });
+
+// B_rectangular
+OGRealDenseMatrix::Ptr B1 = OGRealDenseMatrix::create({ { 1.00, 2.00, 3.00 }, { 1.00, 2.00, 3.00 }, { 1.00, 2.00, 3.00 }, { 1.00, 2.00, 3.00 }, { 1.00, 2.00, 3.00 } });
+
+// C_4len_col_vector
+OGRealDenseMatrix::Ptr C1 = OGRealDenseMatrix::create({{1}, {2}, {3}, {4} });
+
+// C_5len__shuffled_col_matrix
+OGRealDenseMatrix::Ptr C2 = OGRealDenseMatrix::create({{3.e0,10.e0},{1.e0,20.e0},{2.e0,30.e0},{5.e0,40.e0},{4.e0,50.e0}});
+
+
+
+INSTANTIATE_NODE_TEST_CASE_P(MLDIVIDETests,MLDIVIDE,
+  Values
+  (
+
+  // CHECKING REAL SPACE MATRICES
+  new CheckBinary<MLDIVIDE>
+  (
+    // input
+    OGRealScalar::create(2.0),
+    OGRealScalar::create(3.0),
+    // expected
+    OGRealScalar::create(5.0),
+    MATHSEQUAL
+  ),
+  //test UpperTri Branch
+  new CheckBinary<MLDIVIDE>
+  (
+    // input
+    A6,
+    A1,
+    // expected
+    OGRealDenseMatrix::create( { { 0.5333333333333334, 1.0666666666666669, 1.6000000000000001 }, { 0.0666666666666667, 0.1333333333333334, 0.2000000000000000 },
+      { 0.1111111111111111, 0.2222222222222222, 0.3333333333333333 } }),
+    MATHSEQUAL
+  ),
+  //test UnitUpperTri Branch
+  new CheckBinary<MLDIVIDE>
+  (
+    // input
+    A7,
+    A1,
+    // expected
+    OGRealDenseMatrix::create( { {8.0000000000000000, 16.0000000000000000, 24.0000000000000000 }, {-5.0000000000000000, -10.0000000000000000, -15.0000000000000000 },
+      {1.0000000000000000, 2.0000000000000000, 3.0000000000000000 } }),
+    MATHSEQUAL
+  ),
+  //test LowerTri Branch
+  new CheckBinary<MLDIVIDE>
+  (
+    // input
+    A8,
+    A1,
+    // expected
+    OGRealDenseMatrix::create( { {1.0000000000000000, 2.0000000000000000, 3.0000000000000000 }, {-0.6000000000000000, -1.2000000000000000, -1.8000000000000000 },
+      {-0.1333333333333334, -0.2666666666666667, -0.4000000000000000 } }),
+    MATHSEQUAL
+  ),
+  //test UnitLowerTri Branch
+  new CheckBinary<MLDIVIDE>
+  (
+    // input
+    A9,
+    A1,
+    // expected
+    OGRealDenseMatrix::create( { {1.0000000000000000, 2.0000000000000000, 3.0000000000000000 }, {-3.0000000000000000, -6.0000000000000000, -9.0000000000000000 },
+      {18.0000000000000000, 36.0000000000000000, 54.0000000000000000 } }),
+    MATHSEQUAL
+  ),
+  //test PermutedUpperTriangular Branch
+  new CheckBinary<MLDIVIDE>
+  (
+    // input
+    A15,
+    C2,
+    // expected
+    OGRealDenseMatrix::create( { {0.0000000000000000, 8.1445922498554086 }, {0.0000000000000000, 3.1787160208212839 }, {0.0000000000000000, -2.0971659919028340 },
+      {0.0000000000000000, 0.9473684210526315 }, {0.2000000000000000, 1.6000000000000001 } }),
+    MATHSEQUAL
+  ),
+  //test AlmostPermutedUpperTriangular Branch
+  new CheckBinary<MLDIVIDE>
+  (
+    // input
+    A17,
+    C2,
+    // expected
+    OGRealDenseMatrix::create({ {0.0000000000000002, -29.9999999999998650 }, {0.0000000000000004, -57.8526315789472108 }, {-0.0000000000000004, 51.3052631578945864 },
+      {0.0000000000000000, 0.9473684210526315 }, {0.2000000000000000, 1.6000000000000001 } }),
+    MATHSEQUAL
+  ),
+  //test PermutedUpperTriangularZeroOnDiag Branch
+  new CheckBinary<MLDIVIDE>
+  (
+    // input
+    A16,
+    C1,
+    // expected
+    OGRealDenseMatrix::create({ {2.0475247524752480 }, {-0.7168316831683170 }, {0.5287128712871273 }, {0.2000000000000003 } }),
+    MATHSEQUAL
+  ),
+  //test PermutedUpperTriangularSingularToMachPrec Branch
+  new CheckBinary<MLDIVIDE>
+  (
+    // input
+    A18,
+    C2,
+    // expected
+    OGRealDenseMatrix::create({ {-0.0000000000000001, 5.7657712505229739 }, {-0.0000000000000001, -1.3196460795883791 }, {-0.0000000000000001, 2.6102410879868061 },
+      {0.0000000000000000, 0.2699985638374270 }, {0.2000000000000001, 1.5925606778687353 } }),
+    MATHSEQUAL
+  ),
+  //test TriDefinedSingular Branch
+  new CheckBinary<MLDIVIDE>
+  (
+    // input
+    A10,
+    A1,
+    // expected
+    OGRealDenseMatrix::create( { {0.2941176470588236, 0.5882352941176472, 0.8823529411764708 }, {-0.1303167420814479, -0.2606334841628958, -0.3909502262443438 },
+      {-0.0162895927601810, -0.0325791855203620, -0.0488687782805430 } }),
+    MATHSEQUAL
+  ),
+  //test TriMachPrecSingular Branch
+  new CheckBinary<MLDIVIDE>
+  (
+    // input
+    A11,
+    A1,
+    // expected
+    OGRealDenseMatrix::create({ {0.2941176470588236, 0.5882352941176472, 0.8823529411764708 }, {-0.1303167420814479, -0.2606334841628958, -0.3909502262443438 },
+      {-0.0162895927601810, -0.0325791855203620, -0.0488687782805430 } }),
+    MATHSEQUAL
+  ),
+  //test LUP Branch
+  new CheckBinary<MLDIVIDE>
+  (
+    // input
+    A3,
+    A1,
+    // expected
+    OGRealDenseMatrix::create({ {0.0812641083521445, 0.1625282167042890, 0.2437923250564334 }, {0.0609480812641084, 0.1218961625282167, 0.1828442437923251 },
+      {0.0654627539503386, 0.1309255079006772, 0.1963882618510158 } }),
+    MATHSEQUAL
+  ),
+  //test LUPBranchFallToLSQ Branch
+  new CheckBinary<MLDIVIDE>
+  (
+    // input
+    A5,
+    A1,
+    // expected
+    OGRealDenseMatrix::create({ {0.2000000000000003, 0.4000000000000006, 0.6000000000000013 }, {0.4000000000000002, 0.8000000000000004, 1.2000000000000017 },
+      {-0.0000000000000001, -0.0000000000000001, 0.0000000000000000 } }),
+    MATHSEQUAL
+  ),
+   //test Chol Branch
+  new CheckBinary<MLDIVIDE>
+  (
+    // input
+    A2,
+    A1,
+    // expected
+    OGRealDenseMatrix::create({ {0.0059171597633136, 0.0118343195266272, 0.0177514792899408 }, {0.0059171597633136, 0.0118343195266272, 0.0177514792899408 },
+      {0.0059171597633136, 0.0118343195266272, 0.0177514792899408 } }),
+    MATHSEQUAL
+  ),
+   //test Chol Not SPD Branch
+  new CheckBinary<MLDIVIDE>
+  (
+    // input
+    A13,
+    A1,
+    // expected
+    OGRealDenseMatrix::create({ {0.0150267040825563, 0.0300534081651127, 0.0450801122476691 }, {0.0988051054584955, 0.1976102109169910, 0.2964153163754866 },
+      {-0.0030174104583446, -0.0060348209166893, -0.0090522313750339 } }),
+    MATHSEQUAL
+  ),
+   //test Chol Singular Branch
+  new CheckBinary<MLDIVIDE>
+  (
+    // input
+    A12,
+    A1,
+    // expected
+    OGRealDenseMatrix::create({ {0, 0, 0 }, {1e-300, 2e-300, 3e-300 }, {0, 0, 0 } }),
+    MATHSEQUAL
+  ),
+   //test SVD Branch
+  new CheckBinary<MLDIVIDE>
+  (
+    // input
+    A1,
+    A2,
+    // expected
+    OGRealDenseMatrix::create({ {4.0238095238095219, 4.0238095238095228, 4.0238095238095219 }, {8.0476190476190457, 8.0476190476190474, 8.0476190476190457 },
+      {12.0714285714285658, 12.0714285714285694, 12.0714285714285676 } }),
+    MATHSEQUAL
+  ),
+   //test DGELS branch Expansion
+  // this branch tests the necessary expansion of the "B" matrix if the solution to the system is larger than the mallocd space
+  new CheckBinary<MLDIVIDE>
+  (
+    // input
+    A19,
+    A19,
+    // expected
+    OGRealDenseMatrix::create({ {0.1379310344827586, 0.2068965517241379, 0.2758620689655172 },
+      {0.2068965517241379, 0.3103448275862069, 0.4137931034482758 }, {0.2758620689655172, 0.4137931034482757, 0.5517241379310344 } }),
+    MATHSEQUAL
+  )
+
+
+  ) // end value
+);
+
+
+TEST(MLDIVIDETests, CheckBadCommuteThrows) {
+  OGNumeric::Ptr m1 = OGRealDenseMatrix::create(new real8[6]{1,3,5,2,4,6},3,2,OWNER);
+  OGNumeric::Ptr m2 = OGRealDenseMatrix::create(new real8[7]{10,30,20,40,50,60,70},1,7,OWNER);
+  OGExpr::Ptr node = MLDIVIDE::create(m1, m2);
+  ASSERT_THROW(
+  runtree(node),
+  rdag_error);
+}
+
+// QR: this is a right pain to test because it's rank deficient the results are pulled 
+// about by floating point behaviour in deficient part of Q
+// we test by reconstruction opposed to absolute value
+TEST(MLDIVIDETests, test_rank_deficient_QR_Branch) {
+  OGExpr::Ptr op = MLDIVIDE::create(A4, B1);
+  runtree(op);
+  OGExpr::Ptr  reconstr = PLUS::create(NEGATE::create(B1), MTIMES::create(A4, op->getRegs()[0]->asOGTerminal()));
+  runtree(reconstr);
+  OGTerminal::Ptr zeros = OGRealDenseMatrix::create({{0,0,0},{0,0,0},{0,0,0},{0,0,0},{0,0,0}});
+  reconstr->getRegs()[0]->asOGTerminal()->debug_print();
+  EXPECT_TRUE(zeros->mathsequals(reconstr->getRegs()[0]->asOGTerminal(),1e-14,1e-14));
+}

--- a/src/librdag/test/nodes/check_mldivide.cc
+++ b/src/librdag/test/nodes/check_mldivide.cc
@@ -11,6 +11,7 @@
 #include "dispatch.hh"
 #include "testnodes.hh"
 #include "runtree.hh"
+#include "numerictypes.hh"
 #include "test/test_utils.hh"
 
 using namespace std;
@@ -28,275 +29,538 @@ BINARY_NODE_TEST_SETUP(MLDIVIDE)
 // The mass of data cf. java unit tests
 
 // A_square_singular
-OGRealDenseMatrix::Ptr A1 = OGRealDenseMatrix::create({ { 1.00, 2.00, 3.00 }, { 1.00, 2.00, 3.00 }, { 1.00, 2.00, 3.00 } });
+OGRealDenseMatrix::Ptr REAL_A_1 = OGRealDenseMatrix::create({ { 1.00, 2.00, 3.00 }, { 1.00, 2.00, 3.00 }, { 1.00, 2.00, 3.00 } });
+OGComplexDenseMatrix::Ptr CMPLX_A_1 = OGComplexDenseMatrix::create( {{{1.0,10.0},{2.0,20.0},{3.0,30.0}},{{1.0,10.0},{2.0,20.0},{3.0,30.0}},{{1.0,10.0},{2.0,20.0},{3.0,30.0}}});
 
 // A_square_symmetric_positive_definite
-OGRealDenseMatrix::Ptr A2 = OGRealDenseMatrix::create({ { 123.00, 23.00, 23.00 }, { 23.00, 123.00, 23.00 }, { 23.00, 23.00, 123.00 } });
+OGRealDenseMatrix::Ptr REAL_A_2 = OGRealDenseMatrix::create({ { 123.00, 23.00, 23.00 }, { 23.00, 123.00, 23.00 }, { 23.00, 23.00, 123.00 } });
+OGComplexDenseMatrix::Ptr CMPLX_A_2 = OGComplexDenseMatrix::create({{{20.0,0.0},{2.0,1.0},{4.0,0.0}},{{2.0,-1.0},{30.0,0.0},{0.0,1.0}},{{4.0,0.0},{-0.0,-1.0},{10.0,0.0}}}
+); // is hermitian at machine prec
 
 // A_square_non_symmetric_well_conditioned 
-OGRealDenseMatrix::Ptr A3 = OGRealDenseMatrix::create({ { 10.00, 2.00, 1.00 }, { 2.00, 3.00, 10.00 }, { 4.00, 10.00, 1.00 } });
+OGRealDenseMatrix::Ptr REAL_A_3 = OGRealDenseMatrix::create({ { 10.00, 2.00, 1.00 }, { 2.00, 3.00, 10.00 }, { 4.00, 10.00, 1.00 } });
+OGComplexDenseMatrix::Ptr CMPLX_A_3 = OGComplexDenseMatrix::create({{{10.0,100.0},{2.0,20.0},{1.0,10.0}},{{2.0,20.0},{3.0,30.0},{10.0,100.0}},{{4.0,40.0},{10.0,100.0},{1.0,10.0}}});
 
-// A_rectangular 
-OGRealDenseMatrix::Ptr A4 = OGRealDenseMatrix::create({ { 1.00, 2.00, 3.00, 4.00 }, { 5.00, 6.00, 7.00, 8.00 }, { 9.00, 10.00, 11.00, 12.00 }, { 13.00, 14.00, 15.00, 16.00 }, { 17.00, 18.00, 19.00, 20.00 } });
+// A_rectangular
+OGRealDenseMatrix::Ptr REAL_A_4 = OGRealDenseMatrix::create({ { 1.00, 2.00, 3.00, 4.00 }, { 5.00, 6.00, 7.00, 8.00 }, { 9.00, 10.00, 11.00, 12.00 }, { 13.00, 14.00, 15.00, 16.00 }, { 17.00, 18.00, 19.00, 20.00 } });
 
 // A_square_non_symmetric_condition_bad_for_lu_ok_for_qr
-OGRealDenseMatrix::Ptr A5 = OGRealDenseMatrix::create({ { 1.0000000000000009, 2., 20. }, { 1., 2., 0. }, { 1., 2., 40. } });
+OGRealDenseMatrix::Ptr REAL_A_5 = OGRealDenseMatrix::create({ { 1.0000000000000009, 2., 20. }, { 1., 2., 0. }, { 1., 2., 40. } });
+OGComplexDenseMatrix::Ptr CMPLX_A_5 = OGComplexDenseMatrix::create({{{1.0000000000000009,10.0000000000000089},{2.0,20.0},{20.0,200.0}},{{1.0,10.0},{2.0,20.0},{0.0,0.0}},{{1.0,10.0},{2.0,20.0},{40.0,400.0}}});
 
 // A_upper_triangular
-OGRealDenseMatrix::Ptr A6 = OGRealDenseMatrix::create({ { 1., 2., 3. }, { 0., 5., 6. }, { 0., 0., 9. } });
+OGRealDenseMatrix::Ptr REAL_A_6 = OGRealDenseMatrix::create({ { 1., 2., 3. }, { 0., 5., 6. }, { 0., 0., 9. } });
+OGComplexDenseMatrix::Ptr CMPLX_A_6 = OGComplexDenseMatrix::create({{{1.0,10.0},{2.0,20.0},{3.0,30.0}},{{0.0,0.0},{5.0,50.0},{6.0,60.0}},{{0.0,0.0},{0.0,0.0},{9.0,90.0}}});
 
 // A_unit_upper_triangular
-OGRealDenseMatrix::Ptr A7 = OGRealDenseMatrix::create({ { 1., 2., 3. }, { 0., 1., 6. }, { 0., 0., 1. } });
+OGRealDenseMatrix::Ptr REAL_A_7 = OGRealDenseMatrix::create({ { 1., 2., 3. }, { 0., 1., 6. }, { 0., 0., 1. } });
+OGComplexDenseMatrix::Ptr CMPLX_A_7 = OGComplexDenseMatrix::create({{{1.0,0.0},{2.0,20.0},{3.0,30.0}},{{0.0,0.0},{1.0,0.0},{6.0,60.0}},{{0.0,0.0},{0.0,0.0},{1.0,0.0}}});
 
 // A_lower_triangular
-OGRealDenseMatrix::Ptr A8 = OGRealDenseMatrix::create({ { 1., 0., 0. }, { 4., 5., 0. }, { 7., 8., 9. } });
+OGRealDenseMatrix::Ptr REAL_A_8 = OGRealDenseMatrix::create({ { 1., 0., 0. }, { 4., 5., 0. }, { 7., 8., 9. } });
+OGComplexDenseMatrix::Ptr CMPLX_A_8 = OGComplexDenseMatrix::create(
+{{{1.0,10.0},{0.0,0.0},{0.0,0.0}},{{4.0,40.0},{5.0,50.0},{0.0,0.0}},{{7.0,70.0},{8.0,80.0},{9.0,90.0}}});
 
 // A_unit_lower_triangular
-OGRealDenseMatrix::Ptr A9 = OGRealDenseMatrix::create({ { 1., 0., 0. }, { 4., 1., 0. }, { 7., 8., 1. } });
+OGRealDenseMatrix::Ptr REAL_A_9 = OGRealDenseMatrix::create({ { 1., 0., 0. }, { 4., 1., 0. }, { 7., 8., 1. } });
+OGComplexDenseMatrix::Ptr CMPLX_A_9 = OGComplexDenseMatrix::create(
+{{{1.0,0.0},{0.0,0.0},{0.0,0.0}},{{4.0,40.0},{1.0,0.0},{0.0,0.0}},{{7.0,70.0},{8.0,80.0},{1.0,0.0}}});
 
 // A_lower_triangular_singular_zero_on_diag 
-OGRealDenseMatrix::Ptr A10 = OGRealDenseMatrix::create({ { 1., 0., 0. }, { 4., 0., 0. }, { 7., 8., 1. } });
+OGRealDenseMatrix::Ptr REAL_A_10 = OGRealDenseMatrix::create({ { 1., 0., 0. }, { 4., 0., 0. }, { 7., 8., 1. } });
+OGComplexDenseMatrix::Ptr CMPLX_A_10 = OGComplexDenseMatrix::create({{{1.0,10.0},{0.0,0.0},{0.0,0.0}},{{4.0,40.0},{0.0,0.0},{0.0,0.0}},{{7.0,70.0},{8.0,80.0},{1.0,10.0}}});
 
 // A_lower_triangular_singular_near_zero_on_diag 
-OGRealDenseMatrix::Ptr A11 = OGRealDenseMatrix::create(
+OGRealDenseMatrix::Ptr REAL_A_11 = OGRealDenseMatrix::create(
 { { 1., 0., 0. }, { 4., 1e-15, 0. }, { 7., 8., 1. } });
+OGComplexDenseMatrix::Ptr CMPLX_A_11 = OGComplexDenseMatrix::create(
+{{{1.0,10.0},{0.0,0.0},{0.0,0.0}},{{4.0,40.0},{1e-15,1e-14},{0.0,0.0}},{{7.0,70.0},{8.0,80.0},{1.0,10.0}}});
 
 // A_square_spd_near_singular 
-OGRealDenseMatrix::Ptr A12 = OGRealDenseMatrix::create({ { 2.0000e+00, 1.0000e+150, 2.0000e+00 }, { 1.0000e+150, 1.0000e+300, 2.0000e+150 }, { 2.0000e+00, 2.0000e+150, 5.0000e+00 } });
+OGRealDenseMatrix::Ptr REAL_A_12 = OGRealDenseMatrix::create({ { 2.0000e+00, 1.0000e+150, 2.0000e+00 }, { 1.0000e+150, 1.0000e+300, 2.0000e+150 }, { 2.0000e+00, 2.0000e+150, 5.0000e+00 } });
+OGComplexDenseMatrix::Ptr CMPLX_A_12 = OGComplexDenseMatrix::create( {{{1.0e36,0.0},{1.0,1.0},{0.0,3.0}},{{1.0,-1.0},{1.0e14,0.0},{2.0,-2.0}},{{-0.0,-3.0},{2.0,2.0},{1.0,0.0}}});
 
-// A_square_symmetric_not_spd 
-OGRealDenseMatrix::Ptr A13 = OGRealDenseMatrix::create({ { 54., 2., 3. }, { 2., 10., 6. }, { 3., 6., -120. } });
+// A_square_symmetric_not_spd
+OGRealDenseMatrix::Ptr REAL_A_13 = OGRealDenseMatrix::create({ { 54., 2., 3. }, { 2., 10., 6. }, { 3., 6., -120. } });
+OGComplexDenseMatrix::Ptr CMPLX_A_13 = OGComplexDenseMatrix::create({{{54.0,0.0},{2.0,20.0},{3.0,30.0}},{{2.0,-20.0},{10.0,0.0},{6.0,60.0}},{{3.0,-30.0},{6.0,-60.0},{-120.0,0.0}}});
 
 // A_rectangular_with_inf
-OGRealDenseMatrix::Ptr A14 = OGRealDenseMatrix::create({ { std::numeric_limits<real8>::infinity(), 2.00, 3.00, 4.00 }, { 5.00, 6.00, 7.00, 8.00 }, { 9.00, 10.00, 11.00, 12.00 },{ 13.00, 14.00, 15.00, 16.00 }, { 17.00, 18.00, 19.00, 20.00 } });
+OGRealDenseMatrix::Ptr REAL_A_14 = OGRealDenseMatrix::create({ { std::numeric_limits<real8>::infinity(), 2.00, 3.00, 4.00 }, { 5.00, 6.00, 7.00, 8.00 }, { 9.00, 10.00, 11.00, 12.00 },{ 13.00, 14.00, 15.00, 16.00 }, { 17.00, 18.00, 19.00, 20.00 } });
 
 // A_square_permuted_upper_triangular 
-OGRealDenseMatrix::Ptr A15 = OGRealDenseMatrix::create({ { 0., 0., 13., 14., 15. }, { 1., 2., 3., 4., 5. }, { 0., 7., 8., 9., 10. }, { 0., 0., 0., 0., 25. }, { 0., 0., 0., 19., 20. } });
+OGRealDenseMatrix::Ptr REAL_A_15 = OGRealDenseMatrix::create({ { 0., 0., 13., 14., 15. }, { 1., 2., 3., 4., 5. }, { 0., 7., 8., 9., 10. }, { 0., 0., 0., 0., 25. }, { 0., 0., 0., 19., 20. } });
+OGComplexDenseMatrix::Ptr CMPLX_A_15 = OGComplexDenseMatrix::create(
+{{{0.0,0.0},{0.0,0.0},{13.0,130.0},{14.0,140.0},{15.0,150.0}},{{1.0,10.0},{2.0,20.0},{3.0,30.0},{4.0,40.0},{5.0,50.0}},{{0.0,0.0},{7.0,70.0},{8.0,80.0},{9.0,90.0},{10.0,100.0}},{{0.0,0.0},{0.0,0.0},{0.0,0.0},{0.0,0.0},{25.0,250.0}},{{0.0,0.0},{0.0,0.0},{0.0,0.0},{19.0,190.0},{20.0,200.0}}});
+
 
 // A_square_permuted_upper_triangular_zero_on_diag
-OGRealDenseMatrix::Ptr A16 = OGRealDenseMatrix::create({ { 0., 6., 7., 8. }, { 0., 0., 0., 16. }, { 1., 2., 3., 4. }, { 0., 0., 0., 12. } });
+OGRealDenseMatrix::Ptr REAL_A_16 = OGRealDenseMatrix::create({ { 0., 6., 7., 8. }, { 0., 0., 0., 16. }, { 1., 2., 3., 4. }, { 0., 0., 0., 12. } });
+OGComplexDenseMatrix::Ptr CMPLX_A_16 = OGComplexDenseMatrix::create({{{0.0,0.0},{6.0,60.0},{7.0,70.0},{8.0,80.0}},{{0.0,0.0},{0.0,0.0},{0.0,0.0},{16.0,160.0}},{{1.0,10.0},{2.0,20.0},{3.0,30.0},{4.0,40.0}},{{0.0,0.0},{0.0,0.0},{0.0,0.0},{12.0,120.0}}});
 
 // A_square_almost_permuted_upper_triangular
-OGRealDenseMatrix::Ptr A17 = OGRealDenseMatrix::create({ { 0., 12., 13., 14., 15. }, { 1., 2., 3., 4., 5. }, { 0., 7., 8., 9., 10. }, { 0., 0., 0., 0., 25. }, { 0., 0., 0., 19., 20. } });
+OGRealDenseMatrix::Ptr REAL_A_17 = OGRealDenseMatrix::create({ { 0., 12., 13., 14., 15. }, { 1., 2., 3., 4., 5. }, { 0., 7., 8., 9., 10. }, { 0., 0., 0., 0., 25. }, { 0., 0., 0., 19., 20. } });
+OGComplexDenseMatrix::Ptr CMPLX_A_17 = OGComplexDenseMatrix::create( {{{0.0,0.0},{12.0,120.0},{13.0,130.0},{14.0,140.0},{15.0,150.0}},{{1.0,10.0},{2.0,20.0},{3.0,30.0},{4.0,40.0},{5.0,50.0}},{{0.0,0.0},{7.0,70.0},{8.0,80.0},{9.0,90.0},{10.0,100.0}},{{0.0,0.0},{0.0,0.0},{0.0,0.0},{0.0,0.0},{25.0,250.0}},{{0.0,0.0},{0.0,0.0},{0.0,0.0},{19.0,190.0},{20.0,200.0}}});
 
 // A_square_permuted_upper_triangular_singular_to_mach_prec
-OGRealDenseMatrix::Ptr A18 = OGRealDenseMatrix::create({ { 0., 0., 1.e-300, 14., 15. }, { 1., 2., 3., 4., 5. }, { 0., 7., 8., 9., 10. },{ 0., 0., 0., 0., 25. },{ 0., 0., 0., 19., 20. } });
+OGRealDenseMatrix::Ptr REAL_A_18 = OGRealDenseMatrix::create({ { 0., 0., 1.e-300, 14., 15. }, { 1., 2., 3., 4., 5. }, { 0., 7., 8., 9., 10. },{ 0., 0., 0., 0., 25. },{ 0., 0., 0., 19., 20. } });
+OGComplexDenseMatrix::Ptr CMPLX_A_18 = OGComplexDenseMatrix::create({{{0.0,0.0},{0.0,0.0},{1.e-300,1.e-299},{14.0,140.0},{15.0,150.0}},{{1.0,10.0},{2.0,20.0},{3.0,30.0},{4.0,40.0},{5.0,50.0}},{{0.0,0.0},{7.0,70.0},{8.0,80.0},{9.0,90.0},{10.0,100.0}},{{0.0,0.0},{0.0,0.0},{0.0,0.0},{0.0,0.0},{25.0,250.0}},{{0.0,0.0},{0.0,0.0},{0.0,0.0},{19.0,190.0},{20.0,200.0}}});
 
 // A_short_row
-OGRealDenseMatrix::Ptr A19 = OGRealDenseMatrix::create({ { 2, 3, 4 } });
+OGRealDenseMatrix::Ptr REAL_A_19 = OGRealDenseMatrix::create({ { 2, 3, 4 } });
+OGComplexDenseMatrix::Ptr CMPLX_A_19 = OGComplexDenseMatrix::create({{{2,20},{3,30},{4,40}}});
+
+// A_short_2_x_row
+OGRealDenseMatrix::Ptr REAL_A_20 = OGRealDenseMatrix::create({ { 2e-6,3,4e6 },{ 2e-6,3,4e6 } });
+OGComplexDenseMatrix::Ptr CMPLX_A_20 = OGComplexDenseMatrix::create({{{2e-6,0},{3,1},{4e6,1e40}},{{2e-6,0},{3,1},{4e6,1e40}}});
+
+OGRealDenseMatrix::Ptr REAL_A_21 = OGRealDenseMatrix::create({ { 0., 0., 0. }, { 0., 0., 0. }, { 0., 0., 0. }});
+OGComplexDenseMatrix::Ptr CMPLX_A_21 = OGComplexDenseMatrix::create({ { 0., 0., 0. }, { 0., 0., 0. }, { 0., 0., 0. }});
+
 
 // B_rectangular
-OGRealDenseMatrix::Ptr B1 = OGRealDenseMatrix::create({ { 1.00, 2.00, 3.00 }, { 1.00, 2.00, 3.00 }, { 1.00, 2.00, 3.00 }, { 1.00, 2.00, 3.00 }, { 1.00, 2.00, 3.00 } });
+OGRealDenseMatrix::Ptr REAL_B_1 = OGRealDenseMatrix::create({ { 1.00, 2.00, 3.00 }, { 1.00, 2.00, 3.00 }, { 1.00, 2.00, 3.00 }, { 1.00, 2.00, 3.00 }, { 1.00, 2.00, 3.00 } });
 
 // C_4len_col_vector
-OGRealDenseMatrix::Ptr C1 = OGRealDenseMatrix::create({{1}, {2}, {3}, {4} });
+OGRealDenseMatrix::Ptr REAL_C_1 = OGRealDenseMatrix::create({{1}, {2}, {3}, {4} });
 
 // C_5len__shuffled_col_matrix
-OGRealDenseMatrix::Ptr C2 = OGRealDenseMatrix::create({{3.e0,10.e0},{1.e0,20.e0},{2.e0,30.e0},{5.e0,40.e0},{4.e0,50.e0}});
+OGRealDenseMatrix::Ptr REAL_C_2 = OGRealDenseMatrix::create({{3.e0,10.e0},{1.e0,20.e0},{2.e0,30.e0},{5.e0,40.e0},{4.e0,50.e0}});
+OGComplexDenseMatrix::Ptr CMPLX_C_2 = OGComplexDenseMatrix::create({{{3.0,30.0},{10.0,100.0}},{{1.0,10.0},{20.0,200.0}},{{2.0,20.0},{30.0,300.0}},{{5.0,50.0},{40.0,400.0}},{{4.0,40.0},{50.0,500.0}}});
+
+// A more stable LHS for complex space
+OGComplexDenseMatrix::Ptr CMPLX_C_3 = OGComplexDenseMatrix::create({{{1.0,-2.0},{10.0,-20.0}},{{-1.0,2.0},{-10.0,20.0}},{{1.0,-2.0},{10.0,-20.0}},{{-1.0,2.0},{-10.0,20.0}},{{1.0,-2.0},{10.0,-20.0}}});
+
+// 4 row single col variant of CMPLX_C_3
+OGComplexDenseMatrix::Ptr CMPLX_C_4 = OGComplexDenseMatrix::create({{{1.0,-2.0}},{{-1.0,2.0}},{{1.0,-2.0}},{{-1.0,2.0}}});
+
+// stable complex space 3x3, like CMPLX_A_1
+OGComplexDenseMatrix::Ptr CMPLX_C_5 = OGComplexDenseMatrix::create({{{1.0,0.0},{2.0,0.0},{3.0,0.0}},{{4.0,0.0},{0.0,5.0},{1.0,2.0}},{{-4.0,-1.0},{3.0,1.0},{-0.0,-5.0}}});
+
+
 
 
 
 INSTANTIATE_NODE_TEST_CASE_P(MLDIVIDETests,MLDIVIDE,
   Values
   (
-
-  // CHECKING REAL SPACE MATRICES
+  // CHECKING SCALAR
   new CheckBinary<MLDIVIDE>
   (
     // input
     OGRealScalar::create(2.0),
-    OGRealScalar::create(3.0),
+    OGRealScalar::create(6.0),
     // expected
-    OGRealScalar::create(5.0),
+    OGRealScalar::create(3.0),
     MATHSEQUAL
   ),
+
+  // CHECKING MATRIX-MATRIX VARIANTS
+
+  //test catch of all zeros Branch
+  new CheckBinary<MLDIVIDE>
+  (
+    // input
+    REAL_A_21,
+    REAL_A_1,
+    // expected
+    OGRealDenseMatrix::create( { { getPosInf(), getPosInf(), getPosInf()}, { getPosInf(), getPosInf(), getPosInf()}, { getPosInf(), getPosInf(), getPosInf()} }),
+    MATHSEQUAL
+  ),
+  new CheckBinary<MLDIVIDE>
+  (
+    // input
+    CMPLX_A_21,
+    CMPLX_A_1,
+    // expected
+    OGComplexDenseMatrix::create({ { getPosInf(), getPosInf(), getPosInf()}, { getPosInf(), getPosInf(), getPosInf()}, { getPosInf(), getPosInf(), getPosInf()} }),
+    MATHSEQUAL
+  ),
+
   //test UpperTri Branch
   new CheckBinary<MLDIVIDE>
   (
     // input
-    A6,
-    A1,
+    REAL_A_6,
+    REAL_A_1,
     // expected
     OGRealDenseMatrix::create( { { 0.5333333333333334, 1.0666666666666669, 1.6000000000000001 }, { 0.0666666666666667, 0.1333333333333334, 0.2000000000000000 },
       { 0.1111111111111111, 0.2222222222222222, 0.3333333333333333 } }),
     MATHSEQUAL
   ),
+  new CheckBinary<MLDIVIDE>
+  (
+    // input
+    CMPLX_A_6,
+    CMPLX_A_1,
+    // expected
+    OGComplexDenseMatrix::create({{{0.5333333333333334,0.0},{1.0666666666666669,0.0},{1.6000000000000001,0.0}},{{0.0666666666666667,0.0},{0.1333333333333334,0.0},{0.2000000000000000,0.0}},{{0.1111111111111111,0.0},{0.2222222222222222,0.0},{0.3333333333333333,0.0}}}),
+    MATHSEQUAL
+  ),
+
   //test UnitUpperTri Branch
   new CheckBinary<MLDIVIDE>
   (
     // input
-    A7,
-    A1,
+    REAL_A_7,
+    REAL_A_1,
     // expected
     OGRealDenseMatrix::create( { {8.0000000000000000, 16.0000000000000000, 24.0000000000000000 }, {-5.0000000000000000, -10.0000000000000000, -15.0000000000000000 },
       {1.0000000000000000, 2.0000000000000000, 3.0000000000000000 } }),
     MATHSEQUAL
   ),
+  new CheckBinary<MLDIVIDE>
+  (
+    // input
+    CMPLX_A_7,
+    CMPLX_A_1,
+    // expected
+    OGComplexDenseMatrix::create({{{-3092.0,-11730.0},{-6184.0,-23460.0},{-9276.0,-35190.0}},{{595.0,-110.0},{1190.0,-220.0},{1785.0,-330.0}},{{1.0,10.0},{2.0,20.0},{3.0,30.0}}}),
+    MATHSEQUAL
+  ),
+
   //test LowerTri Branch
   new CheckBinary<MLDIVIDE>
   (
     // input
-    A8,
-    A1,
+    REAL_A_8,
+    REAL_A_1,
     // expected
     OGRealDenseMatrix::create( { {1.0000000000000000, 2.0000000000000000, 3.0000000000000000 }, {-0.6000000000000000, -1.2000000000000000, -1.8000000000000000 },
       {-0.1333333333333334, -0.2666666666666667, -0.4000000000000000 } }),
     MATHSEQUAL
   ),
+  new CheckBinary<MLDIVIDE>
+  (
+    // input
+    CMPLX_A_8,
+    CMPLX_A_1,
+    // expected
+    OGComplexDenseMatrix::create({{{1.0,0.0},{2.0,0.0},{3.0,0.0}},{{-0.6000000000000000,0.0},{-1.2000000000000000,0.0},{-1.8000000000000000,0.0}},{{-0.1333333333333333,0.0},{-0.2666666666666666,0.0},{-0.4000000000000000,-0.0}}}),
+    MATHSEQUAL
+  ),
+
   //test UnitLowerTri Branch
   new CheckBinary<MLDIVIDE>
   (
     // input
-    A9,
-    A1,
+    REAL_A_9,
+    REAL_A_1,
     // expected
     OGRealDenseMatrix::create( { {1.0000000000000000, 2.0000000000000000, 3.0000000000000000 }, {-3.0000000000000000, -6.0000000000000000, -9.0000000000000000 },
       {18.0000000000000000, 36.0000000000000000, 54.0000000000000000 } }),
     MATHSEQUAL
   ),
+  new CheckBinary<MLDIVIDE>
+  (
+    // input
+    CMPLX_A_9,
+    CMPLX_A_1,
+    // expected
+    OGComplexDenseMatrix::create({{{1.0,10.0},{2.0,20.0},{3.0,30.0}},{{397.0,-70.0},{794.0,-140.0},{1191.0,-210.0}},{{-8082.0,-31330.0},{-16164.0,-62660.0},{-24246.0,-93990.0}}}),
+    MATHSEQUAL
+  ),
+
   //test PermutedUpperTriangular Branch
   new CheckBinary<MLDIVIDE>
   (
     // input
-    A15,
-    C2,
+    REAL_A_15,
+    REAL_C_2,
     // expected
     OGRealDenseMatrix::create( { {0.0000000000000000, 8.1445922498554086 }, {0.0000000000000000, 3.1787160208212839 }, {0.0000000000000000, -2.0971659919028340 },
       {0.0000000000000000, 0.9473684210526315 }, {0.2000000000000000, 1.6000000000000001 } }),
     MATHSEQUAL
   ),
+  new CheckBinary<MLDIVIDE>
+  (
+    // input
+    CMPLX_A_15,
+    CMPLX_C_2,
+    // expected
+    OGComplexDenseMatrix::create({{{0.0,0.0},{8.1445922498554069,-0.0000000000000002}},{{0.0,0.0},{3.1787160208212835,0.0000000000000001}},{{0.0,0.0},{-2.0971659919028340,-0.0}},{{0.0,0.0},{0.9473684210526316,0.0}},{{0.2000000000000000,0.0},{1.6000000000000001,0.0}}}),
+    MATHSEQUAL
+  ),
+
   //test AlmostPermutedUpperTriangular Branch
   new CheckBinary<MLDIVIDE>
   (
     // input
-    A17,
-    C2,
+    REAL_A_17,
+    REAL_C_2,
     // expected
     OGRealDenseMatrix::create({ {0.0000000000000002, -29.9999999999998650 }, {0.0000000000000004, -57.8526315789472108 }, {-0.0000000000000004, 51.3052631578945864 },
       {0.0000000000000000, 0.9473684210526315 }, {0.2000000000000000, 1.6000000000000001 } }),
     MATHSEQUAL
   ),
+  new CheckBinary<MLDIVIDE>
+  (
+    // input
+    CMPLX_A_17,
+    CMPLX_C_3,
+    // expected
+    OGComplexDenseMatrix::create({{{0.3762376237623766,0.2376237623762379},{3.7623762376237662,2.3762376237623792}},{{0.1853465346534657,0.1170609692548206},{1.8534653465346569,1.1706096925482055}},{{-0.1750495049504954,-0.1105575820739972},{-1.7504950495049536,-1.1055758207399717}},{{-0.0178217821782178,-0.0112558624283481},{-0.1782178217821782,-0.1125586242834810}},{{0.0075247524752475,0.0047524752475248},{0.0752475247524752,0.0475247524752475}}}),
+    MATHSEQUAL
+  ),
+
   //test PermutedUpperTriangularZeroOnDiag Branch
   new CheckBinary<MLDIVIDE>
   (
     // input
-    A16,
-    C1,
+    REAL_A_16,
+    REAL_C_1,
     // expected
     OGRealDenseMatrix::create({ {2.0475247524752480 }, {-0.7168316831683170 }, {0.5287128712871273 }, {0.2000000000000003 } }),
     MATHSEQUAL
   ),
+  new CheckBinary<MLDIVIDE>
+  (
+    // input
+    CMPLX_A_16,
+    CMPLX_C_4,
+    // expected
+    OGComplexDenseMatrix::create({{{-0.1067620821488090,-0.0674286834624056}},{{0.0144534849524556,0.0091285168120772}},{{-0.0543123223213409,-0.0343025193608469}},{{0.0131683168316832,0.0083168316831683}}}),
+    MATHSEQUAL
+  ),
+
   //test PermutedUpperTriangularSingularToMachPrec Branch
   new CheckBinary<MLDIVIDE>
   (
     // input
-    A18,
-    C2,
+    REAL_A_18,
+    REAL_C_2,
     // expected
     OGRealDenseMatrix::create({ {-0.0000000000000001, 5.7657712505229739 }, {-0.0000000000000001, -1.3196460795883791 }, {-0.0000000000000001, 2.6102410879868061 },
       {0.0000000000000000, 0.2699985638374270 }, {0.2000000000000001, 1.5925606778687353 } }),
     MATHSEQUAL
   ),
+  new CheckBinary<MLDIVIDE>
+  (
+    // input
+    CMPLX_A_18,
+    CMPLX_C_3,
+    // expected
+    OGComplexDenseMatrix::create( {{{0.2109968569492433,0.1332611728100484},{2.1099685694924331,1.3326117281004841}},{{-0.0803459698947434,-0.0507448230914169},{-0.8034596989474336,-0.5074482309141690}},{{0.0588880750840383,0.0371924684741295},{0.5888807508403830,0.3719246847412949}},{{-0.0191009622289243,-0.0120637656182680},{-0.1910096222892430,-0.1206376561826800}},{{0.0075107036770028,0.0047436023223175},{0.0751070367700277,0.0474360232231754}}}),
+    MATHSEQUAL
+  ),
+
+
   //test TriDefinedSingular Branch
   new CheckBinary<MLDIVIDE>
   (
     // input
-    A10,
-    A1,
+    REAL_A_10,
+    REAL_A_1,
     // expected
     OGRealDenseMatrix::create( { {0.2941176470588236, 0.5882352941176472, 0.8823529411764708 }, {-0.1303167420814479, -0.2606334841628958, -0.3909502262443438 },
       {-0.0162895927601810, -0.0325791855203620, -0.0488687782805430 } }),
     MATHSEQUAL
   ),
+  new CheckBinary<MLDIVIDE>
+  (
+    // input
+    CMPLX_A_10,
+    CMPLX_A_1,
+    // expected
+    // NOTE: the "zero" values here are highly dubious as they are suceptible to fp issues
+    OGComplexDenseMatrix::create({{{0.2941176470588236,-0.0000000000000001},{0.5882352941176472,-0.0000000000000002},{0.8823529411764708,-0.0000000000000005}},{{-0.1303167420814480,0.0000000000000001},{-0.2606334841628959,0.0000000000000002},{-0.3909502262443439,0.0000000000000006}},{{-0.0162895927601810,0.0},{-0.0325791855203620,0.0},{-0.0488687782805430,0.0}}}),
+    MATHSEQUAL
+  ),
+
   //test TriMachPrecSingular Branch
   new CheckBinary<MLDIVIDE>
   (
     // input
-    A11,
-    A1,
+    REAL_A_11,
+    REAL_A_1,
     // expected
-    OGRealDenseMatrix::create({ {0.2941176470588236, 0.5882352941176472, 0.8823529411764708 }, {-0.1303167420814479, -0.2606334841628958, -0.3909502262443438 },
-      {-0.0162895927601810, -0.0325791855203620, -0.0488687782805430 } }),
+    OGRealDenseMatrix::create({ {0.2941176470588236, 0.5882352941176472, 0.8823529411764708 }, {-0.1303167420814479, -0.2606334841628958, -0.3909502262443438 },      {-0.0162895927601810, -0.0325791855203620, -0.0488687782805430 } }),
     MATHSEQUAL
   ),
+  new CheckBinary<MLDIVIDE>
+  (
+    // input
+    CMPLX_A_11,
+    CMPLX_C_5,
+    // expected
+    // NOTE: numbers straight from plumbing into fortran
+    OGComplexDenseMatrix::create({{{  0.990099009900991325E-02, -0.990099009900990285E-01},{  0.117647058823529424E+00, -0.543923179043097550E-17},{  0.506697728596388758E-01, -0.361094933022714157E-01}},{{ -0.255902513328255879E-01,  0.132825590251332781E+00},
+    { -0.855158819049325336E-01, -0.353389185072353201E-01},{ -0.104583127996057484E+00,  0.250168003225661913E-01}},{{ -0.319878141660320066E-02,  0.166031987814166011E-01},{ -0.106894852381165684E-01, -0.441736481340441502E-02},{ -0.130728909995071873E-01,  0.312710004032077304E-02}}}),
+    MATHSEQUAL
+  ),
+
   //test LUP Branch
   new CheckBinary<MLDIVIDE>
   (
     // input
-    A3,
-    A1,
+    REAL_A_3,
+    REAL_A_1,
     // expected
     OGRealDenseMatrix::create({ {0.0812641083521445, 0.1625282167042890, 0.2437923250564334 }, {0.0609480812641084, 0.1218961625282167, 0.1828442437923251 },
       {0.0654627539503386, 0.1309255079006772, 0.1963882618510158 } }),
     MATHSEQUAL
   ),
+  new CheckBinary<MLDIVIDE>
+  (
+    // input
+    CMPLX_A_3,
+    CMPLX_A_1,
+    // expected
+    OGComplexDenseMatrix::create({{{0.0812641083521445,0.0},{0.1625282167042889,0.0},{0.2437923250564334,0.0}},{{0.0609480812641084,0.0},{0.1218961625282167,0.0},{0.1828442437923251,0.0}},{{0.0654627539503386,0.0},{0.1309255079006772,0.0},{0.1963882618510158,0.0}}}),
+    MATHSEQUAL
+  ),
+
   //test LUPBranchFallToLSQ Branch
   new CheckBinary<MLDIVIDE>
   (
     // input
-    A5,
-    A1,
+    REAL_A_5,
+    REAL_A_1,
     // expected
     OGRealDenseMatrix::create({ {0.2000000000000003, 0.4000000000000006, 0.6000000000000013 }, {0.4000000000000002, 0.8000000000000004, 1.2000000000000017 },
       {-0.0000000000000001, -0.0000000000000001, 0.0000000000000000 } }),
     MATHSEQUAL
   ),
+  new CheckBinary<MLDIVIDE>
+  (
+    // input
+    CMPLX_A_5,
+    CMPLX_A_1,
+    // expected
+    OGComplexDenseMatrix::create({{{0.2000000000000012,-0.0},{0.4000000000000024,-0.0},{0.6000000000000035,-0.0000000000000001}},{{0.4000000000000009,0.0},{0.8000000000000017,0.0},{1.2000000000000024,0.0}},{{0.0,-0.0},{0.0,-0.0},{0.0000000000000002,-0.0}}}),
+    MATHSEQUAL
+  ),
+
    //test Chol Branch
   new CheckBinary<MLDIVIDE>
   (
     // input
-    A2,
-    A1,
+    REAL_A_2,
+    REAL_A_1,
     // expected
     OGRealDenseMatrix::create({ {0.0059171597633136, 0.0118343195266272, 0.0177514792899408 }, {0.0059171597633136, 0.0118343195266272, 0.0177514792899408 },
       {0.0059171597633136, 0.0118343195266272, 0.0177514792899408 } }),
     MATHSEQUAL
   ),
+  new CheckBinary<MLDIVIDE>
+  (
+    // input
+    CMPLX_A_2,
+    CMPLX_A_1,
+    // expected
+    OGComplexDenseMatrix::create({{{0.0510841602352076,0.2881293642043367},{0.1021683204704153,0.5762587284086734},{0.1532524807056229,0.8643880926130100}},{{0.0499816244027931,0.3142227122381478},{0.0999632488055862,0.6284454244762956},{0.1499448732083793,0.9426681367144433}},{{0.0481440646821022,0.8897464167585445},{0.0962881293642043,1.7794928335170890},{0.1444321940463065,2.6692392502756337}}}),
+    MATHSEQUAL
+  ),
+
    //test Chol Not SPD Branch
   new CheckBinary<MLDIVIDE>
   (
     // input
-    A13,
-    A1,
+    REAL_A_13,
+    REAL_A_1,
     // expected
     OGRealDenseMatrix::create({ {0.0150267040825563, 0.0300534081651127, 0.0450801122476691 }, {0.0988051054584955, 0.1976102109169910, 0.2964153163754866 },
       {-0.0030174104583446, -0.0060348209166893, -0.0090522313750339 } }),
     MATHSEQUAL
   ),
+  new CheckBinary<MLDIVIDE>
+  (
+    // input
+    CMPLX_A_13,
+    CMPLX_A_1,
+    // expected
+    OGComplexDenseMatrix::create({{{0.1277309984054606,0.1753993342098637},{0.2554619968109212,0.3507986684197275},{0.3831929952163817,0.5261980026295914}},{{-0.2394186924776904,0.2617002825411923},{-0.4788373849553809,0.5234005650823845},{-0.7182560774330713,0.7851008476235766}},{{0.1575889818259807,0.0219132607864529},{0.3151779636519615,0.0438265215729059},{0.4727669454779422,0.0657397823593588}}}),
+    MATHSEQUAL
+  ),
+
    //test Chol Singular Branch
   new CheckBinary<MLDIVIDE>
   (
     // input
-    A12,
-    A1,
+    REAL_A_12,
+    REAL_A_1,
     // expected
     OGRealDenseMatrix::create({ {0, 0, 0 }, {1e-300, 2e-300, 3e-300 }, {0, 0, 0 } }),
     MATHSEQUAL
   ),
+  new CheckBinary<MLDIVIDE>
+  (
+    // input
+    CMPLX_A_12,
+    CMPLX_A_1,
+    // expected
+    // NOTE: getting here is quite hard...
+    // need something Hermitian AND p.d. AND with a bad 1 norm condition estimate
+    OGComplexDenseMatrix::create({{{0.0e0,0.0e0},{0.0e0,0.0e0},{0.0e0,0.0e0}},{{0.0e0,0.0e0},{0.0e0,0.0e0},{0.0e0,0.0e0}},{{0.0e0,0.0e0},{0.0e0,0.0e0},{0.0e0,0.0e0}}}),
+    MATHSEQUAL
+  ),
+
+  //test DGELS branch Expansion
+  // this branch tests the necessary expansion of the "B" matrix if the solution to the system is larger than the mallocd space
+  new CheckBinary<MLDIVIDE>
+  (
+    // input
+    REAL_A_19,
+    REAL_A_19,
+    // expected
+    OGRealDenseMatrix::create({ {0.1379310344827586, 0.2068965517241379, 0.2758620689655172 },
+      {0.2068965517241379, 0.3103448275862069, 0.4137931034482758 }, {0.2758620689655172, 0.4137931034482757, 0.5517241379310344 } }),
+    MATHSEQUAL
+  ),
+  new CheckBinary<MLDIVIDE>
+  (
+    // input
+    CMPLX_A_19,
+    CMPLX_A_19,
+    // expected
+    OGComplexDenseMatrix::create({{{0.1379310344827586,0.0},{0.2068965517241380,0.0},{0.2758620689655172,0.0}},{{0.2068965517241379,0.0},{0.3103448275862069,0.0},{0.4137931034482759,0.0}},{{0.2758620689655172,0.0},{0.4137931034482760,0.0},{0.5517241379310345,0.0}}}),
+    MATHSEQUAL
+  ),
+
    //test SVD Branch
   new CheckBinary<MLDIVIDE>
   (
     // input
-    A1,
-    A2,
+    REAL_A_1,
+    REAL_A_2,
     // expected
     OGRealDenseMatrix::create({ {4.0238095238095219, 4.0238095238095228, 4.0238095238095219 }, {8.0476190476190457, 8.0476190476190474, 8.0476190476190457 },
       {12.0714285714285658, 12.0714285714285694, 12.0714285714285676 } }),
     MATHSEQUAL
   ),
-   //test DGELS branch Expansion
-  // this branch tests the necessary expansion of the "B" matrix if the solution to the system is larger than the mallocd space
   new CheckBinary<MLDIVIDE>
   (
     // input
-    A19,
-    A19,
+    CMPLX_A_1,
+    CMPLX_A_2,
     // expected
-    OGRealDenseMatrix::create({ {0.1379310344827586, 0.2068965517241379, 0.2758620689655172 },
-      {0.2068965517241379, 0.3103448275862069, 0.4137931034482758 }, {0.2758620689655172, 0.4137931034482757, 0.5517241379310344 } }),
+    // NOTE: Solving this system on Fedora boxes manually via LAPACK calls and not using
+    // our LAPACK/BLAS will likely result in wild results. Fedora uses ATLAS LAPACK and
+    // ATLAS BLAS if linked with just -llapack. To obtain the result below, one needs to link
+    // with -llapack -lblas such that the system /usr/lib64/libblas.so BLAS is used as it has
+    // superior (IIRC, and this is stretching my memory back 2 years), Householder routines).
+    OGComplexDenseMatrix::create({{{0.0037718057520038,-0.0615275813295615},{0.0075436115040075,-0.0754361150400754},{0.0056577086280057,-0.0327675624705328}},{{0.0075436115040076,-0.1230551626591231},{0.0150872230080151,-0.1508722300801509},{0.0113154172560113,-0.0655351249410655}},{{0.0113154172560114,-0.1845827439886846},{0.0226308345120226,-0.2263083451202263},{0.0169731258840169,-0.0983026874115983}}}),
+    MATHSEQUAL
+  ),
+
+   //test QR fail, then SVD xgelsd answer size re-uses memory Branch
+  new CheckBinary<MLDIVIDE>
+  (
+    // input
+    REAL_A_20,
+    REAL_A_20,
+    // expected
+    OGRealDenseMatrix::create({{0.0,0.0,0.0000000000005000},{0.0,0.0000000000005625,0.0000007500000000},{0.0000000000005000,0.0000007500000000,0.9999999999994372}}),
+    MATHSEQUAL
+  ),
+  new CheckBinary<MLDIVIDE>
+  (
+    // input
+    CMPLX_A_20,
+    CMPLX_A_20,
+    // expected
+    OGComplexDenseMatrix::create({{{0.0,0.0},{0.0,0.0},{0.0,0.0}},{{0.0,-0.0},{0.0,0.0},{0.0,0.0}},{{0.0,-0.0},{0.0,-0.0},{1.0000000000000002,0.0}}}),
     MATHSEQUAL
   )
-
 
   ) // end value
 );
@@ -309,17 +573,4 @@ TEST(MLDIVIDETests, CheckBadCommuteThrows) {
   ASSERT_THROW(
   runtree(node),
   rdag_error);
-}
-
-// QR: this is a right pain to test because it's rank deficient the results are pulled 
-// about by floating point behaviour in deficient part of Q
-// we test by reconstruction opposed to absolute value
-TEST(MLDIVIDETests, test_rank_deficient_QR_Branch) {
-  OGExpr::Ptr op = MLDIVIDE::create(A4, B1);
-  runtree(op);
-  OGExpr::Ptr  reconstr = PLUS::create(NEGATE::create(B1), MTIMES::create(A4, op->getRegs()[0]->asOGTerminal()));
-  runtree(reconstr);
-  OGTerminal::Ptr zeros = OGRealDenseMatrix::create({{0,0,0},{0,0,0},{0,0,0},{0,0,0},{0,0,0}});
-  reconstr->getRegs()[0]->asOGTerminal()->debug_print();
-  EXPECT_TRUE(zeros->mathsequals(reconstr->getRegs()[0]->asOGTerminal(),1e-14,1e-14));
 }

--- a/src/librdag/test/nodes/testnodes.cc
+++ b/src/librdag/test/nodes/testnodes.cc
@@ -195,4 +195,7 @@ template class UnaryOpTest<TRANSPOSE>;
 template class CheckBinary<MTIMES>;
 template class BinaryOpTest<MTIMES>;
 
+template class CheckBinary<MLDIVIDE>;
+template class BinaryOpTest<MLDIVIDE>;
+
 }


### PR DESCRIPTION
This PR contains the code required to add the `mldivide` (matrix left division|magic backslash|super solver [depends who you ask]) algorithm. The code is a rough translation of the java variant of this from the OG-Maths prototype, but with both algorithmic changes and bug fixes added. Also, thanks to the massive templating effort, the complex domain variant of this algorithm came for free.

Unfortunately this PR is fairly heavy going, the algorithm is complicated in the first place, the memory management is hard work and the testing is fairly tricky. I've tried to add as much commentary regarding the alg and what the different branches etc. are doing inline. Similarly, the unit test pairs for `<real8, complex16>` each have a one liner stating their properties. 

Coverage from the unit tests is extensive and in some places overlapping, this is with intention of ensuring the right branches are tripped. I've also manually checked each unit test pair to make sure that both real and complex data sets in the pair trip the same branches in the alg. Obviously the problem with a super solver is that it just keeps going so optimisation/efficiency attempts had to be manually checked to ensure e.g. a triangular matrix was indeed hitting a triangular back solver opposed to e.g. a SVD based solver.

Just as a process note: I've left the debugging flag on for now, so calls to this routine are a bit noisy as the decision tree is dumped to `stdout`. I intend to turn this off once we've run the fuzzer on this for a good long while, given the complexity, there's potential for bugs.

Further to the work on `mldivide`, I've added construct from `std::initializer_list` to the `OGXXXDenseMatrix` types on the C++ side, this considerably neatens and simplifies setting up input data in testing.

On the back of this work, it would appear sensible to create a "unrecoverable" error type from which a `xerbla_error` could be derived such that throws from the `lapack::` namespace of this sort of error are not caught under the standard `rdag_error&` catches. Similarly a `nonconformance_error` type would also be beneficial and be in the the same hierarchy. Ticket [[MAT-440]](http://jira.opengamma.com/browse/MAT-440) is raised to address this issue.

**Coverage**
Java: 77% (up 1%)
build/src/jshim 0.8% (no change)
build/src/librdag 17.1% (up 0.5%)
src/jshim 53.7% (no change)
src/librdag 94.2% (down 0.2%)
src/librdag/runners 94.5% (down 1.2%, missed branches for xerbla based fails and a branch I think is dead (see below)).
