### PR TITLE
[Mat-462] Add checking capability for inputs to LAPACK 

### DIFF
--- a/include/exceptions.hh
+++ b/include/exceptions.hh
@@ -112,6 +112,22 @@ class rdag_error: public ::dogma_exceptions::dogma_error
   using ::dogma_exceptions::dogma_error::dogma_error;
 };
 
+/**
+ * To be thrown when an unrecoverable (but not fatal) error has occurred.
+ */
+class rdag_unrecoverable_error: public rdag_error
+{
+  using rdag_error::rdag_error;
+};
+
+/**
+ * To be thrown when an recoverable error has occurred.
+ */
+class rdag_recoverable_error: public rdag_error
+{
+  using rdag_error::rdag_error;
+};
+
 } // namespace librdag
 
 namespace convert {

--- a/include/exceptions.hh
+++ b/include/exceptions.hh
@@ -121,7 +121,7 @@ class rdag_unrecoverable_error: public rdag_error
 };
 
 /**
- * To be thrown when an recoverable error has occurred.
+ * To be thrown when a recoverable error has occurred.
  */
 class rdag_recoverable_error: public rdag_error
 {

--- a/include/iss.hh
+++ b/include/iss.hh
@@ -11,12 +11,51 @@
 
 namespace librdag {
 
-bool isScalar(const OGTerminal::Ptr&);
-bool isMatrix(const OGTerminal::Ptr&);
-bool isVector(const OGTerminal::Ptr&);
-bool isReal(const OGTerminal::Ptr&);
-bool isComplex(const OGTerminal::Ptr&);
+/**
+ * Returns true if an OGTerminal is a scalar type.
+ * @param term an OGTerminal to test.
+ * @return true if \a term is a scalar type, false else.
+ */
+bool isScalar(const OGTerminal::Ptr& term);
 
-} // end namespace librdage
+/**
+ * Returns true if an OGTerminal is a matrix type.
+ * @param term an OGTerminal to test.
+ * @return true if \a term is a matrix type, false else.
+ */
+bool isMatrix(const OGTerminal::Ptr& term);
+
+/**
+ * Returns true if an OGTerminal has vector dimensions (i.e. single row or single column).
+ * @param term an OGTerminal to test.
+ * @return true if \a term has vector dimensions, false else.
+ */
+bool isVector(const OGTerminal::Ptr& term);
+
+/**
+ * Returns true if an OGTerminal is a real space OGTerminal type.
+ * @param term an OGTerminal to test.
+ * @return true if \a term is a real space OGTerminal type, false else.
+ */
+bool isReal(const OGTerminal::Ptr& term);
+
+/**
+ * Returns true if an OGTerminal is a complex space OGTerminal type.
+ * @param term an OGTerminal to test.
+ * @return true if \a term is a complex space OGTerminal type, false else.
+ */
+bool isComplex(const OGTerminal::Ptr& term);
+
+/**
+ * Returns true if the data is finite (i.e. not NaN and not +/-Inf).
+ * @param T the type of the data, real8 and complex16 are valid.
+ * @param data the data to test.
+ * @param n the number of items in \a data.
+ * @return true if the data is finite else false.
+ */
+template<typename T>
+bool isfinite(T * data, int4 n);
+
+} // end namespace librdag
 
 #endif // _ISS_HH

--- a/include/lapack.hh
+++ b/include/lapack.hh
@@ -23,7 +23,14 @@ namespace lapack
  */
 enum class OnInputCheck
 {
+  /**
+   * Indicates that the relevant input data should be checked to ensure it is finite
+   * as defined by std::isfinite();
+   */
   isfinite,
+  /**
+   * Indicates that the relevant input data should not be checked.
+   */
   nothing
 };
 
@@ -68,18 +75,22 @@ template<typename T> void xgels(char * TRANS, int4 * M, int4 * N, int4 * NRHS, T
 template<typename T> void xgeqrf(int4 * M, int4 * N, T * A, int4 * LDA, T * TAU, T * WORK, int4 * LWORK, int4 *INFO);
 template<typename T> void xxxgqr(int4 * M, int4 * N, int4 * K, T * A, int4 * LDA, T * TAU, T * WORK, int4 * LWORK, int4 * INFO);
 
-template<typename T, OnInputCheck Check> void checkData(T * data, int4 n);
+/**
+ * Template for checking data local to lapack calls for NaN/Inf on input.
+ * @tparam T data type, real8/complex16 are accepted.
+ * @tparam CHECK what to check.
+ * @param data the data to check.
+ * @param n the count of \a data.
+ */
+template<typename T, OnInputCheck CHECK> void checkData(T * data, int4 n);
 
-// Partial template specialisation (PTS) buffer, bounce function templates via structs
-// so that PTS can be used.
+/**
+ * Partial template specialisation (PTS) buffer for routines that need input
+ * checking and need partial specialisation due to differences in their Fortran prototypes.
+ */
 template<typename T, OnInputCheck CHECK> struct PTSBuffer
 {
   static void xgesvd(char * JOBU, char * JOBVT, int4 * M, int4 * N, T * A, int4 * LDA, real8 * S, T * U, int4 * LDU, T * VT, int4 * LDVT, int4 * INFO);
-};
-
-template<typename T, OnInputCheck CHECK> struct TemplateBuffer
-{
-  static void xgetrf(int4 * M, int4 * N, T * A, int4 * LDA, int4 * IPIV, int4 *INFO);
 };
 
 }
@@ -242,6 +253,7 @@ template<typename T, OnInputCheck CHECK> void xgesvd(char * JOBU, char * JOBVT, 
 /**
  * xgetrf() computes the LU decomposition using parital pivoting
  * @tparam T the type of the underlying data real8 and complex16 are accepted
+ * @tparam CHECK what to assert the input complies with on entry to this routine
  * @param M as LAPACK dgetrf M
  * @param N as LAPACK dgetrf N
  * @param A data type specific with intent as LAPACK dgetrf A

--- a/include/lapack.hh
+++ b/include/lapack.hh
@@ -18,6 +18,16 @@
 namespace lapack
 {
 
+/**
+ * Enumeration of checks available for input data.
+ */
+enum class OnInputCheck
+{
+  isfinite,
+  nothing
+};
+
+
 namespace detail
 {
 // constants
@@ -57,6 +67,15 @@ template<typename T> void xgetrs(char * TRANS, int4 * N, int4 * NRHS, T * A, int
 template<typename T> void xgels(char * TRANS, int4 * M, int4 * N, int4 * NRHS, T * A, int4 * LDA, T * B, int4 * LDB, T * WORK, int4 * LWORK, int4 * INFO );
 template<typename T> void xgeqrf(int4 * M, int4 * N, T * A, int4 * LDA, T * TAU, T * WORK, int4 * LWORK, int4 *INFO);
 template<typename T> void xxxgqr(int4 * M, int4 * N, int4 * K, T * A, int4 * LDA, T * TAU, T * WORK, int4 * LWORK, int4 * INFO);
+
+template<typename T, OnInputCheck Check> void checkData(T * data, int4 n);
+
+// Partial template specialisation (PTS) buffer, bounce function templates via structs
+// so that PTS can be used
+template<typename T, OnInputCheck CHECK> struct PTSBuffer
+{
+  static void xgesvd(char * JOBU, char * JOBVT, int4 * M, int4 * N, T * A, int4 * LDA, real8 * S, T * U, int4 * LDU, T * VT, int4 * LDVT, int4 * INFO);
+};
 
 }
 
@@ -206,7 +225,7 @@ template<typename T> real8 xnrm2(int4 * N, T * X, int4 * INCX);
  * @param INFO as LAPACK dgesvd INFO
  * @throws rdag_error on illegal input OR non-convergence
  */
-template<typename T> void xgesvd(char * JOBU, char * JOBVT, int4 * M, int4 * N, T * A, int4 * LDA, real8 * S, T * U, int4 * LDU, T * VT, int4 * LDVT, int4 * INFO);
+template<typename T, OnInputCheck CHECK> void xgesvd(char * JOBU, char * JOBVT, int4 * M, int4 * N, T * A, int4 * LDA, real8 * S, T * U, int4 * LDU, T * VT, int4 * LDVT, int4 * INFO);
 
 /**
  * xgetrf() computes the LU decomposition using parital pivoting

--- a/include/lapack.hh
+++ b/include/lapack.hh
@@ -145,6 +145,7 @@ extern complex16 * czero;
 
 /**
  * xscal generalised vector scaling
+ * @tparam T the type of the underlying data real8 and complex16 are accepted
  * @param N as BLAS dscal N
  * @param DA data type specific with intent as BLAS dscal DA
  * @param DX data type specific with intent as BLAS dscal DX
@@ -154,6 +155,7 @@ template<typename T> void xscal(int4 * N, T * DA, T * DX, int4 * INCX);
 
 /**
  * xswap generalised vector interchange
+ * @tparam T the type of the underlying data real8 and complex16 are accepted
  * @param N as BLAS dswap N
  * @param DX data type specific with intent as BLAS dswap DX
  * @param INCX as BLAS dswap INCX
@@ -166,6 +168,7 @@ template<typename T>void xswap(int4 * N, T * DX, int4 * INCX, T * DY, int4 * INC
 /**
  * xgemv generalised matrix vector multiplication.
  * @param TRANS as BLAS dgemv TRANS
+ * @tparam T the type of the underlying data real8 and complex16 are accepted
  * @param M as BLAS dgemv M
  * @param N as BLAS dgemv N
  * @param ALPHA data type specific with intent as BLAS dgemv ALPHA
@@ -181,6 +184,7 @@ template<typename T> void xgemv(char * TRANS, int4 * M, int4 * N, T * ALPHA, T *
 
 /**
  * xgemm generalised matrix matrix multiplication.
+ * @tparam T the type of the underlying data real8 and complex16 are accepted
  * @param TRANSA as BLAS dgemm TRANSA
  * @param TRANSB as BLAS dgemm TRANSB
  * @param M as BLAS dgemm M
@@ -200,6 +204,7 @@ template<typename T> void xgemm(char * TRANSA, char * TRANSB, int4 * M, int4 * N
 
 /**
  * xnrm2 generalised 2-norm implementation
+ * @tparam T the type of the underlying data real8 and complex16 are accepted
  * @param N as BLAS dnrm2 N
  * @param X data type specific with intent as BLAS dnrm2 X
  * @param INCX as BLAS dnrm2 INCX
@@ -211,6 +216,8 @@ template<typename T> real8 xnrm2(int4 * N, T * X, int4 * INCX);
 
 /**
  * xgesvd is a generalised svd implementation that takes care of workspaces
+ * @tparam T the type of the underlying data real8 and complex16 are accepted
+ * @tparam CHECK what to assert the input complies with on entry to this routine
  * @param JOBU as LAPACK dgesvd JOBU
  * @param JOBVT as LAPACK dgesvd JOBVT
  * @param M as LAPACK dgesvd M
@@ -229,6 +236,7 @@ template<typename T, OnInputCheck CHECK> void xgesvd(char * JOBU, char * JOBVT, 
 
 /**
  * xgetrf() computes the LU decomposition using parital pivoting
+ * @tparam T the type of the underlying data real8 and complex16 are accepted
  * @param M as LAPACK dgetrf M
  * @param N as LAPACK dgetrf N
  * @param A data type specific with intent as LAPACK dgetrf A
@@ -240,6 +248,7 @@ template<typename T> void xgetrf(int4 * M, int4 * N, T * A, int4 * LDA, int4 * I
 
 /**
  * xgetri() computes the inverse of a matrix via LU decomposition
+ * @tparam T the type of the underlying data real8 and complex16 are accepted
  * @param N as LAPACK dgetri N
  * @param A  data type specific with intent as LAPACK dgetri A
  * @param LDA as LAPACK dgetri LDA
@@ -250,6 +259,7 @@ template<typename T> void xgetri(int4 * N, T * A, int4 * LDA, int4 * IPIV, int4 
 
 /**
  * xtrcon general triangular matrix condition number estimate
+ * @tparam T the type of the underlying data real8 and complex16 are accepted
  * @param NORM as LAPACK dtrcon NORM
  * @param UPLO as LAPACK dtrcon UPLO
  * @param DIAG as LAPACK dtrcon DIAG
@@ -265,6 +275,7 @@ template<typename T> void xtrcon(char * NORM, char * UPLO, char * DIAG, int4 * N
 
 /**
  * Solves a triangular system of the form : A * X = B  or  A**T * X = B
+ * @tparam T the type of the underlying data real8 and complex16 are accepted
  * @param UPLO as LAPACK dtrtrs UPLO
  * @param TRANS as LAPACK dtrtrs TRANS
  * @param DIAG as LAPACK dtrtrs DIAG
@@ -281,6 +292,7 @@ template<typename T> void xtrtrs(char * UPLO, char * TRANS, char * DIAG, int4 * 
 
 /**
  * xpotrf() computes the Cholesky factorisation of a Hermitian positive definite matrix A.
+ * @tparam T the type of the underlying data real8 and complex16 are accepted
  * @param UPLO as LAPACK dpotrf UPLO
  * @param N as LAPACK dpotrf N
  * @param A data type specific with intent as LAPACK dpotrf A
@@ -293,6 +305,7 @@ template<typename T> void  xpotrf(char * UPLO, int4 * N, T * A, int4 * LDA, int4
 
 /**
  * xpocon() computes the reciprocal condition estimate (in the 1-norm) of a s.p.d. matrix using the factorization computed by xpotrf().
+ * @tparam T the type of the underlying data real8 and complex16 are accepted
  * @param UPLO as LAPACK dpocon UPLO
  * @param N as LAPACK dpocon N
  * @param A data type specific with intent as LAPACK dpocon A
@@ -305,6 +318,7 @@ template<typename T> void xpocon(char * UPLO, int4 * N, T * A, int4 * LDA, real8
 
 /**
  * xlansy() computes condition numbers for a symmetric matrix.
+ * @tparam T the type of the underlying data real8 and complex16 are accepted
  * @param NORM as LAPACK dlansy NORM
  * @param UPLO as LAPACK dlansy UPLO
  * @param N as LAPACK dlansy N
@@ -327,6 +341,7 @@ real8 zlanhe(char * NORM, char * UPLO, int4 * N, complex16 * A, int4 * LDA);
 
 /**
  * xpotrs() solves s.p.d. systems via Cholesky decomposition as computed by xpotrf().
+ * @tparam T the type of the underlying data real8 and complex16 are accepted
  * @param UPLO as LAPACK dpotrs UPLO.
  * @param N as LAPACK dpotrs N.
  * @param NRHS as LAPACK dpotrs NRHS.
@@ -340,6 +355,7 @@ template<typename T> void xpotrs(char * UPLO, int4 * N, int4 * NRHS, T * A, int4
 
 /**
  * xlange() computes matrix norms (one, Inf, Frobenius)
+ * @tparam T the type of the underlying data real8 and complex16 are accepted
  * @param NORM as LAPACK dlange NORM.
  * @param M as LAPACK dlange M.
  * @param N as LAPACK dlange N.
@@ -351,6 +367,7 @@ template<typename T> real8 xlange(char * NORM, int4 * M, int4 * N, T * A, int4 *
 /**
  * xgecon() computes reciprocal condition numbers calculated from a LU factorisation as
  * computed by xgetrf().
+ * @tparam T the type of the underlying data real8 and complex16 are accepted
  * @param NORM as LAPACK dgecon NORM.
  * @param N as LAPACK dgecon N.
  * @param A data type specific with intent as LAPACK dgecon A.
@@ -363,6 +380,7 @@ template<typename T> void xgecon(char * NORM, int4 * N, T * A, int4 * LDA, real8
 
 /**
  * xgetrs() solves linear systems using a LU factorisation computed by xgetrf().
+ * @tparam T the type of the underlying data real8 and complex16 are accepted
  * @param TRANS as LAPACK xgetrs TRANS.
  * @param N as LAPACK xgetrs N.
  * @param NRHS as LAPACK xgetrs NRHS.
@@ -377,6 +395,7 @@ template<typename T>void xgetrs(char * TRANS, int4 * N, int4 * NRHS, T * A, int4
 
 /**
  * xgels() solves {over,under}determined linear systems via QR decomposition.
+ * @tparam T the type of the underlying data real8 and complex16 are accepted
  * @param TRANS as LAPACK dgels TRANS.
  * @param M as LAPACK dgels M.
  * @param N as LAPACK dgels N.
@@ -391,6 +410,7 @@ template<typename T> void xgels(char * TRANS, int4 * M, int4 * N, int4 * NRHS, T
 
 /**
  * xgelsd() solves {over,under}determined linear systems via SV decomposition.
+ * @tparam T the type of the underlying data real8 and complex16 are accepted
  * @param M as LAPACK dgelsd M.
  * @param N as LAPACK dgelsd N.
  * @param NRHS as LAPACK dgelsd NRHS.
@@ -407,6 +427,7 @@ template<typename T> void xgelsd(int4 * M, int4 * N, int4 * NRHS, T * A, int4 * 
 
 /**
  * xgeev() computes eigen{values,vectors}.
+ * @tparam T the type of the underlying data real8 and complex16 are accepted
  * @param JOBVL as LAPACK dgeev JOBVL.
  * @param JOBVR as LAPACK dgeev JOBVR.
  * @param N as LAPACK dgeev N.
@@ -424,6 +445,7 @@ template<typename T> void xgeev(char * JOBVL, char * JOBVR, int4 * N, T * A, int
 
 /**
  * xgeqrf() computes the QR decomposition.
+ * @tparam T the type of the underlying data real8 and complex16 are accepted
  * @param M as LAPACK degqrf M.
  * @param N as LAPACK degqrf N.
  * @param A data type specific with intent as LAPACK degqrf A.
@@ -436,6 +458,7 @@ template<typename T> void xgeqrf(int4 * M, int4 * N, T * A, int4 * LDA, T * TAU,
 
 /**
  * xxxgqr() computes the orthogonal Q matrix from elementary reflectors as returned by xgeqrf()
+ * @tparam T the type of the underlying data real8 and complex16 are accepted
  * @param M as LAPACK dorgqr M.
  * @param N as LAPACK dorgqr N.
  * @param K as LAPACK dorgqr K.

--- a/include/lapack.hh
+++ b/include/lapack.hh
@@ -71,10 +71,15 @@ template<typename T> void xxxgqr(int4 * M, int4 * N, int4 * K, T * A, int4 * LDA
 template<typename T, OnInputCheck Check> void checkData(T * data, int4 n);
 
 // Partial template specialisation (PTS) buffer, bounce function templates via structs
-// so that PTS can be used
+// so that PTS can be used.
 template<typename T, OnInputCheck CHECK> struct PTSBuffer
 {
   static void xgesvd(char * JOBU, char * JOBVT, int4 * M, int4 * N, T * A, int4 * LDA, real8 * S, T * U, int4 * LDU, T * VT, int4 * LDVT, int4 * INFO);
+};
+
+template<typename T, OnInputCheck CHECK> struct TemplateBuffer
+{
+  static void xgetrf(int4 * M, int4 * N, T * A, int4 * LDA, int4 * IPIV, int4 *INFO);
 };
 
 }
@@ -244,7 +249,7 @@ template<typename T, OnInputCheck CHECK> void xgesvd(char * JOBU, char * JOBVT, 
  * @param IPIV as LAPACK dgetrf IPIV
  * @param INFO as LAPACK dgetrf INFO
  */
-template<typename T> void xgetrf(int4 * M, int4 * N, T * A, int4 * LDA, int4 * IPIV, int4 *INFO);
+template<typename T, OnInputCheck CHECK> void xgetrf(int4 * M, int4 * N, T * A, int4 * LDA, int4 * IPIV, int4 *INFO);
 
 /**
  * xgetri() computes the inverse of a matrix via LU decomposition

--- a/src/java/src/test/java/com/opengamma/maths/testnodes/TestNorm2Materialise.java
+++ b/src/java/src/test/java/com/opengamma/maths/testnodes/TestNorm2Materialise.java
@@ -17,6 +17,7 @@ import com.opengamma.maths.datacontainers.scalar.OGComplexScalar;
 import com.opengamma.maths.datacontainers.scalar.OGRealScalar;
 import com.opengamma.maths.exceptions.MathsException;
 import com.opengamma.maths.exceptions.MathsExceptionIllegalArgument;
+import com.opengamma.maths.exceptions.MathsExceptionNativeComputation;
 import com.opengamma.maths.helpers.FuzzyEquals;
 import com.opengamma.maths.materialisers.Materialisers;
 import com.opengamma.maths.nodes.NORM2;
@@ -90,7 +91,27 @@ public class TestNorm2Materialise {
 
   @Test(dataProvider = "dataContainer", expectedExceptions = MathsExceptionIllegalArgument.class)
   public void outsideArgBound(OGExpr input, OGRealScalar expected) {
-    OGNumeric n = input.getArg(1);
+    input.getArg(1);
   }
 
+  /**
+   * Check NORM2 will throw if NaN is present in real system matrix context
+   */
+  @Test(expectedExceptions = MathsExceptionNativeComputation.class)
+  public void throwIfNaNPresentRealDataTest() {
+    OGRealDenseMatrix mat = new OGRealDenseMatrix(new double[][] { { 1, 2 }, { 3, Double.NaN } });
+    NORM2 norm2 = new NORM2(mat);
+    Materialisers.toOGTerminal(norm2);
+  }
+
+  /**
+   * Check NORM2 will throw if NaN is present in complex system matrix context
+   */
+  @Test(expectedExceptions = MathsExceptionNativeComputation.class)
+  public void throwIfNaNPresentComplexDataTest() {
+    OGComplexDenseMatrix mat = new OGComplexDenseMatrix(new double[][] { { 1, 2 }, { 3, Double.NaN } });
+    NORM2 norm2 = new NORM2(mat);
+    Materialisers.toOGTerminal(norm2);
+  }
+  
 }

--- a/src/java/src/test/java/com/opengamma/maths/testnodes/TestSVDMaterialise.java
+++ b/src/java/src/test/java/com/opengamma/maths/testnodes/TestSVDMaterialise.java
@@ -18,6 +18,7 @@ import com.opengamma.maths.datacontainers.matrix.OGRealDiagonalMatrix;
 import com.opengamma.maths.datacontainers.other.ComplexArrayContainer;
 import com.opengamma.maths.exceptions.MathsException;
 import com.opengamma.maths.exceptions.MathsExceptionIllegalArgument;
+import com.opengamma.maths.exceptions.MathsExceptionNativeComputation;
 import com.opengamma.maths.helpers.FuzzyEquals;
 import com.opengamma.maths.materialisers.Materialisers;
 import com.opengamma.maths.nodes.MTIMES;
@@ -177,4 +178,26 @@ public class TestSVDMaterialise {
     input.getArg(1);
   }
 
+  /**
+   * Check SVD will throw if NaN is present in real system matrix
+   */
+  @Test(expectedExceptions = MathsExceptionNativeComputation.class)
+  public void throwIfNaNPresentRealDataTest() {
+    OGRealDenseMatrix mat = new OGRealDenseMatrix(new double[][] { { 1, 2 }, { 3, Double.NaN } });
+    SVD svd = new SVD(mat);
+    OGNumeric U = svd.getU();
+    Materialisers.toOGTerminal(U);
+  }
+
+  /**
+   * Check SVD will throw if NaN is present in complex system matrix
+   */
+  @Test(expectedExceptions = MathsExceptionNativeComputation.class)
+  public void throwIfNaNPresentComplexDataTest() {
+    OGComplexDenseMatrix mat = new OGComplexDenseMatrix(new double[][] { { 1, 2 }, { 3, Double.NaN } });
+    SVD svd = new SVD(mat);
+    OGNumeric U = svd.getU();
+    Materialisers.toOGTerminal(U);
+  }
+  
 }

--- a/src/librdag/iss.cc
+++ b/src/librdag/iss.cc
@@ -96,7 +96,7 @@ bool isfinite(complex16 * data, int4 n)
 {
   for(int4 k = 0; k < n; k++)
   {
-    if(!(std::isfinite(std::real(data[k]))||std::isfinite(std::imag(data[k]))))
+    if(!(std::isfinite(std::real(data[k]))&&std::isfinite(std::imag(data[k]))))
     {
       return false;
     }

--- a/src/librdag/iss.cc
+++ b/src/librdag/iss.cc
@@ -77,4 +77,31 @@ bool isComplex(const OGTerminal::Ptr& terminal)
   return !isReal(terminal);
 }
 
+
+template<>
+bool isfinite(real8 * data, int4 n)
+{
+  for(int4 k = 0; k < n; k++)
+  {
+    if(!std::isfinite(data[k]))
+    {
+      return false;
+    }
+  }
+  return true;
+}
+
+template<>
+bool isfinite(complex16 * data, int4 n)
+{
+  for(int4 k = 0; k < n; k++)
+  {
+    if(!(std::isfinite(std::real(data[k]))||std::isfinite(std::imag(data[k]))))
+    {
+      return false;
+    }
+  }
+  return true;
+}
+
 } // end namespace librdag

--- a/src/librdag/lapack.cc
+++ b/src/librdag/lapack.cc
@@ -333,6 +333,9 @@ namespace detail
   template<typename T, OnInputCheck CHECK> void TemplateBuffer<T, CHECK>::xgetrf(int4 * M, int4 * N, T * A, int4 * LDA, int4 * IPIV, int4 *INFO)
   {
     set_xerbla_death_switch(lapack::izero);
+
+    checkData<T, CHECK>(A,(*M)*(*N));
+
     lapack::detail::xgetrf(M,N,A,LDA,IPIV,INFO);
     if(*INFO!=0)
     {
@@ -340,12 +343,13 @@ namespace detail
       if(*INFO<0)
       {
         message << "Input to LAPACK::xgetrf call incorrect at arg: " << -(*INFO) << ".";
+        throw rdag_unrecoverable_error(message.str());
       }
       else
       {
         message << "LAPACK::xgetrf, in LU decomposition, matrix U is singular at U[" << (*INFO - 1) << "," << (*INFO - 1) << "].";
+        throw rdag_recoverable_error(message.str());
       }
-      throw rdag_error(message.str());
     }
   }
 

--- a/src/librdag/lapack.cc
+++ b/src/librdag/lapack.cc
@@ -226,17 +226,29 @@ namespace detail
   // Data checkers
   template<> void checkData<real8, lapack::OnInputCheck::isfinite>(real8 * data, int4 n)
   {
+    if(n < 0)
+    {
+      std::stringstream message;
+      message << "Invalid data length (" << n << ") specified.";
+      throw rdag_unrecoverable_error(message.str());
+    }
     if(!librdag::isfinite(data, n))
     {
-      throw rdag_error("Only finite data is permitted in this function.");
+      throw rdag_unrecoverable_error("Only finite data is permitted in this function.");
     }
   }
   template<> void checkData<real8, lapack::OnInputCheck::nothing>(real8 SUPPRESS_UNUSED * data, int4 SUPPRESS_UNUSED n){}
   template<> void checkData<complex16, lapack::OnInputCheck::isfinite>(complex16 * data, int4 n)
   {
+    if(n < 0)
+    {
+      std::stringstream message;
+      message << "Invalid data length (" << n << ") specified.";
+      throw rdag_unrecoverable_error(message.str());
+    }
     if(!librdag::isfinite(data, n))
     {
-      throw rdag_error("Only finite data is permitted in this function.");
+      throw rdag_unrecoverable_error("Only finite data is permitted in this function.");
     }
   }
   template<> void checkData<complex16, lapack::OnInputCheck::nothing>(complex16 SUPPRESS_UNUSED * data, int4 SUPPRESS_UNUSED n){}
@@ -260,7 +272,7 @@ namespace detail
       {
         std::stringstream message;
         message << "Input to LAPACK::dgesvd call incorrect at arg: " << -(*INFO);
-        throw rdag_error(message.str());
+        throw rdag_unrecoverable_error(message.str());
       }
 
       // query complete tmp contains size needed
@@ -273,7 +285,7 @@ namespace detail
 
       if(*INFO!=0)
       {
-        throw rdag_error("LAPACK::dgesvd, internal call to dbdsqr did not converge.");
+        throw rdag_recoverable_error("LAPACK::dgesvd, internal call to dbdsqr did not converge.");
       }
     };
   };
@@ -296,7 +308,7 @@ namespace detail
       {
         std::stringstream message;
         message << "Input to LAPACK::zgesvd call incorrect at arg: " << -(*INFO);
-        throw rdag_error(message.str());
+        throw rdag_unrecoverable_error(message.str());
       }
 
       // query complete tmp contains size needed
@@ -312,7 +324,7 @@ namespace detail
 
       if(*INFO!=0)
       {
-        throw rdag_error("LAPACK::zgesvd, internal call to zbdsqr did not converge.");
+        throw rdag_recoverable_error("LAPACK::zgesvd, internal call to zbdsqr did not converge.");
       }
     };
   };

--- a/src/librdag/runners/invrunner.cc
+++ b/src/librdag/runners/invrunner.cc
@@ -100,7 +100,7 @@ inv_dense_runner(RegContainer& reg, shared_ptr<const OGMatrix<T>> arg)
     try
     {
       // LU decomp
-      lapack::xgetrf(&size, &size, A, &lda, ipiv, &info);
+      lapack::xgetrf<T, lapack::OnInputCheck::isfinite>(&size, &size, A, &lda, ipiv, &info);
       // Inversion backsolve
       lapack::xgetri(&size, A, &lda, ipiv, &info);
     }

--- a/src/librdag/runners/invrunner.cc
+++ b/src/librdag/runners/invrunner.cc
@@ -111,10 +111,7 @@ inv_dense_runner(RegContainer& reg, shared_ptr<const OGMatrix<T>> arg)
       cerr << "Warning: singular system detected in matrix inversion." << std::endl;
       cerr << "---> LAPACK details: " << e.what() << std::endl;
     }
-    catch (rdag_error& e)
-    {
-      throw;
-    }
+    // Else, exception propagates, stack unwinds
 
     ret = makeConcreteDenseMatrix(Aptr.release(), size, size, OWNER);
   }

--- a/src/librdag/runners/invrunner.cc
+++ b/src/librdag/runners/invrunner.cc
@@ -90,11 +90,13 @@ inv_dense_runner(RegContainer& reg, shared_ptr<const OGMatrix<T>> arg)
     int4 info = 0;
 
     // copy A else it's destroyed
-    T * A = new T[sizesize];
+    unique_ptr<T[]> Aptr (new T[sizesize]);
+    T * A = Aptr.get();
     std::memcpy(A, arg->getData(), sizeof(T)*sizesize);
 
     // create pivot vector
-    int4 * ipiv = new int4[size]();
+    unique_ptr<int4[]> ipivptr (new int4[size]());
+    int4 * ipiv = ipivptr.get();
 
     // call lapack to get LU decomp
     try
@@ -104,25 +106,17 @@ inv_dense_runner(RegContainer& reg, shared_ptr<const OGMatrix<T>> arg)
       // Inversion backsolve
       lapack::xgetri(&size, A, &lda, ipiv, &info);
     }
-    catch (exception& e)
+    catch (rdag_recoverable_error& e)
     {
-      if(info < 0) // illegal arg
-      {
-        delete[] ipiv;
-        delete[] A;
-        throw ;
-      }
-      else
-      {
-        cerr << "Warning: singular system detected in matrix inversion." << std::endl;
-        cerr << "---> LAPACK details: " << e.what() << std::endl;
-      }
+      cerr << "Warning: singular system detected in matrix inversion." << std::endl;
+      cerr << "---> LAPACK details: " << e.what() << std::endl;
+    }
+    catch (rdag_error& e)
+    {
+      throw;
     }
 
-    // normal return, delete pivot info
-    delete [] ipiv;
-
-    ret = makeConcreteDenseMatrix(A, size, size, OWNER);
+    ret = makeConcreteDenseMatrix(Aptr.release(), size, size, OWNER);
   }
 
   // shove ret into register

--- a/src/librdag/runners/lurunner.cc
+++ b/src/librdag/runners/lurunner.cc
@@ -47,7 +47,7 @@ template<typename T> void lu_dense_runner(RegContainer& reg, shared_ptr<const OG
   // call lapack
   try
   {
-    lapack::xgetrf(&m, &n, A, &lda, ipiv, &info);
+    lapack::xgetrf<T, lapack::OnInputCheck::isfinite>(&m, &n, A, &lda, ipiv, &info);
   }
   catch (exception& e)
   {

--- a/src/librdag/runners/lurunner.cc
+++ b/src/librdag/runners/lurunner.cc
@@ -60,10 +60,7 @@ template<typename T> void lu_dense_runner(RegContainer& reg, shared_ptr<const OG
     cerr << "Warning: singular system detected in matrix decomposition." << std::endl;
     cerr << "---> LAPACK details: " << e.what() << std::endl;
   }
-  catch (rdag_error& e)
-  {
-    throw;
-  }
+  // Else, exception propagates, stack unwinds
 
   // The following is adapted from DOGMAv1
 

--- a/src/librdag/runners/mldividerunner.cc
+++ b/src/librdag/runners/mldividerunner.cc
@@ -743,7 +743,7 @@ mldivide_dense_runner(RegContainer& reg0, shared_ptr<const OGMatrix<T>> arg0, sh
         // Try a LUP decomposition
         try
         {
-          lapack::xgetrf(&int4rows1, &int4cols1, data1, &int4rows1, ipivPtr.get(), &info);
+          lapack::xgetrf<T, lapack::OnInputCheck::isfinite>(&int4rows1, &int4cols1, data1, &int4rows1, ipivPtr.get(), &info);
         }
         catch (rdag_error& e)
         {

--- a/src/librdag/runners/mldividerunner.cc
+++ b/src/librdag/runners/mldividerunner.cc
@@ -749,10 +749,7 @@ mldivide_dense_runner(RegContainer& reg0, shared_ptr<const OGMatrix<T>> arg0, sh
         {
           // we're ok, this just means it's singular
         }
-        catch (rdag_error& e)
-        {
-          throw; // something bad happened in decomp, likely unrecoverable
-        }
+        // Else, exception propagates, stack unwinds
 
         if (info == 0)
         {

--- a/src/librdag/runners/mldividerunner.cc
+++ b/src/librdag/runners/mldividerunner.cc
@@ -745,12 +745,13 @@ mldivide_dense_runner(RegContainer& reg0, shared_ptr<const OGMatrix<T>> arg0, sh
         {
           lapack::xgetrf<T, lapack::OnInputCheck::isfinite>(&int4rows1, &int4cols1, data1, &int4rows1, ipivPtr.get(), &info);
         }
+        catch (rdag_recoverable_error& e)
+        {
+          // we're ok, this just means it's singular
+        }
         catch (rdag_error& e)
         {
-          if(info<0) // caught a xerbla error, rethrow
-          {
-            throw;
-          }
+          throw; // something bad happened in decomp, likely unrecoverable
         }
 
         if (info == 0)

--- a/src/librdag/runners/norm2runner.cc
+++ b/src/librdag/runners/norm2runner.cc
@@ -75,19 +75,12 @@ norm2_dense_runner(RegContainer& reg, shared_ptr<const OGMatrix<T>> arg)
     {
       lapack::xgesvd<T,lapack::OnInputCheck::isfinite>(lapack::N, lapack::N, &m, &n, A, &lda, S, U, &ldu, VT, &ldvt, &info);
     }
-    catch (exception& e)
+    catch (rdag_recoverable_error& e)
     {
-      try
-      {
-        throw;
-      }
-      catch (rdag_unrecoverable_error& e)
-      {
-        throw;
-      }
       // error is recoverable so just complain
       cerr << e.what() << std::endl;
     }
+    // Else, exception propagates, stack unwinds
 
     ret = OGRealScalar::create(std::real(S[0]));
   }

--- a/src/librdag/runners/norm2runner.cc
+++ b/src/librdag/runners/norm2runner.cc
@@ -68,7 +68,7 @@ norm2_dense_runner(RegContainer& reg, shared_ptr<const OGMatrix<T>> arg)
     std::memcpy(A, arg->getData(), sizeof(T)*m*n);
 
     // call lapack
-    lapack::xgesvd(lapack::N, lapack::N, &m, &n, A, &lda, S, U, &ldu, VT, &ldvt, &info);
+    lapack::xgesvd<T,lapack::OnInputCheck::isfinite>(lapack::N, lapack::N, &m, &n, A, &lda, S, U, &ldu, VT, &ldvt, &info);
 
     ret = OGRealScalar::create(std::real(S[0]));
     delete[] A;

--- a/src/librdag/runners/norm2runner.cc
+++ b/src/librdag/runners/norm2runner.cc
@@ -61,18 +61,35 @@ norm2_dense_runner(RegContainer& reg, shared_ptr<const OGMatrix<T>> arg)
 
     T * U = nullptr; //IGNORED
     T * VT = nullptr; //IGNORED
-    real8 * S = new real8[minmn];
+
+    std::unique_ptr<real8[]> Sptr(new real8[minmn]);
+    real8 * S = Sptr.get();
 
     // copy A else it's destroyed
-    T * A = new T[m*n];
+    std::unique_ptr<T[]> Aptr(new T[m*n]);
+    T * A = Aptr.get();
     std::memcpy(A, arg->getData(), sizeof(T)*m*n);
 
     // call lapack
-    lapack::xgesvd<T,lapack::OnInputCheck::isfinite>(lapack::N, lapack::N, &m, &n, A, &lda, S, U, &ldu, VT, &ldvt, &info);
+    try
+    {
+      lapack::xgesvd<T,lapack::OnInputCheck::isfinite>(lapack::N, lapack::N, &m, &n, A, &lda, S, U, &ldu, VT, &ldvt, &info);
+    }
+    catch (exception& e)
+    {
+      try
+      {
+        throw;
+      }
+      catch (rdag_unrecoverable_error& e)
+      {
+        throw;
+      }
+      // error is recoverable so just complain
+      cerr << e.what() << std::endl;
+    }
 
     ret = OGRealScalar::create(std::real(S[0]));
-    delete[] A;
-    delete[] S;
   }
 
   // shove ret into register

--- a/src/librdag/runners/svdrunner.cc
+++ b/src/librdag/runners/svdrunner.cc
@@ -48,19 +48,12 @@ template<typename T> void svd_dense_runner(RegContainer& reg, shared_ptr<const O
   {
     lapack::xgesvd<T, lapack::OnInputCheck::isfinite>(lapack::A, lapack::A, &m, &n, A, &lda, S, U, &ldu, VT, &ldvt, &info);
   }
-  catch (exception& e)
+  catch (rdag_recoverable_error& e)
   {
-    try
-    {
-      throw;
-    }
-    catch (rdag_unrecoverable_error& e)
-    {
-      throw;
-    }
     // error is recoverable so just complain
     cerr << e.what() << std::endl;
   }
+  // Else, exception propagates, stack unwinds
 
   reg.push_back(makeConcreteDenseMatrix(Uptr.release(), m, m, OWNER));
   reg.push_back(OGRealDiagonalMatrix::create(Sptr.release(), m, n, OWNER));

--- a/src/librdag/runners/svdrunner.cc
+++ b/src/librdag/runners/svdrunner.cc
@@ -46,7 +46,7 @@ template<typename T> void svd_dense_runner(RegContainer& reg, shared_ptr<const O
   // call lapack
   try
   {
-    lapack::xgesvd(lapack::A, lapack::A, &m, &n, A, &lda, S, U, &ldu, VT, &ldvt, &info);
+    lapack::xgesvd<T, lapack::OnInputCheck::isfinite>(lapack::A, lapack::A, &m, &n, A, &lda, S, U, &ldu, VT, &ldvt, &info);
   }
   catch (exception& e)
   {

--- a/src/librdag/runners/svdrunner.cc
+++ b/src/librdag/runners/svdrunner.cc
@@ -50,14 +50,16 @@ template<typename T> void svd_dense_runner(RegContainer& reg, shared_ptr<const O
   }
   catch (exception& e)
   {
-    if(info < 0) // illegal arg
+    try
     {
-      throw e;
+      throw;
     }
-    else // failed convergence TODO: this will end up in logs (MAT-369) and userland (MAT-370).
+    catch (rdag_unrecoverable_error& e)
     {
-      cerr << e.what() << std::endl;
+      throw;
     }
+    // error is recoverable so just complain
+    cerr << e.what() << std::endl;
   }
 
   reg.push_back(makeConcreteDenseMatrix(Uptr.release(), m, m, OWNER));

--- a/src/librdag/test/check_iss.cc
+++ b/src/librdag/test/check_iss.cc
@@ -154,6 +154,10 @@ TEST(issTest_isfinite, real8)
 
   EXPECT_TRUE(isfinite(r, 2));
   EXPECT_FALSE(isfinite(r, 4));
+
+  // Check qNaN fires correctly
+  r[2]=std::numeric_limits<real8>::quiet_NaN();
+  EXPECT_FALSE(isfinite(r, 4));
 }
 
 TEST(issTest_isfinite, complex16)
@@ -172,4 +176,9 @@ TEST(issTest_isfinite, complex16)
   c[2]={5,std::numeric_limits<real8>::signaling_NaN()};
   EXPECT_FALSE(isfinite(c, 4));
 
+  // check qNaN in real and imag parts
+  c[2]={std::numeric_limits<real8>::quiet_NaN(),1};
+  EXPECT_FALSE(isfinite(c, 4));
+  c[2]={5, std::numeric_limits<real8>::quiet_NaN()};
+  EXPECT_FALSE(isfinite(c, 4));
 }

--- a/src/librdag/test/check_iss.cc
+++ b/src/librdag/test/check_iss.cc
@@ -141,3 +141,35 @@ TEST_F(issTest, isMatrix)
   ASSERT_TRUE (isMatrix(_ogrealsparsematrix));
   ASSERT_TRUE (isMatrix(_ogcomplexsparsematrix));
 }
+
+
+TEST(issTest_isfinite, real8)
+{
+  std::unique_ptr<real8> rd (new real8[4]);
+  real8 * r = rd.get();
+  r[0]=1;
+  r[1]=2;
+  r[2]=std::numeric_limits<real8>::signaling_NaN();
+  r[3]=4;
+
+  EXPECT_TRUE(isfinite(r, 2));
+  EXPECT_FALSE(isfinite(r, 4));
+}
+
+TEST(issTest_isfinite, complex16)
+{
+  std::unique_ptr<complex16> cd (new complex16[4]);
+  complex16 * c = cd.get();
+  c[0]={1,2};
+  c[1]={2,3};
+  c[2]={std::numeric_limits<real8>::signaling_NaN(),1};
+  c[3]={4,3};
+
+  EXPECT_TRUE(isfinite(c, 2));
+  EXPECT_FALSE(isfinite(c, 4));
+
+  // check NaN in imag part
+  c[2]={5,std::numeric_limits<real8>::signaling_NaN()};
+  EXPECT_FALSE(isfinite(c, 4));
+
+}

--- a/src/librdag/test/check_lapack.cc
+++ b/src/librdag/test/check_lapack.cc
@@ -276,10 +276,22 @@ TEST(LAPACKTest_xgesvd, dgesvd) {
   EXPECT_TRUE(ArrayFuzzyEquals(expectedS,S,2,1e-14,1e-14));
   EXPECT_TRUE(ArrayFuzzyEquals(expectedVT,VT,4,1e-14,1e-14));
 
-  // check throw on bad arg
+  // check errors on bad arg (m=-1)
   std::copy(A,A+m*n,Acpy);
   m = -1;
-  EXPECT_THROW((lapack::xgesvd<real8,lapack::OnInputCheck::isfinite>(lapack::A, lapack::A, &m, &n, Acpy, &m, S, U, &m, VT, &n, &INFO)), rdag_error);
+  // will throw as data length is bad for finite domain check
+  EXPECT_THROW((lapack::xgesvd<real8,lapack::OnInputCheck::isfinite>(lapack::A, lapack::A, &m, &n, Acpy, &m, S, U, &m, VT, &n, &INFO)), rdag_unrecoverable_error);
+  // will throw from xerbla as m is negative
+  EXPECT_THROW((lapack::xgesvd<real8,lapack::OnInputCheck::nothing>(lapack::A, lapack::A, &m, &n, Acpy, &m, S, U, &m, VT, &n, &INFO)), rdag_unrecoverable_error);
+
+  // check errors with input checking (A[0] = NaN).
+  m = 3;
+  std::copy(A,A+m*n,Acpy);
+  Acpy[0]=std::numeric_limits<real8>::signaling_NaN();
+  // will throw as finite domain check sees NaN
+  EXPECT_THROW((lapack::xgesvd<real8,lapack::OnInputCheck::isfinite>(lapack::A, lapack::A, &m, &n, Acpy, &m, S, U, &m, VT, &n, &INFO)), rdag_unrecoverable_error);
+  // will not throw
+  EXPECT_NO_THROW((lapack::xgesvd<real8,lapack::OnInputCheck::nothing>(lapack::A, lapack::A, &m, &n, Acpy, &m, S, U, &m, VT, &n, &INFO)));
 
   delete[] U;
   delete[] S;
@@ -318,7 +330,7 @@ TEST(LAPACKTest_xgesvd, zgesvd) {
   // check throw on bad arg
   std::copy(A,A+m*n,Acpy);
   m = -1;
-  EXPECT_THROW((lapack::xgesvd<complex16,lapack::OnInputCheck::isfinite>(lapack::A, lapack::A, &m, &n, Acpy, &m, S, U, &m, VT, &n, &INFO)), rdag_error);
+  EXPECT_THROW((lapack::xgesvd<complex16,lapack::OnInputCheck::isfinite>(lapack::A, lapack::A, &m, &n, Acpy, &m, S, U, &m, VT, &n, &INFO)), rdag_unrecoverable_error);
 
   delete[] U;
   delete[] S;

--- a/src/librdag/test/check_lapack.cc
+++ b/src/librdag/test/check_lapack.cc
@@ -357,7 +357,7 @@ TEST(LAPACKTest_xgetrf, dgetrf) {
   real8 * Acpy = new real8[20];
   std::copy(rcondok5x4,rcondok5x4+m*n,Acpy);
   int4 * ipiv = new int4[minmn]();
-  lapack::xgetrf(&m,&n,Acpy,&m,ipiv,&INFO);
+  lapack::xgetrf<real8, lapack::OnInputCheck::nothing>(&m,&n,Acpy,&m,ipiv,&INFO);
 
   EXPECT_TRUE(ArrayBitEquals(expectedIPIV,ipiv,4));
   EXPECT_TRUE(ArrayFuzzyEquals(expectedA,Acpy,20));
@@ -365,13 +365,13 @@ TEST(LAPACKTest_xgetrf, dgetrf) {
   // check throw on bad arg
   std::copy(rcondok5x4,rcondok5x4+m*n,Acpy);
   m = -1;
-  EXPECT_THROW(lapack::xgetrf(&m,&n,Acpy,&m,ipiv,&INFO), rdag_error);
+  EXPECT_THROW((lapack::xgetrf<real8, lapack::OnInputCheck::nothing>(&m,&n,Acpy,&m,ipiv,&INFO)), rdag_error);
 
   // check throw on singular
   m=3;
   n=3;
   std::copy(rsingular3x3,rsingular3x3+m*n,Acpy);
-  EXPECT_THROW(lapack::xgetrf(&m,&n,Acpy,&m,ipiv,&INFO), rdag_error);
+  EXPECT_THROW((lapack::xgetrf<real8, lapack::OnInputCheck::nothing>(&m,&n,Acpy,&m,ipiv,&INFO)), rdag_error);
 
   delete [] ipiv;
   delete [] expectedIPIV;
@@ -393,7 +393,7 @@ TEST(LAPACKTest_xgetrf, zgetrf) {
   complex16 * Acpy = new complex16[20];
   std::copy(ccondok5x4,ccondok5x4+m*n,Acpy);
   int4 * ipiv = new int4[minmn]();
-  lapack::xgetrf(&m,&n,Acpy,&m,ipiv,&INFO);
+  lapack::xgetrf<complex16, lapack::OnInputCheck::nothing>(&m,&n,Acpy,&m,ipiv,&INFO);
 
   EXPECT_TRUE(ArrayBitEquals(expectedIPIV,ipiv,4));
   EXPECT_TRUE(ArrayFuzzyEquals(expectedA,Acpy,20));
@@ -401,13 +401,13 @@ TEST(LAPACKTest_xgetrf, zgetrf) {
   // check throw on bad arg
   std::copy(rcondok5x4,rcondok5x4+m*n,Acpy);
   m = -1;
-  EXPECT_THROW(lapack::xgetrf(&m,&n,Acpy,&m,ipiv,&INFO), rdag_error);
+  EXPECT_THROW((lapack::xgetrf<complex16, lapack::OnInputCheck::nothing>(&m,&n,Acpy,&m,ipiv,&INFO)), rdag_error);
 
   // check throw on singular
   m=3;
   n=3;
   std::copy(csingular3x3,csingular3x3+m*n,Acpy);
-  EXPECT_THROW(lapack::xgetrf(&m,&n,Acpy,&m,ipiv,&INFO), rdag_error);
+  EXPECT_THROW((lapack::xgetrf<complex16, lapack::OnInputCheck::nothing>(&m,&n,Acpy,&m,ipiv,&INFO)), rdag_error);
 
   delete [] ipiv;
   delete [] expectedIPIV;
@@ -796,7 +796,7 @@ TEST(LAPACKTest_xgecon, dgecon) {
 
   // need a LU decomp
   int4 * ipiv = new int4[minmn]();
-  lapack::xgetrf(&m,&n,Acpy,&m,ipiv,&INFO);
+  lapack::xgetrf<real8, lapack::OnInputCheck::nothing>(&m,&n,Acpy,&m,ipiv,&INFO);
 
   // make the call
   real8 rcond = 0;
@@ -833,7 +833,7 @@ TEST(LAPACKTest_xgecon, zgecon) {
 
   // need a LU decomp
   int4 * ipiv = new int4[minmn]();
-  lapack::xgetrf(&m,&n,Acpy,&m,ipiv,&INFO);
+  lapack::xgetrf<complex16, lapack::OnInputCheck::nothing>(&m,&n,Acpy,&m,ipiv,&INFO);
 
   // make the call
   real8 rcond = 0;
@@ -863,7 +863,7 @@ TEST(LAPACKTest_xgetrs, dgetrs) {
 
   // need a LU decomp
   int4 * ipiv = new int4[minmn]();
-  lapack::xgetrf(&m,&n,Acpy,&m,ipiv,&INFO);
+  lapack::xgetrf<real8, lapack::OnInputCheck::nothing>(&m,&n,Acpy,&m,ipiv,&INFO);
 
   // need an RHS
   real8 * rhs = new real8[8]{1,2,3,4,1,2,3,4};
@@ -901,7 +901,7 @@ TEST(LAPACKTest_xgetrs, zgetrs) {
 
   // need a LU decomp
   int4 * ipiv = new int4[minmn]();
-  lapack::xgetrf(&m,&n,Acpy,&m,ipiv,&INFO);
+  lapack::xgetrf<complex16, lapack::OnInputCheck::nothing>(&m,&n,Acpy,&m,ipiv,&INFO);
 
   // need an RHS
   complex16 * rhs = new complex16[8]{{1.,10.}, {2.,20.}, {3.,30.}, {4.,40.},{1.,10.}, {2.,20.}, {3.,30.}, {4.,40.}};

--- a/src/librdag/test/check_lapack.cc
+++ b/src/librdag/test/check_lapack.cc
@@ -327,10 +327,22 @@ TEST(LAPACKTest_xgesvd, zgesvd) {
   EXPECT_TRUE(ArrayFuzzyEquals(expectedS,S,2,1e-14,1e-14));
   EXPECT_TRUE(ArrayFuzzyEquals(expectedVT,VT,4,1e-14,1e-14));
 
-  // check throw on bad arg
+  // check errors on bad arg (m=-1)
   std::copy(A,A+m*n,Acpy);
   m = -1;
+  // will throw as data length is bad for finite domain check
   EXPECT_THROW((lapack::xgesvd<complex16,lapack::OnInputCheck::isfinite>(lapack::A, lapack::A, &m, &n, Acpy, &m, S, U, &m, VT, &n, &INFO)), rdag_unrecoverable_error);
+  // will throw from xerbla as m is negative
+  EXPECT_THROW((lapack::xgesvd<complex16,lapack::OnInputCheck::nothing>(lapack::A, lapack::A, &m, &n, Acpy, &m, S, U, &m, VT, &n, &INFO)), rdag_unrecoverable_error);
+
+  // check errors with input checking (A[0] = NaN).
+  m = 3;
+  std::copy(A,A+m*n,Acpy);
+  Acpy[0]=std::numeric_limits<real8>::signaling_NaN();
+  // will throw as finite domain check sees NaN
+  EXPECT_THROW((lapack::xgesvd<complex16,lapack::OnInputCheck::isfinite>(lapack::A, lapack::A, &m, &n, Acpy, &m, S, U, &m, VT, &n, &INFO)), rdag_unrecoverable_error);
+  // will not throw
+  EXPECT_NO_THROW((lapack::xgesvd<complex16,lapack::OnInputCheck::nothing>(lapack::A, lapack::A, &m, &n, Acpy, &m, S, U, &m, VT, &n, &INFO)));
 
   delete[] U;
   delete[] S;
@@ -365,13 +377,26 @@ TEST(LAPACKTest_xgetrf, dgetrf) {
   // check throw on bad arg
   std::copy(rcondok5x4,rcondok5x4+m*n,Acpy);
   m = -1;
-  EXPECT_THROW((lapack::xgetrf<real8, lapack::OnInputCheck::nothing>(&m,&n,Acpy,&m,ipiv,&INFO)), rdag_error);
+  // will throw as data length is bad for finite domain check
+  EXPECT_THROW((lapack::xgetrf<real8, lapack::OnInputCheck::isfinite>(&m,&n,Acpy,&m,ipiv,&INFO)), rdag_unrecoverable_error);
+  // will throw from xerbla as m is negative
+  EXPECT_THROW((lapack::xgetrf<real8, lapack::OnInputCheck::nothing>(&m,&n,Acpy,&m,ipiv,&INFO)), rdag_unrecoverable_error);
+
+  // check errors with input checking (A[0] = NaN).
+  m = 5;
+  std::copy(rcondok5x4,rcondok5x4+m*n,Acpy);
+  Acpy[0]=std::numeric_limits<real8>::signaling_NaN();
+  // will throw as finite domain check sees NaN
+  EXPECT_THROW((lapack::xgetrf<real8, lapack::OnInputCheck::isfinite>(&m,&n,Acpy,&m,ipiv,&INFO)), rdag_unrecoverable_error);
+  // will not throw
+  EXPECT_NO_THROW((lapack::xgetrf<real8, lapack::OnInputCheck::nothing>(&m,&n,Acpy,&m,ipiv,&INFO)));
 
   // check throw on singular
   m=3;
   n=3;
   std::copy(rsingular3x3,rsingular3x3+m*n,Acpy);
-  EXPECT_THROW((lapack::xgetrf<real8, lapack::OnInputCheck::nothing>(&m,&n,Acpy,&m,ipiv,&INFO)), rdag_error);
+  EXPECT_THROW((lapack::xgetrf<real8, lapack::OnInputCheck::nothing>(&m,&n,Acpy,&m,ipiv,&INFO)), rdag_recoverable_error);
+  EXPECT_THROW((lapack::xgetrf<real8, lapack::OnInputCheck::isfinite>(&m,&n,Acpy,&m,ipiv,&INFO)), rdag_recoverable_error);
 
   delete [] ipiv;
   delete [] expectedIPIV;
@@ -399,15 +424,28 @@ TEST(LAPACKTest_xgetrf, zgetrf) {
   EXPECT_TRUE(ArrayFuzzyEquals(expectedA,Acpy,20));
 
   // check throw on bad arg
-  std::copy(rcondok5x4,rcondok5x4+m*n,Acpy);
+  std::copy(ccondok5x4,ccondok5x4+m*n,Acpy);
   m = -1;
-  EXPECT_THROW((lapack::xgetrf<complex16, lapack::OnInputCheck::nothing>(&m,&n,Acpy,&m,ipiv,&INFO)), rdag_error);
+  // will throw as data length is bad for finite domain check
+  EXPECT_THROW((lapack::xgetrf<complex16, lapack::OnInputCheck::isfinite>(&m,&n,Acpy,&m,ipiv,&INFO)), rdag_unrecoverable_error);
+  // will throw from xerbla as m is negative
+  EXPECT_THROW((lapack::xgetrf<complex16, lapack::OnInputCheck::nothing>(&m,&n,Acpy,&m,ipiv,&INFO)), rdag_unrecoverable_error);
+
+  // check errors with input checking (A[0] = NaN).
+  m = 5;
+  std::copy(ccondok5x4,ccondok5x4+m*n,Acpy);
+  Acpy[0]=std::numeric_limits<real8>::signaling_NaN();
+  // will throw as finite domain check sees NaN
+  EXPECT_THROW((lapack::xgetrf<complex16, lapack::OnInputCheck::isfinite>(&m,&n,Acpy,&m,ipiv,&INFO)), rdag_unrecoverable_error);
+  // will not throw
+  EXPECT_NO_THROW((lapack::xgetrf<complex16, lapack::OnInputCheck::nothing>(&m,&n,Acpy,&m,ipiv,&INFO)));
 
   // check throw on singular
   m=3;
   n=3;
   std::copy(csingular3x3,csingular3x3+m*n,Acpy);
-  EXPECT_THROW((lapack::xgetrf<complex16, lapack::OnInputCheck::nothing>(&m,&n,Acpy,&m,ipiv,&INFO)), rdag_error);
+  EXPECT_THROW((lapack::xgetrf<complex16, lapack::OnInputCheck::nothing>(&m,&n,Acpy,&m,ipiv,&INFO)), rdag_recoverable_error);
+  EXPECT_THROW((lapack::xgetrf<complex16, lapack::OnInputCheck::isfinite>(&m,&n,Acpy,&m,ipiv,&INFO)), rdag_recoverable_error);
 
   delete [] ipiv;
   delete [] expectedIPIV;

--- a/src/librdag/test/check_lapack.cc
+++ b/src/librdag/test/check_lapack.cc
@@ -270,7 +270,7 @@ TEST(LAPACKTest_xgesvd, dgesvd) {
   real8 * Acpy = new real8[6];
   std::copy(A,A+m*n,Acpy);
 
-  lapack::xgesvd(lapack::A, lapack::A, &m, &n, Acpy, &m, S, U, &m, VT, &n, &INFO);
+  lapack::xgesvd<real8,lapack::OnInputCheck::isfinite>(lapack::A, lapack::A, &m, &n, Acpy, &m, S, U, &m, VT, &n, &INFO);
 
   EXPECT_TRUE(ArrayFuzzyEquals(expectedU,U,9,1e-14,1e-14));
   EXPECT_TRUE(ArrayFuzzyEquals(expectedS,S,2,1e-14,1e-14));
@@ -279,7 +279,7 @@ TEST(LAPACKTest_xgesvd, dgesvd) {
   // check throw on bad arg
   std::copy(A,A+m*n,Acpy);
   m = -1;
-  EXPECT_THROW(lapack::xgesvd(lapack::A, lapack::A, &m, &n, Acpy, &m, S, U, &m, VT, &n, &INFO), rdag_error);
+  EXPECT_THROW((lapack::xgesvd<real8,lapack::OnInputCheck::isfinite>(lapack::A, lapack::A, &m, &n, Acpy, &m, S, U, &m, VT, &n, &INFO)), rdag_error);
 
   delete[] U;
   delete[] S;
@@ -309,7 +309,7 @@ TEST(LAPACKTest_xgesvd, zgesvd) {
   complex16 * Acpy = new complex16[6];
   std::copy(A,A+m*n,Acpy);
 
-  lapack::xgesvd(lapack::A, lapack::A, &m, &n, Acpy, &m, S, U, &m, VT, &n, &INFO);
+  lapack::xgesvd<complex16,lapack::OnInputCheck::isfinite>(lapack::A, lapack::A, &m, &n, Acpy, &m, S, U, &m, VT, &n, &INFO);
 
   EXPECT_TRUE(ArrayFuzzyEquals(expectedU,U,9,1e-14,1e-14));
   EXPECT_TRUE(ArrayFuzzyEquals(expectedS,S,2,1e-14,1e-14));
@@ -318,7 +318,7 @@ TEST(LAPACKTest_xgesvd, zgesvd) {
   // check throw on bad arg
   std::copy(A,A+m*n,Acpy);
   m = -1;
-  EXPECT_THROW(lapack::xgesvd(lapack::A, lapack::A, &m, &n, Acpy, &m, S, U, &m, VT, &n, &INFO), rdag_error);
+  EXPECT_THROW((lapack::xgesvd<complex16,lapack::OnInputCheck::isfinite>(lapack::A, lapack::A, &m, &n, Acpy, &m, S, U, &m, VT, &n, &INFO)), rdag_error);
 
   delete[] U;
   delete[] S;

--- a/src/librdag/test/nodes/check_norm2.cc
+++ b/src/librdag/test/nodes/check_norm2.cc
@@ -10,6 +10,7 @@
 #include "execution.hh"
 #include "dispatch.hh"
 #include "testnodes.hh"
+#include "runtree.hh"
 
 using namespace std;
 using namespace librdag;
@@ -42,3 +43,24 @@ new CheckUnary<NORM2>( OGComplexScalar::create({-1.0,1.0}), OGRealScalar::create
   new CheckUnary<NORM2>( OGComplexDenseMatrix::create(new complex16[12]{{1,10},{4,40},{7,70},{10,100},{2,20},{5,50},{8,80},{11,110},{3,30},{6,60},{9,90},{12,120}},4,3, OWNER), OGRealScalar::create(255.894027746469), MATHSEQUAL)
   )
 );
+
+TEST(NORM2Tests_check_finite,real8)
+{
+  OGTerminal::Ptr A = OGRealDenseMatrix::create({{1,2,3},{4,5,std::numeric_limits<real8>::signaling_NaN()}});
+
+  OGNumeric::Ptr norm2 = NORM2::create(A);
+
+  EXPECT_THROW(runtree(norm2),rdag_unrecoverable_error);
+
+}
+
+
+TEST(NORM2Tests_check_finite,complex16)
+{
+  OGTerminal::Ptr A = OGComplexDenseMatrix::create({{{1,0},{2,3},{3,5}},{{4,1},{5,2},{std::numeric_limits<real8>::signaling_NaN(),8}}});
+
+  OGNumeric::Ptr norm2 = NORM2::create(A);
+
+  EXPECT_THROW(runtree(norm2),rdag_unrecoverable_error);
+
+}

--- a/src/librdag/test/nodes/check_svd.cc
+++ b/src/librdag/test/nodes/check_svd.cc
@@ -11,6 +11,7 @@
 #include "dispatch.hh"
 #include "testnodes.hh"
 #include "equals.hh"
+#include "runtree.hh"
 
 using namespace std;
 using namespace librdag;
@@ -120,6 +121,11 @@ TEST(SVDTests,CheckRealDenseMatrix)
   }
   reconstruct = m2->getRegs()[0];
   EXPECT_TRUE((*M) ==~ (*(reconstruct->asOGTerminal())));
+
+  // Check sending in a non finite number throws unrecoverable error
+  OGTerminal::Ptr Mbad = OGRealDenseMatrix::create(new real8[6]{std::numeric_limits<real8>::signaling_NaN(),3,5,2,4,6},3,2,OWNER);
+  svd = SVD::create(Mbad);
+  EXPECT_THROW(runtree(svd), rdag_unrecoverable_error);
 }
 
 // MAT-404, test demonstrates fixing of bug.
@@ -241,4 +247,9 @@ TEST(SVDTests,CheckComplexDenseMatrix)
   reconstruct = m2->getRegs()[0];
   // FP fuzz causes grief on reconstruction
   EXPECT_TRUE(ArrayFuzzyEquals(M->asOGComplexDenseMatrix()->getData(),reconstruct->asOGComplexDenseMatrix()->getData(),1e-15,1e-15));
+
+  // Check sending in a non finite number throws unrecoverable error
+  OGTerminal::Ptr Mbad = OGComplexDenseMatrix::create(new complex16[6]{{std::numeric_limits<real8>::signaling_NaN(),10}, {3,30}, {5,50}, {2,20}, {4,40}, {6,60}},3,2,OWNER);
+  svd = SVD::create(Mbad);
+  EXPECT_THROW(runtree(svd), rdag_unrecoverable_error);
 }


### PR DESCRIPTION
This PR is purely to add in some code/idea stubs because I don't want to go any further with it before we decide it's sensible given the number of call sites and bits of logic that will need adjusting due to the size of the LAPACK namespace.

The intent is:
- To add a template parameter to LAPACK namespace routines that are susceptible to getting stuck (xgesvd) or just producing nonsense on the presence of non-finite data. The template parameter is added to such routines to specify what is to be checked for in the input data prior to the call the LAPACK. At the minute `nothing` and `isfinite` are implemented. The decision to add the option as a template parameter opposed to the method prototype is so that the prototypes remain LAPACK like, also to avoid clumsy branching on testing types in the LAPACK call staging implementation. This also means that in routines where many LAPACK calls are made, necessary checks can be made prior to LAPACK calls which can then proceed without further checking.
- The LAPACK calls are all template functions so the necessary partial template specialisation is performed via buffering the call site through a specialisation struct.
- Adds two new exceptions that extend `rdag_error`, these are `rdag_recoverable_error` (error present but is recoverable) and `rdag_unrecoverable_error` (error present and cannot recover). These are added in part to circumvent the need to check many LAPACK routines' `info` variable status, and also in part to just make the exception hierarchy more sensible. Should this seem sufficient I'll mirror this on the Java side.
- Fixes up a load of runner code to use smart pointer based memory management, I did this whilst adjusting the LAPACK call sites.

Coverage:
Java: 82% (no change)
build/src/jshim 0.8% (no change)
build/src/librdag 40.8% (no change)
src/jshim 53.1% (no change)
src/librdag 85.9% (up 0.2%)
src/librdag/runners 95.8% (up 1%).
