### PR TITLE
[MAT-443] fix segfault in mldivide from "triangle" pass.

### DIFF
--- a/src/librdag/test/nodes/check_mldivide.cc
+++ b/src/librdag/test/nodes/check_mldivide.cc
@@ -560,7 +560,20 @@ INSTANTIATE_NODE_TEST_CASE_P(MLDIVIDETests,MLDIVIDE,
     // expected
     OGComplexDenseMatrix::create({{{0.0,0.0},{0.0,0.0},{0.0,0.0}},{{0.0,-0.0},{0.0,0.0},{0.0,0.0}},{{0.0,-0.0},{0.0,-0.0},{1.0000000000000002,0.0}}}),
     MATHSEQUAL
+  ),
+
+  // Regression test for [MAT-443], system matrix with row entirely made of zeros
+  new CheckBinary<MLDIVIDE>
+  (
+    // data straight from the fuzzer
+    // input
+    OGComplexDenseMatrix::create({{{1,0},{1302631145,0}},{{0,0},{0,0}}}),
+    OGComplexDenseMatrix::create({{{-749178602,0}, {0,0}, {0,0}, {0,0}},{{0,0}, {-1645077094,0}, {0,0}, {0,0}}}),
+    // expected
+    OGRealDenseMatrix::create({{-0.0000000004415119,0.0,0.0,0.0},{-0.5751271991888387,0.0,0.0,0.0}}),
+    MATHSEQUAL
   )
+
 
   ) // end value
 );
@@ -574,3 +587,4 @@ TEST(MLDIVIDETests, CheckBadCommuteThrows) {
   runtree(node),
   rdag_error);
 }
+


### PR DESCRIPTION
The fuzzer picked up a segfault in mldivide for the data presented in the regression test included. Essentially, matrix with a row containing all zeros, which is a valid input, could cause a segfault due to the value -1 being a flag and it not being overwritten by a `rowStart` as there effectively isn't one in this case. So a lookup of index `size_t = -1` occurs and causes havoc. Patch basically checks indices are valid before attempting the check of permutation validity. Regression test added straight from fuzzer input that found the bug.

Coverage:
Java: 77% (no change)
build/src/jshim 0.8% (no change)
build/src/librdag 17.1% (no change)
src/jshim 53.1% (no change)
src/librdag 94.2% (no change)
src/librdag/runners 94.8% (up 0.2%).
