### PR TITLE
Mat 425 add in OG-Izy wiring.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,11 @@ else()
 #This is a temporary thing. Expect later to add in ExternalProject_add to get the code!!
   message( FATAL_ERROR "LAPACK_BUILDDIR must be defined: e.g. -DLAPACK_BUILDDIR=\"/path/to/OG-Lapack/build\"" )
 endif()
+if(IZY_BUILDDIR)
+  set(IZY_BUILDINFO ${IZY_BUILDDIR}/IZY_EXPORTS.cmake)
+else()
+  message( FATAL_ERROR "IZY_BUILDDIR must be defined: e.g. -DIZY_BUILDDIR=\"/path/to/OG-Izy/build\"" )
+endif()
 
 
 enable_language(C)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,7 +227,7 @@ if(NOT DEFINED BUILDNUMBER)
   set(BUILDNUMBER local)
 endif()
 add_custom_target(verinfo
-                  ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/cmake/verinfo.py ${CMAKE_BINARY_DIR}/verinfo.yaml ${JAR_VERSION} ${LAPACK_BUILDDIR}/verinfo.yaml ${BUILDNUMBER}
+                  ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/cmake/verinfo.py ${CMAKE_BINARY_DIR}/verinfo.yaml ${JAR_VERSION} ${LAPACK_BUILDDIR}/verinfo.yaml ${IZY_BUILDDIR}/verinfo.yaml ${BUILDNUMBER}
                   COMMENT "Generating version info")
 
 add_subdirectory(src)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -69,6 +69,7 @@ Generally recent versions of the requirements are preferred:
 
 #### Dependencies
 * OG-Lapack, our OpenGamma LAPACK build, available [here](https://github.com/OpenGamma/OG-Lapack/).
+* OG-Izy, our OpenGamma vector maths library implementation, available [here](https://github.com/OpenGamma/OG-Izy/).
 * jcommander 1.17+ (we test with 1.17)
 * TestNG 6.3.1+ (we test with 6.3.1)
 
@@ -97,11 +98,18 @@ variable contains the paths to your `jcommander` and `TestNG` jars. **
 Next run CMake. It is required that the path to the OG-Lapack exports file is
 provided ([build OG-Lapack locally first!](https://github.com/OpenGamma/OG-Lapack/))
 so that the build can link against the LAPACK libraries and include them in the
-built JAR. This is done with the `LAPACK_EXPORT` CMake variable. Invocation of
+built JAR. This is done with the `LAPACK_EXPORT` CMake variable.
+
+In a similar manner to OG-Lapack, it is required that the path to the OG-Izy
+exports file is provided ([build OG-Izy locally first!](https://github.com/OpenGamma/OG-Izy/))
+so that the build can link against the OG-Izy libraries and include them in the
+built JAR. This is done with the `IZY_EXPORT` CMake variable.
+
+Invocation of
 CMake:
 
 ```
-cmake .. -DLAPACK_EXPORT=<path_to_og_lapack>/build/LAPACK_EXPORTS.cmake -DGCC_LIB_FOLDER=<path to gcc RTLs>
+cmake .. -DLAPACK_EXPORT=<path_to_og_lapack>/build/LAPACK_EXPORTS.cmake -DIZY_EXPORT=<path_to_og_izy>/build/IZY_EXPORTS.cmake -DGCC_LIB_FOLDER=<path to gcc RTLs>
 ```
 
 The build process includes the GCC runtime libraries, which are copied from

--- a/cmake/verinfo.py
+++ b/cmake/verinfo.py
@@ -27,20 +27,22 @@ def jarname(version, suffix):
         suffix = '-%s' % suffix
     return 'jars/og-maths-%s-%s%s.jar' % (platform_code(), version, suffix)
 
-def get_subprojects(lapack_verinfo_file):
-    """Returns a list of verinfo data for the OG-Maths subprojects. At the
-    moment, the only OG-Maths subproject is OG-Lapack."""
-    with open(lapack_verinfo_file, 'r') as f:
-        lapack_verinfo = load(f, Loader=Loader)
-    if len(lapack_verinfo['platforms']) != 1 or lapack_verinfo['platforms'][0] != platform_code():
-        raise RuntimeError('OG-Lapack platform mismatch')
-    return [lapack_verinfo]
+def get_subprojects(*args):
+    """Returns a list of verinfo data for the OG-Maths subprojects."""
+    ret = list()
+    for val in args:
+      with open(val, 'r') as f:
+          verinfo = load(f, Loader=Loader)
+      if len(verinfo['platforms']) != 1 or verinfo['platforms'][0] != platform_code():
+          raise RuntimeError('OG subproject platform mismatch')
+      ret.append(verinfo)
+    return ret
 
-def generate_verinfo(project, version, revision, lapack_verinfo_file, buildnumber):
+def generate_verinfo(project, version, revision, lapack_verinfo_file, izy_verinfo_file, buildnumber):
     """Generates a dict containing the verinfo for this build, incorporating
     the values passed in its parameters."""
     artifacts = [ jarname (version, jar) for jar in jars ]
-    subprojects = get_subprojects(lapack_verinfo_file)
+    subprojects = get_subprojects(lapack_verinfo_file , izy_verinfo_file);
     try:
         buildnumber = int(buildnumber)
     except ValueError:
@@ -53,8 +55,8 @@ def generate_verinfo(project, version, revision, lapack_verinfo_file, buildnumbe
     return d
 
 def main():
-    if len(sys.argv) != 5:
-        print "Usage: verinfo.py <output_file> <version> <lapack_verinfo> <build number>"
+    if len(sys.argv) != 6:
+        print "Usage: verinfo.py <output_file> <version> <lapack_verinfo> <izy_verinfo> <build number>"
         return 1
 
     process = subprocess.Popen(['git', 'rev-parse', 'HEAD'], stdout=subprocess.PIPE)
@@ -64,7 +66,7 @@ def main():
         raise RuntimeError('Error getting SHA1 of git HEAD')
 
     with open(sys.argv[1],'w') as f:
-        f.write(dump(generate_verinfo('OG-Maths', sys.argv[2], rev.strip(), sys.argv[3], sys.argv[4]), Dumper=Dumper))
+        f.write(dump(generate_verinfo('OG-Maths', sys.argv[2], rev.strip(), sys.argv[3], sys.argv[4], sys.argv[5],), Dumper=Dumper))
     return 0
 
 if __name__ == '__main__':

--- a/cmake/verinfo.py
+++ b/cmake/verinfo.py
@@ -34,7 +34,7 @@ def get_subprojects(*args):
       with open(val, 'r') as f:
           verinfo = load(f, Loader=Loader)
       if len(verinfo['platforms']) != 1 or verinfo['platforms'][0] != platform_code():
-          raise RuntimeError('OG subproject platform mismatch')
+          raise RuntimeError('OG subproject platform mismatch, for project %s.' % val)
       ret.append(verinfo)
     return ret
 

--- a/include/izy.hh
+++ b/include/izy.hh
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+#ifndef _IZY_HH
+#define _IZY_HH
+
+#include <iostream>
+#include <memory>
+#include "libizy/izy.h"
+#include "numerictypes.hh"
+
+/**
+ * The izy namespace contains templated variants of functions that vary
+ * <real8,complex16> in their signature.
+ */
+namespace izy
+{
+
+template<typename T>
+std::unique_ptr<T[]>
+vx_cos(const int count, T * vector);
+
+}
+
+#endif

--- a/src/java/src/main/config/NativeLibraries.properties
+++ b/src/java/src/main/config/NativeLibraries.properties
@@ -5,33 +5,33 @@
 #
 
 NativeLibraries.mac.initialise = libjinitialise.0.dylib
-NativeLibraries.mac.dbg.libraries = libjshim_dbg.0.dylib, librdag_dbg.0.dylib, liboglapack_dbg.3.dylib,libogblas_dbg.3.dylib,libogxerbla_dbg.3.dylib, libstdc++.6.dylib, libgcc_s.1.dylib, libgfortran.3.dylib, libquadmath.0.dylib
+NativeLibraries.mac.dbg.libraries = libjshim_dbg.0.dylib, librdag_dbg.0.dylib, liboglapack_dbg.3.dylib,libogblas_dbg.3.dylib,libogxerbla_dbg.3.dylib, libizy_dbg.0.dylib, libizyreference_dbg.0.dylib, libstdc++.6.dylib, libgcc_s.1.dylib, libgfortran.3.dylib, libquadmath.0.dylib
 NativeLibraries.mac.dbg.load = libjshim_dbg.0.dylib
-NativeLibraries.mac.std.libraries = libjshim_std.0.dylib, librdag_std.0.dylib, liboglapack_std.3.dylib,libogblas_std.3.dylib,libogxerbla_std.3.dylib, libstdc++.6.dylib, libgcc_s.1.dylib, libgfortran.3.dylib, libquadmath.0.dylib
+NativeLibraries.mac.std.libraries = libjshim_std.0.dylib, librdag_std.0.dylib, libizyreference_std.0.dylib, liboglapack_std.3.dylib,libogblas_std.3.dylib,libogxerbla_std.3.dylib, libizy_std.0.dylib, libstdc++.6.dylib, libgcc_s.1.dylib, libgfortran.3.dylib, libquadmath.0.dylib
 NativeLibraries.mac.std.load = libjshim_std.0.dylib
-NativeLibraries.mac.sse41.libraries = libjshim_sse41.0.dylib, librdag_sse41.0.dylib, liboglapack_sse41.3.dylib,libogblas_sse41.3.dylib,libogxerbla_sse41.3.dylib, libstdc++.6.dylib, libgcc_s.1.dylib, libgfortran.3.dylib, libquadmath.0.dylib
+NativeLibraries.mac.sse41.libraries = libjshim_sse41.0.dylib, librdag_sse41.0.dylib, liboglapack_sse41.3.dylib,libogblas_sse41.3.dylib,libogxerbla_sse41.3.dylib, libizy_sse41.0.dylib, libizyreference_sse41.0.dylib, libstdc++.6.dylib, libgcc_s.1.dylib, libgfortran.3.dylib, libquadmath.0.dylib
 NativeLibraries.mac.sse41.load = libjshim_sse41.0.dylib
-NativeLibraries.mac.avx1.libraries = libjshim_avx1.0.dylib, librdag_avx1.0.dylib, liboglapack_avx1.3.dylib,libogblas_avx1.3.dylib,libogxerbla_avx1.3.dylib, libstdc++.6.dylib, libgcc_s.1.dylib, libgfortran.3.dylib, libquadmath.0.dylib
+NativeLibraries.mac.avx1.libraries = libjshim_avx1.0.dylib, librdag_avx1.0.dylib, liboglapack_avx1.3.dylib,libogblas_avx1.3.dylib,libogxerbla_avx1.3.dylib, libizy_avx1.0.dylib, libizyreference_avx1.0.dylib, libstdc++.6.dylib, libgcc_s.1.dylib, libgfortran.3.dylib, libquadmath.0.dylib
 NativeLibraries.mac.avx1.load = libjshim_avx1.0.dylib
 
 
 NativeLibraries.win.initialise = libjinitialise.dll
-NativeLibraries.win.dbg.libraries = libjshim_dbg.dll, librdag_dbg.dll, liboglapack_dbg.dll,libogblas_dbg.dll,libogxerbla_dbg.dll, libstdc++-6.dll, libgcc_s_seh-1.dll, libgfortran-3.dll, libquadmath-0.dll
+NativeLibraries.win.dbg.libraries = libjshim_dbg.dll, librdag_dbg.dll, liboglapack_dbg.dll,libogblas_dbg.dll,libogxerbla_dbg.dll, libizy_dbg.dll, libizyreference_dbg.dll, libstdc++-6.dll, libgcc_s_seh-1.dll, libgfortran-3.dll, libquadmath-0.dll
 NativeLibraries.win.dbg.load = libjshim_dbg.dll
-NativeLibraries.win.std.libraries = libjshim_std.dll, librdag_std.dll, liboglapack_std.dll,libogblas_std.dll,libogxerbla_std.dll, libstdc++-6.dll, libgcc_s_seh-1.dll, libgfortran-3.dll, libquadmath-0.dll
+NativeLibraries.win.std.libraries = libjshim_std.dll, librdag_std.dll, liboglapack_std.dll,libogblas_std.dll,libogxerbla_std.dll, libizy_std.dll, libizyreference_std.dll, libstdc++-6.dll, libgcc_s_seh-1.dll, libgfortran-3.dll, libquadmath-0.dll
 NativeLibraries.win.std.load = libjshim_std.dll
-NativeLibraries.win.sse41.libraries = libjshim_sse41.dll, librdag_sse41.dll, liboglapack_sse41.dll,libogblas_sse41.dll,libogxerbla_sse41.dll, libstdc++-6.dll, libgcc_s_seh-1.dll, libgfortran-3.dll, libquadmath-0.dll
+NativeLibraries.win.sse41.libraries = libjshim_sse41.dll, librdag_sse41.dll, liboglapack_sse41.dll,libogblas_sse41.dll,libogxerbla_sse41.dll, libizy_sse41.dll, libizyreference_sse41.dll, libstdc++-6.dll, libgcc_s_seh-1.dll, libgfortran-3.dll, libquadmath-0.dll
 NativeLibraries.win.sse41.load = libjshim_sse41.dll
-NativeLibraries.win.avx1.libraries = libjshim_avx1.dll, librdag_avx1.dll, liboglapack_avx1.dll,libogblas_avx1.dll,libogxerbla_avx1.dll, libstdc++-6.dll, libgcc_s_seh-1.dll, libgfortran-3.dll, libquadmath-0.dll
+NativeLibraries.win.avx1.libraries = libjshim_avx1.dll, librdag_avx1.dll, liboglapack_avx1.dll,libogblas_avx1.dll,libogxerbla_avx1.dll, libizy_avx1.dll, libizyreference_avx1.dll, libstdc++-6.dll, libgcc_s_seh-1.dll, libgfortran-3.dll, libquadmath-0.dll
 NativeLibraries.win.avx1.load = libjshim_avx1.dll
 
 
 NativeLibraries.lin.initialise = libjinitialise.so.0
-NativeLibraries.lin.dbg.libraries = libjshim_dbg.so.0, librdag_dbg.so.0,liboglapack_dbg.so.3,libogblas_dbg.so.3,libogxerbla_dbg.so.3, libstdc++.so.6, libgcc_s.so.1, libgfortran.so.3, libquadmath.so.0
+NativeLibraries.lin.dbg.libraries = libjshim_dbg.so.0, librdag_dbg.so.0,liboglapack_dbg.so.3,libogblas_dbg.so.3,libogxerbla_dbg.so.3, libizy_dbg.so.0, libizyreference_dbg.so.0, libstdc++.so.6, libgcc_s.so.1, libgfortran.so.3, libquadmath.so.0
 NativeLibraries.lin.dbg.load = libjshim_dbg.so.0
-NativeLibraries.lin.std.libraries = libjshim_std.so.0, librdag_std.so.0,liboglapack_std.so.3,libogblas_std.so.3,libogxerbla_std.so.3, libstdc++.so.6, libgcc_s.so.1, libgfortran.so.3, libquadmath.so.0
+NativeLibraries.lin.std.libraries = libjshim_std.so.0, librdag_std.so.0,liboglapack_std.so.3,libogblas_std.so.3,libogxerbla_std.so.3, libizy_std.so.0, libizyreference_std.so.0, libstdc++.so.6, libgcc_s.so.1, libgfortran.so.3, libquadmath.so.0
 NativeLibraries.lin.std.load = libjshim_std.so.0
-NativeLibraries.lin.sse41.libraries = libjshim_sse41.so.0, librdag_sse41.so.0,liboglapack_sse41.so.3,libogblas_sse41.so.3,libogxerbla_sse41.so.3, libstdc++.so.6, libgcc_s.so.1, libgfortran.so.3, libquadmath.so.0
+NativeLibraries.lin.sse41.libraries = libjshim_sse41.so.0, librdag_sse41.so.0,liboglapack_sse41.so.3,libogblas_sse41.so.3,libogxerbla_sse41.so.3, libizy_sse41.so.0, libizyreference_sse41.so.0, libstdc++.so.6, libgcc_s.so.1, libgfortran.so.3, libquadmath.so.0
 NativeLibraries.lin.sse41.load = libjshim_sse41.so.0
-NativeLibraries.lin.avx1.libraries = libjshim_avx1.so.0, librdag_avx1.so.0,liboglapack_avx1.so.3,libogblas_avx1.so.3,libogxerbla_avx1.so.3, libstdc++.so.6, libgcc_s.so.1, libgfortran.so.3, libquadmath.so.0
+NativeLibraries.lin.avx1.libraries = libjshim_avx1.so.0, librdag_avx1.so.0,liboglapack_avx1.so.3,libogblas_avx1.so.3,libogxerbla_avx1.so.3, libizy_avx1.so.0, libizyreference_avx1.so.0, libstdc++.so.6, libgcc_s.so.1, libgfortran.so.3, libquadmath.so.0
 NativeLibraries.lin.avx1.load = libjshim_avx1.so.0

--- a/src/librdag/CMakeLists.txt
+++ b/src/librdag/CMakeLists.txt
@@ -4,7 +4,9 @@
 # Please see distribution for license.
 #
 
-include_directories (${NATIVE_HEADER_DIR} ${CMAKE_SOURCE_DIR}/include ${JNIDIR} ${JNI_INCLUDE_DIRS} ${BIN_INCLUDE_DIR})
+include(${IZY_BUILDINFO})
+
+include_directories (${NATIVE_HEADER_DIR} ${CMAKE_SOURCE_DIR}/include ${JNIDIR} ${JNI_INCLUDE_DIRS} ${BIN_INCLUDE_DIR} ${IZY_INCLUDE_DIR})
 SET(CMAKE_FC_FLAGS  "${CMAKE_FC_FLAGS} ${GCC_COVERAGE_COMPILE_FLAGS} -cpp" )
 SET(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -Wl,--no-undefined")
 SET(CMAKE_CC_FLAGS  "${CMAKE_CC_FLAGS} -Wl,--no-undefined -frepo")
@@ -20,6 +22,7 @@ set(RDAG_SOURCES convertto.cc
                  execution.cc
                  expressionbase.cc
                  iss.cc
+                 izy.cc
                  lapack.cc
                  mem.cc
                  numericbase.cc
@@ -45,7 +48,7 @@ add_multitarget_library(rdag
                         SOVERSION ${og_maths_VERSION_MAJOR}
                         SOURCES ${RDAG_SOURCES}
                         DEPENDS runners_cc dispatch_cc expression_cc numeric_cc exprenum_hh
-                        LINK_MULTILIBRARIES oglapack ogblas ogxerbla
+                        LINK_MULTILIBRARIES oglapack ogblas ogxerbla izy izyreference
                         TARGETS ${TARGET_TYPES})
 
 jar_native_multitarget_library(rdag TARGETS ${TARGET_TYPES})
@@ -56,10 +59,16 @@ jar_native_multitarget_library(ogblas TARGETS ${TARGET_TYPES})
 
 jar_native_multitarget_library(ogxerbla TARGETS ${TARGET_TYPES})
 
+jar_native_multitarget_library(izy TARGETS ${TARGET_TYPES})
+
+jar_native_multitarget_library(izyreference TARGETS ${TARGET_TYPES})
+
 if(WIN32)
   windows_import_external_native_multitarget_library(oglapack TARGETS ${TARGET_TYPES})
   windows_import_external_native_multitarget_library(ogblas TARGETS ${TARGET_TYPES})
   windows_import_external_native_multitarget_library(ogxerbla TARGETS ${TARGET_TYPES})
+  windows_import_external_native_multitarget_library(izy TARGETS ${TARGET_TYPES})
+  windows_import_external_native_multitarget_library(izyreference TARGETS ${TARGET_TYPES})
 endif()
 
 add_subdirectory(test)

--- a/src/librdag/izy.cc
+++ b/src/librdag/izy.cc
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+#include "izy.hh"
+#include "exceptions.hh"
+
+#include <memory>
+
+using namespace librdag;
+
+namespace izy {
+
+namespace detail
+{
+  const int zero = 0;
+}
+
+template<>
+std::unique_ptr<real8[]>
+vx_cos(const int count, real8 * vector)
+{
+  std::unique_ptr<real8[]> ret (new real8[count]);
+  vd_cos(&count, vector, &detail::zero, ret.get(), &detail::zero);
+  return ret;
+}
+
+template<>
+std::unique_ptr<complex16[]>
+vx_cos(const int count, complex16 * vector)
+{
+  std::unique_ptr<complex16[]> ret (new complex16[count]);
+  vz_cos(&count, vector, &detail::zero, ret.get(), &detail::zero);
+  return ret;
+}
+
+}

--- a/src/librdag/test/CMakeLists.txt
+++ b/src/librdag/test/CMakeLists.txt
@@ -17,6 +17,7 @@ set(TESTS
   check_execution
   check_expressions
   check_iss
+  check_izy
   check_lapack
   check_mem
   check_numerictypes

--- a/src/librdag/test/check_izy.cc
+++ b/src/librdag/test/check_izy.cc
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+
+#include "gtest/gtest.h"
+#include "warningmacros.h"
+#include "equals.hh"
+#include "izy.hh"
+#include "exceptions.hh"
+#include <memory>
+
+using namespace std;
+using namespace librdag;
+using namespace izy;
+
+// Check successful templating of vx_cos.
+TEST(IZYTest_vx_cos, vd_cos) {
+
+real8 vector[] = {3.1415926535897931,-1.5707963267948966,1.0,-1.0,0.0};
+const int count = 5;
+std::unique_ptr<real8[]> answer = vx_cos(count, vector);
+real8 expected[] = {-1.0,0.0000000000000001,0.5403023058681398,0.5403023058681398,1.0};
+EXPECT_TRUE(ArrayFuzzyEquals(expected,answer.get(),count));
+
+}
+
+TEST(IZYTest_vx_cos, vz_cos) {
+
+complex16 vector[] = {{2.3561944901923448,1.5707963267948966},{1.0,1.0},{3.1415926535897931,-1.0},{0.0,1.0}};
+const int count = 4;
+std::unique_ptr<complex16[]> answer = vx_cos(count, vector);
+complex16 expected[] = {{-1.7742571174664565,-1.6272640593586463},{0.8337300251311491,-0.9888977057628651},{-1.5430806348152437,0.0000000000000001},{1.5430806348152437,0.0}};
+EXPECT_TRUE(ArrayFuzzyEquals(expected,answer.get(),count));
+
+}


### PR DESCRIPTION
This PR is to be read in conjunction with https://github.com/OpenGamma/OG-Izy/pull/4: 
- It adds in the ability to link against OG-Izy.
- It adds an izy namespace and then demonstrates the pattern needed to add a single function binding from izy to the namespace, and then tests it.
- It adds the ability to accept multiple subprojects in `verinfo.py`. It then adds the necessary wiring to include the buildinfo yaml from `izy` into the OG-Maths master yaml.
- It updates the properties file to include the izy libraries in the jar.

Note: I'm not convinced of the API in the `izy` namespace as yet. I've simply added in the most obvious thing just to test that the code is wired up correctly and gives the correct numerical results. The `izy` namespace and functionality is subject to both autogeneration and multiple interfaces. IIRC the original OG-Maths had multiple interfaces to this library too, I expect the same will be required here.
