### PR TITLE
[MAT-444] remove dynamic libstdc++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,11 +101,12 @@ set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules ${CMAKE_MODULE_PATH})
 # Use C99 and C++11, other flags for preventing common errors. Also add thread libs.
 set(CMAKE_C_FLAGS "-std=c99 -Wall -Werror -Wextra -pedantic ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_C_FLAGS}")
 set(CMAKE_CXX_FLAGS "-std=c++11 -Wall -Werror -Wextra -pedantic ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_CXX_FLAGS}")
+# we want static libstdc++ everywhere!
+set(CMAKE_SHARED_LINKER_FLAGS "-static-libstdc++")
 
 # On Linux, add -rdynamic for stack traces
 if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-  set(CMAKE_C_FLAGS"${CMAKE_C_FLAGS} -rdynamic")
-  set(CMAKE_CXX_FLAGS"${CMAKE_CXX_FLAGS} -rdynamic")
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -rdynamic")
 endif()
 
 # Use the native assembler on Apple in order to be able to generate AVX instructions.

--- a/cmake/syslibs.py
+++ b/cmake/syslibs.py
@@ -13,9 +13,9 @@ import argparse, os, shutil, subprocess, sys, re
 from buildutils import platform_code
 
 libs = {}
-libs['lnx'] = [ 'libstdc++.so.6', 'libgcc_s.so.1', 'libgfortran.so.3', 'libquadmath.so.0' ]
-libs['osx'] = [ 'libstdc++.6.dylib', 'libgcc_s.1.dylib', 'libgfortran.3.dylib', 'libquadmath.0.dylib' ]
-libs['win'] = [ 'libstdc++-6.dll', 'libgcc_s_seh-1.dll', 'libgfortran-3.dll', 'libquadmath-0.dll' ]
+libs['lnx'] = [ 'libgcc_s.so.1', 'libgfortran.so.3', 'libquadmath.so.0' ]
+libs['osx'] = [ 'libgcc_s.1.dylib', 'libgfortran.3.dylib', 'libquadmath.0.dylib' ]
+libs['win'] = [ 'libgcc_s_seh-1.dll', 'libgfortran-3.dll', 'libquadmath-0.dll' ]
 
 default_gcc_lib_folder = {}
 default_gcc_lib_folder['lnx'] = '/opt/gcc/4.8.2/lib64'

--- a/src/java/src/main/config/NativeLibraries.properties
+++ b/src/java/src/main/config/NativeLibraries.properties
@@ -5,33 +5,33 @@
 #
 
 NativeLibraries.mac.initialise = libjinitialise.0.dylib
-NativeLibraries.mac.dbg.libraries = libjshim_dbg.0.dylib, librdag_dbg.0.dylib, liboglapack_dbg.3.dylib,libogblas_dbg.3.dylib,libogxerbla_dbg.3.dylib, libizy_dbg.0.dylib, libizyreference_dbg.0.dylib, libstdc++.6.dylib, libgcc_s.1.dylib, libgfortran.3.dylib, libquadmath.0.dylib
+NativeLibraries.mac.dbg.libraries = libjshim_dbg.0.dylib, librdag_dbg.0.dylib, liboglapack_dbg.3.dylib,libogblas_dbg.3.dylib,libogxerbla_dbg.3.dylib, libizy_dbg.0.dylib, libizyreference_dbg.0.dylib, libgcc_s.1.dylib, libgfortran.3.dylib, libquadmath.0.dylib
 NativeLibraries.mac.dbg.load = libjshim_dbg.0.dylib
-NativeLibraries.mac.std.libraries = libjshim_std.0.dylib, librdag_std.0.dylib, libizyreference_std.0.dylib, liboglapack_std.3.dylib,libogblas_std.3.dylib,libogxerbla_std.3.dylib, libizy_std.0.dylib, libstdc++.6.dylib, libgcc_s.1.dylib, libgfortran.3.dylib, libquadmath.0.dylib
+NativeLibraries.mac.std.libraries = libjshim_std.0.dylib, librdag_std.0.dylib, libizyreference_std.0.dylib, liboglapack_std.3.dylib,libogblas_std.3.dylib,libogxerbla_std.3.dylib, libizy_std.0.dylib, libgcc_s.1.dylib, libgfortran.3.dylib, libquadmath.0.dylib
 NativeLibraries.mac.std.load = libjshim_std.0.dylib
-NativeLibraries.mac.sse41.libraries = libjshim_sse41.0.dylib, librdag_sse41.0.dylib, liboglapack_sse41.3.dylib,libogblas_sse41.3.dylib,libogxerbla_sse41.3.dylib, libizy_sse41.0.dylib, libizyreference_sse41.0.dylib, libstdc++.6.dylib, libgcc_s.1.dylib, libgfortran.3.dylib, libquadmath.0.dylib
+NativeLibraries.mac.sse41.libraries = libjshim_sse41.0.dylib, librdag_sse41.0.dylib, liboglapack_sse41.3.dylib,libogblas_sse41.3.dylib,libogxerbla_sse41.3.dylib, libizy_sse41.0.dylib, libizyreference_sse41.0.dylib, libgcc_s.1.dylib, libgfortran.3.dylib, libquadmath.0.dylib
 NativeLibraries.mac.sse41.load = libjshim_sse41.0.dylib
-NativeLibraries.mac.avx1.libraries = libjshim_avx1.0.dylib, librdag_avx1.0.dylib, liboglapack_avx1.3.dylib,libogblas_avx1.3.dylib,libogxerbla_avx1.3.dylib, libizy_avx1.0.dylib, libizyreference_avx1.0.dylib, libstdc++.6.dylib, libgcc_s.1.dylib, libgfortran.3.dylib, libquadmath.0.dylib
+NativeLibraries.mac.avx1.libraries = libjshim_avx1.0.dylib, librdag_avx1.0.dylib, liboglapack_avx1.3.dylib,libogblas_avx1.3.dylib,libogxerbla_avx1.3.dylib, libizy_avx1.0.dylib, libizyreference_avx1.0.dylib, libgcc_s.1.dylib, libgfortran.3.dylib, libquadmath.0.dylib
 NativeLibraries.mac.avx1.load = libjshim_avx1.0.dylib
 
 
 NativeLibraries.win.initialise = libjinitialise.dll
-NativeLibraries.win.dbg.libraries = libjshim_dbg.dll, librdag_dbg.dll, liboglapack_dbg.dll,libogblas_dbg.dll,libogxerbla_dbg.dll, libizy_dbg.dll, libizyreference_dbg.dll, libstdc++-6.dll, libgcc_s_seh-1.dll, libgfortran-3.dll, libquadmath-0.dll
+NativeLibraries.win.dbg.libraries = libjshim_dbg.dll, librdag_dbg.dll, liboglapack_dbg.dll,libogblas_dbg.dll,libogxerbla_dbg.dll, libizy_dbg.dll, libizyreference_dbg.dll, libgcc_s_seh-1.dll, libgfortran-3.dll, libquadmath-0.dll
 NativeLibraries.win.dbg.load = libjshim_dbg.dll
-NativeLibraries.win.std.libraries = libjshim_std.dll, librdag_std.dll, liboglapack_std.dll,libogblas_std.dll,libogxerbla_std.dll, libizy_std.dll, libizyreference_std.dll, libstdc++-6.dll, libgcc_s_seh-1.dll, libgfortran-3.dll, libquadmath-0.dll
+NativeLibraries.win.std.libraries = libjshim_std.dll, librdag_std.dll, liboglapack_std.dll,libogblas_std.dll,libogxerbla_std.dll, libizy_std.dll, libizyreference_std.dll, libgcc_s_seh-1.dll, libgfortran-3.dll, libquadmath-0.dll
 NativeLibraries.win.std.load = libjshim_std.dll
-NativeLibraries.win.sse41.libraries = libjshim_sse41.dll, librdag_sse41.dll, liboglapack_sse41.dll,libogblas_sse41.dll,libogxerbla_sse41.dll, libizy_sse41.dll, libizyreference_sse41.dll, libstdc++-6.dll, libgcc_s_seh-1.dll, libgfortran-3.dll, libquadmath-0.dll
+NativeLibraries.win.sse41.libraries = libjshim_sse41.dll, librdag_sse41.dll, liboglapack_sse41.dll,libogblas_sse41.dll,libogxerbla_sse41.dll, libizy_sse41.dll, libizyreference_sse41.dll, libgcc_s_seh-1.dll, libgfortran-3.dll, libquadmath-0.dll
 NativeLibraries.win.sse41.load = libjshim_sse41.dll
-NativeLibraries.win.avx1.libraries = libjshim_avx1.dll, librdag_avx1.dll, liboglapack_avx1.dll,libogblas_avx1.dll,libogxerbla_avx1.dll, libizy_avx1.dll, libizyreference_avx1.dll, libstdc++-6.dll, libgcc_s_seh-1.dll, libgfortran-3.dll, libquadmath-0.dll
+NativeLibraries.win.avx1.libraries = libjshim_avx1.dll, librdag_avx1.dll, liboglapack_avx1.dll,libogblas_avx1.dll,libogxerbla_avx1.dll, libizy_avx1.dll, libizyreference_avx1.dll, libgcc_s_seh-1.dll, libgfortran-3.dll, libquadmath-0.dll
 NativeLibraries.win.avx1.load = libjshim_avx1.dll
 
 
 NativeLibraries.lin.initialise = libjinitialise.so.0
-NativeLibraries.lin.dbg.libraries = libjshim_dbg.so.0, librdag_dbg.so.0,liboglapack_dbg.so.3,libogblas_dbg.so.3,libogxerbla_dbg.so.3, libizy_dbg.so.0, libizyreference_dbg.so.0, libstdc++.so.6, libgcc_s.so.1, libgfortran.so.3, libquadmath.so.0
+NativeLibraries.lin.dbg.libraries = libjshim_dbg.so.0, librdag_dbg.so.0,liboglapack_dbg.so.3,libogblas_dbg.so.3,libogxerbla_dbg.so.3, libizy_dbg.so.0, libizyreference_dbg.so.0, libgcc_s.so.1, libgfortran.so.3, libquadmath.so.0
 NativeLibraries.lin.dbg.load = libjshim_dbg.so.0
-NativeLibraries.lin.std.libraries = libjshim_std.so.0, librdag_std.so.0,liboglapack_std.so.3,libogblas_std.so.3,libogxerbla_std.so.3, libizy_std.so.0, libizyreference_std.so.0, libstdc++.so.6, libgcc_s.so.1, libgfortran.so.3, libquadmath.so.0
+NativeLibraries.lin.std.libraries = libjshim_std.so.0, librdag_std.so.0,liboglapack_std.so.3,libogblas_std.so.3,libogxerbla_std.so.3, libizy_std.so.0, libizyreference_std.so.0, libgcc_s.so.1, libgfortran.so.3, libquadmath.so.0
 NativeLibraries.lin.std.load = libjshim_std.so.0
-NativeLibraries.lin.sse41.libraries = libjshim_sse41.so.0, librdag_sse41.so.0,liboglapack_sse41.so.3,libogblas_sse41.so.3,libogxerbla_sse41.so.3, libizy_sse41.so.0, libizyreference_sse41.so.0, libstdc++.so.6, libgcc_s.so.1, libgfortran.so.3, libquadmath.so.0
+NativeLibraries.lin.sse41.libraries = libjshim_sse41.so.0, librdag_sse41.so.0,liboglapack_sse41.so.3,libogblas_sse41.so.3,libogxerbla_sse41.so.3, libizy_sse41.so.0, libizyreference_sse41.so.0, libgcc_s.so.1, libgfortran.so.3, libquadmath.so.0
 NativeLibraries.lin.sse41.load = libjshim_sse41.so.0
-NativeLibraries.lin.avx1.libraries = libjshim_avx1.so.0, librdag_avx1.so.0,liboglapack_avx1.so.3,libogblas_avx1.so.3,libogxerbla_avx1.so.3, libizy_avx1.so.0, libizyreference_avx1.so.0, libstdc++.so.6, libgcc_s.so.1, libgfortran.so.3, libquadmath.so.0
+NativeLibraries.lin.avx1.libraries = libjshim_avx1.so.0, librdag_avx1.so.0,liboglapack_avx1.so.3,libogblas_avx1.so.3,libogxerbla_avx1.so.3, libizy_avx1.so.0, libizyreference_avx1.so.0, libgcc_s.so.1, libgfortran.so.3, libquadmath.so.0
 NativeLibraries.lin.avx1.load = libjshim_avx1.so.0


### PR DESCRIPTION
In this PR:
The dynamic linking of `libstdc++` is swapped for static linking.

This is done, in the parlance of GCC, to "freeze" the version of `libstc++` against which the build links. This is so that C++ symbols are guaranteed to resolve correctly regardless of other `libstdc++` versions potentially loaded, which under dynamic linking circumstances may prevent the loading of our "correct" ones.

In reviewing, please, along with anything else you see fit, confirm that the built article:
- Does not dynamically link against `libstdc++`.
- Does run, with no modules loaded, on the HPC dev box which altered us to this issue in the first place.

Coverage:
No change as diff is in the build system/bootstrapping config only. 
