### PR TITLE
Mat-441Fix segfault occuring in pinv()

### DIFF
--- a/src/librdag/runners/pinvrunner.cc
+++ b/src/librdag/runners/pinvrunner.cc
@@ -85,7 +85,7 @@ pinv_dense_runner(RegContainer& reg, shared_ptr<const OGMatrix<T>> arg)
     const size_t minmn = m > n ? n : m;
 
     // Perform SVD on a copy of the argument, since it will get destroyed
-    OGExpr::Ptr svd = SVD::create(arg);
+    OGExpr::Ptr svd = SVD::create(arg->createOwningCopy());
 
     // run the tree
     runtree(svd);

--- a/src/librdag/runners/pinvrunner.cc
+++ b/src/librdag/runners/pinvrunner.cc
@@ -103,8 +103,8 @@ pinv_dense_runner(RegContainer& reg, shared_ptr<const OGMatrix<T>> arg)
       return;
     }
 
-    // Perform SVD on a copy of the argument, since it will get destroyed
-    OGExpr::Ptr svd = SVD::create(arg->createOwningCopy());
+    // Perform SVD
+    OGExpr::Ptr svd = SVD::create(arg);
 
     // run the tree
     runtree(svd);

--- a/src/librdag/runners/pinvrunner.cc
+++ b/src/librdag/runners/pinvrunner.cc
@@ -97,8 +97,7 @@ pinv_dense_runner(RegContainer& reg, shared_ptr<const OGMatrix<T>> arg)
     }
     if(allzero)
     {
-      unique_ptr<T[]> retData(new T[len]());
-      ret = makeConcreteDenseMatrix(retData.release(), n, m, OWNER);
+      ret = makeConcreteDenseMatrix(new T[len](), n, m, OWNER);
       reg.push_back(ret);
       return;
     }
@@ -160,8 +159,7 @@ pinv_dense_runner(RegContainer& reg, shared_ptr<const OGMatrix<T>> arg)
     }
     else // this is a safety net, practically impossible to reach here because we catch all zeros input!
     {
-      unique_ptr<T[]> retData(new T[len]());
-      ret = makeConcreteDenseMatrix(retData.release(), n, m, OWNER);
+      ret = makeConcreteDenseMatrix(new T[len](), n, m, OWNER);
       reg.push_back(ret);
       return;
     }

--- a/src/librdag/test/nodes/check_pinv.cc
+++ b/src/librdag/test/nodes/check_pinv.cc
@@ -80,7 +80,27 @@ INSTANTIATE_NODE_TEST_CASE_P(PINVTests,PINV,
   new CheckUnary<PINV>(
       OGComplexDenseMatrix::create(new complex16[12]{{1,10},{4,40},{7,70},{10,100},{2,20},{5,50},{8,80},{11,110},{3,30},{6,60},{9,90},{12,120}},4,3, OWNER),
       OGComplexDenseMatrix::create(new complex16[12]{{-0.0047854785478551, 0.0478547854785478}, {-0.0003300330033002, 0.0033003300330034}, {0.0041254125412542,-0.0412541254125413}, {-0.0024202420242024, 0.0242024202420241}, {-0.0001100110011000, 0.0011001100110011}, {0.0022002200220021,-0.0220022002200220}, {-0.0000550055005500, 0.0005500550055006}, {0.0001100110011001,-0.0011001100110011}, {0.0002750275027502,-0.0027502750275028}, {0.0023102310231024,-0.0231023102310231}, {0.0003300330033003,-0.0033003300330033}, {-0.0016501650165016, 0.0165016501650165}},3,4,OWNER),
+      MATHSEQUAL),
+
+  // Regression tests for MAT-441, segfault in PINV caused by negative value
+  // written to size_t, which when used as a loop bound causes invalid access.
+  new CheckUnary<PINV>(
+      OGRealDenseMatrix::create(new real8[12](),4,3, OWNER),
+      OGRealDenseMatrix::create(new real8[12](),3,4,OWNER),
+      MATHSEQUAL),
+  new CheckUnary<PINV>(
+      OGComplexDenseMatrix::create(new complex16[12](),4,3, OWNER),
+      OGComplexDenseMatrix::create(new complex16[12](),3,4,OWNER),
+      MATHSEQUAL),
+  new CheckUnary<PINV>(
+      OGRealDenseMatrix::create(new real8[9]{1,0,0,0,1,0,0,0,5e-17},3,3, OWNER),
+      OGRealDenseMatrix::create(new real8[9]{1,0,0,0,1,0,0,0,0},3,3,OWNER),
+      MATHSEQUAL),
+  new CheckUnary<PINV>(
+      OGComplexDenseMatrix::create(new complex16[9]{{1,1},{0,0},{0,0},{0,0},{1,1},{0,0},{0,0},{0,0},{5e-17,5e-17}},3,3, OWNER),
+      OGComplexDenseMatrix::create(new complex16[9]{{0.5,-0.5},{0,0},{0,0},{0,0},{0.5,-0.5},{0,0},{0,0},{0,0},{0,0}},3,3,OWNER),
       MATHSEQUAL)
+
   )
 );
 


### PR DESCRIPTION
The fuzzer spotted a segfault in the `pinv()` function, turns out this was from an invalid loop induction setting a limit of type `size_t` to `-1`, this limit was then used as a upper bound to index an array and hence segfaulted!

To fix this:
- A branch to test for all zeros in the input matrix is added, this is quicker to handle than a SVD anyway and allows an early escape.
- The offending loop is now patched and a further branch is added should it be possible to escape early when all singular values are below the threshold (this branch is not tested as it is a safety net and I'm not wholly convinced it's even reachable!).
- The svd runner is also patched to use smart pointer managed memory.

Coverage:
Java: 77% (no change)
build/src/jshim 0.8% (no change)
build/src/librdag 17.1% (no change)
src/jshim 53.1% (no change)
src/librdag 94.2% (no change)
src/librdag/runners 94.6% (up 0.1%).
