### PR TITLE
MAT-475 Fix OSX libstdc++ linkage issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,8 +93,11 @@ set(PATH_AND_JAR_JAVADOC_NAME "${JARDIR}/${JAR_JAVADOC_NAME}" )
 # Use C99 and C++11, other flags for preventing common errors. Also add thread libs.
 set(CMAKE_C_FLAGS "-std=c99 -Wall -Werror -Wextra -pedantic ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_C_FLAGS}")
 set(CMAKE_CXX_FLAGS "-std=c++11 -Wall -Wno-sign-compare -Werror -Wextra -pedantic ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_CXX_FLAGS}")
-# we want static libstdc++ everywhere!
-set(CMAKE_SHARED_LINKER_FLAGS "-static-libstdc++")
+
+if(NOT APPLE)
+  # we want static libstdc++ everywhere apart from apple who does the 2 layer namespace thing!
+  set(CMAKE_SHARED_LINKER_FLAGS "-static-libstdc++")
+endif()
 
 # On Linux, add -rdynamic for stack traces
 if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")

--- a/cmake/syslibs.py
+++ b/cmake/syslibs.py
@@ -20,7 +20,7 @@ libs['w32'] = [ 'libgcc_s_sjlj-1.dll', 'libgfortran-3.dll', 'libquadmath-0.dll' 
 
 default_gcc_lib_folder = {}
 default_gcc_lib_folder['lnx'] = '/opt/gcc/4.9.1/lib64'
-default_gcc_lib_folder['osx'] = '/opt/local/lib/gcc49'
+default_gcc_lib_folder['osx'] = '/opt/gcc/4.9.1/lib'
 default_gcc_lib_folder['w64'] = 'C:\\buildsystem\\mingw-w64\\x86_64\\4.9.1\\mingw64\\bin'
 default_gcc_lib_folder['w32'] = 'C:\\buildsystem\\mingw-w64\\x86\\4.9.1\\mingw32\\bin'
 

--- a/cmake/syslibs.py
+++ b/cmake/syslibs.py
@@ -14,7 +14,7 @@ from buildutils import platform_code
 
 libs = {}
 libs['lnx'] = [ 'libgcc_s.so.1', 'libgfortran.so.3', 'libquadmath.so.0' ]
-libs['osx'] = [ 'libgcc_s.1.dylib', 'libgfortran.3.dylib', 'libquadmath.0.dylib' ]
+libs['osx'] = [ 'libgcc_s.1.dylib', 'libstdc++.6.dylib', 'libgfortran.3.dylib', 'libquadmath.0.dylib' ]
 libs['w64'] = [ 'libgcc_s_seh-1.dll', 'libgfortran-3.dll', 'libquadmath-0.dll' ]
 libs['w32'] = [ 'libgcc_s_sjlj-1.dll', 'libgfortran-3.dll', 'libquadmath-0.dll' ]
 

--- a/src/java/src/main/config/NativeLibraries.properties
+++ b/src/java/src/main/config/NativeLibraries.properties
@@ -5,13 +5,13 @@
 #
 
 NativeLibraries.osx.initialise = libjinitialise.0.dylib
-NativeLibraries.osx.dbg.libraries = libjshim_dbg.0.dylib, librdag_dbg.0.dylib, liboglapack_dbg.3.dylib,libogblas_dbg.3.dylib,libogxerbla_dbg.3.dylib, libizy_dbg.0.dylib, libizyreference_dbg.0.dylib, libgcc_s.1.dylib, libgfortran.3.dylib, libquadmath.0.dylib
+NativeLibraries.osx.dbg.libraries = libjshim_dbg.0.dylib, librdag_dbg.0.dylib, liboglapack_dbg.3.dylib,libogblas_dbg.3.dylib,libogxerbla_dbg.3.dylib, libizy_dbg.0.dylib, libizyreference_dbg.0.dylib, libgcc_s.1.dylib, libstdc++.6.dylib, libgfortran.3.dylib, libquadmath.0.dylib
 NativeLibraries.osx.dbg.load = libjshim_dbg.0.dylib
-NativeLibraries.osx.std.libraries = libjshim_std.0.dylib, librdag_std.0.dylib, libizyreference_std.0.dylib, liboglapack_std.3.dylib,libogblas_std.3.dylib,libogxerbla_std.3.dylib, libizy_std.0.dylib, libgcc_s.1.dylib, libgfortran.3.dylib, libquadmath.0.dylib
+NativeLibraries.osx.std.libraries = libjshim_std.0.dylib, librdag_std.0.dylib, libizyreference_std.0.dylib, liboglapack_std.3.dylib,libogblas_std.3.dylib,libogxerbla_std.3.dylib, libizy_std.0.dylib, libgcc_s.1.dylib, libstdc++.6.dylib, libgfortran.3.dylib, libquadmath.0.dylib
 NativeLibraries.osx.std.load = libjshim_std.0.dylib
-NativeLibraries.osx.sse41.libraries = libjshim_sse41.0.dylib, librdag_sse41.0.dylib, liboglapack_sse41.3.dylib,libogblas_sse41.3.dylib,libogxerbla_sse41.3.dylib, libizy_sse41.0.dylib, libizyreference_sse41.0.dylib, libgcc_s.1.dylib, libgfortran.3.dylib, libquadmath.0.dylib
+NativeLibraries.osx.sse41.libraries = libjshim_sse41.0.dylib, librdag_sse41.0.dylib, liboglapack_sse41.3.dylib,libogblas_sse41.3.dylib,libogxerbla_sse41.3.dylib, libizy_sse41.0.dylib, libizyreference_sse41.0.dylib, libgcc_s.1.dylib, libstdc++.6.dylib, libgfortran.3.dylib, libquadmath.0.dylib
 NativeLibraries.osx.sse41.load = libjshim_sse41.0.dylib
-NativeLibraries.osx.avx1.libraries = libjshim_avx1.0.dylib, librdag_avx1.0.dylib, liboglapack_avx1.3.dylib,libogblas_avx1.3.dylib,libogxerbla_avx1.3.dylib, libizy_avx1.0.dylib, libizyreference_avx1.0.dylib, libgcc_s.1.dylib, libgfortran.3.dylib, libquadmath.0.dylib
+NativeLibraries.osx.avx1.libraries = libjshim_avx1.0.dylib, librdag_avx1.0.dylib, liboglapack_avx1.3.dylib,libogblas_avx1.3.dylib,libogxerbla_avx1.3.dylib, libizy_avx1.0.dylib, libizyreference_avx1.0.dylib, libgcc_s.1.dylib, libstdc++.6.dylib, libgfortran.3.dylib, libquadmath.0.dylib
 NativeLibraries.osx.avx1.load = libjshim_avx1.0.dylib
 
 

--- a/src/java/src/main/java/com/opengamma/maths/datacontainers/other/ComplexArrayContainer.java
+++ b/src/java/src/main/java/com/opengamma/maths/datacontainers/other/ComplexArrayContainer.java
@@ -6,6 +6,8 @@
 
 package com.opengamma.maths.datacontainers.other;
 
+import java.util.Arrays;
+
 import com.opengamma.maths.helpers.Catchers;
 import com.opengamma.maths.helpers.MatrixPrimitiveUtils;
 
@@ -69,6 +71,24 @@ public class ComplexArrayContainer {
    */
   public boolean anyImaginary() {
     return _anyImag;
+  }
+
+  @Override
+  public String toString() {
+    String str = "ComplexArrayContainer:";
+    str = str + "\n====Pretty Print====\n";
+    int rows = _real.length;
+    int cols = _real[0].length;
+    str = str + "Rows: " + rows + "Cols: " + cols + "\n";
+    str = str + "Data:\n";
+    for (int i = 0; i < rows; i++) {
+      for (int j = 0; j < cols; j++) {
+        str += String.format("%24.18f + %24.18fi, ", _real[i][j], _imag[i][j]);
+      }
+      str += String.format("\n");
+    }
+    str += "\n";
+    return str;
   }
 
 }

--- a/src/java/src/test/java/com/opengamma/maths/datacontainers/other/ComplexArrayContainerTest.java
+++ b/src/java/src/test/java/com/opengamma/maths/datacontainers/other/ComplexArrayContainerTest.java
@@ -92,4 +92,9 @@ public class ComplexArrayContainerTest {
     tmp[0][0] = Double.longBitsToDouble(2L << 63);
     assertFalse(new ComplexArrayContainer(real, tmp).anyImaginary());
   }
+
+  @Test
+  public void toStringTest() {
+    new ComplexArrayContainer(real, imag).toString();
+  }
 }

--- a/src/jshim/jshim.cc
+++ b/src/jshim/jshim.cc
@@ -253,17 +253,17 @@ JNIEXPORT jobjectArray JNICALL Java_com_opengamma_maths_materialisers_Materialis
 
     returnVal = Real8AoA{answer}.toJDoubleAoA(env);
   }
-  catch (convert_error e)
+  catch (convert_error& e)
   {
     convertExceptionJava(env, e);
     return nullptr;
   }
-  catch (rdag_error e)
+  catch (rdag_error& e)
   {
     rdagExceptionJava(env, e);
     return nullptr;
   }
-  catch (exception e)
+  catch (exception& e)
   {
     unspecifiedExceptionJava(env, e);
     return nullptr;
@@ -304,17 +304,17 @@ JNIEXPORT jobject JNICALL Java_com_opengamma_maths_materialisers_Materialisers_m
                                JVMManager::getComplexArrayContainerClazz_ctor_DAoA_DAoA(),
                                realPart, imagPart);
   }
-  catch (convert_error e)
+  catch (convert_error& e)
   {
     convertExceptionJava(env, e);
     return nullptr;
   }
-  catch (rdag_error e)
+  catch (rdag_error& e)
   {
     rdagExceptionJava(env, e);
     return nullptr;
   }
-  catch (exception e)
+  catch (exception& e)
   {
     unspecifiedExceptionJava(env, e);
     return nullptr;
@@ -355,17 +355,17 @@ Java_com_opengamma_maths_materialisers_Materialisers_materialiseToOGTerminal(JNI
 
     result = JavaTerminal{env, answer}.getObject();
   }
-  catch (convert_error e)
+  catch (convert_error& e)
   {
     convertExceptionJava(env, e);
     return nullptr;
   }
-  catch (rdag_error e)
+  catch (rdag_error& e)
   {
     rdagExceptionJava(env, e);
     return nullptr;
   }
-  catch (exception e)
+  catch (exception& e)
   {
     unspecifiedExceptionJava(env, e);
     return nullptr;

--- a/src/jshim/jterminals.cc
+++ b/src/jshim/jterminals.cc
@@ -77,7 +77,7 @@ JOGRealScalar::~JOGRealScalar()
   try {
     unbindOGArrayData<real8, jdoubleArray>(this->_dataRef, _backingObject);
   }
-  catch (convert_error e)
+  catch (convert_error& e)
   {
     cerr << "Warning (~JOGRealScalar): convert_error thrown when unbinding Java array data" << endl;
   }
@@ -121,7 +121,7 @@ JOGComplexScalar::~JOGComplexScalar()
   try {
     unbindOGArrayData<complex16, jdoubleArray>(this->_dataRef, _backingObject);
   }
-  catch (convert_error e)
+  catch (convert_error& e)
   {
     cerr << "Warning (~JOGComplexScalar): convert_error thrown when unbinding Java array data" << endl;
   }
@@ -206,7 +206,7 @@ JOGRealDenseMatrix::~JOGRealDenseMatrix()
   try {
     unbindOGArrayData<real8, jdoubleArray>(this->getData(), _backingObject);
   }
-  catch (convert_error e)
+  catch (convert_error& e)
   {
     cerr << "Warning (~JOGRealDenseMatrix): convert_error thrown when unbinding Java array data" << endl;
   }
@@ -244,7 +244,7 @@ JOGComplexDenseMatrix::~JOGComplexDenseMatrix() {
   try {
     unbindOGArrayData<complex16, jdoubleArray>(this->getData(), _backingObject);
   }
-  catch (convert_error e)
+  catch (convert_error& e)
   {
     cerr << "Warning (~JOGComplexDenseMatrix): convert_error thrown when unbinding Java array data" << endl;
   }
@@ -283,7 +283,7 @@ JOGLogicalMatrix::~JOGLogicalMatrix()
   try {
     unbindOGArrayData<real8, jdoubleArray>(this->getData(), _backingObject);
   }
-  catch (convert_error e)
+  catch (convert_error& e)
   {
     cerr << "Warning (~JOGLogicalMatrix): convert_error thrown when unbinding Java array data" << endl;
   }
@@ -326,7 +326,7 @@ JOGRealSparseMatrix::~JOGRealSparseMatrix()
     unbindPrimitiveArrayData<jint, jintArray>(reinterpret_cast<jint*>(this->getRowIdx()), _backingObject, JVMManager::getOGSparseMatrixClazz_getRowIdx());
     unbindPrimitiveArrayData<jint, jintArray>(reinterpret_cast<jint*>(this->getColPtr()), _backingObject, JVMManager::getOGSparseMatrixClazz_getColPtr());
   }
-  catch (convert_error e)
+  catch (convert_error& e)
   {
     cerr << "Warning (~JOGRealSparseMatrix): convert_error thrown when unbinding Java array data" << endl;
   }
@@ -381,7 +381,7 @@ JOGComplexSparseMatrix::~JOGComplexSparseMatrix()
     unbindPrimitiveArrayData<jint, jintArray>(reinterpret_cast<jint*>(this->getRowIdx()), _backingObject, JVMManager::getOGSparseMatrixClazz_getRowIdx());
     unbindPrimitiveArrayData<jint, jintArray>(reinterpret_cast<jint*>(this->getColPtr()), _backingObject, JVMManager::getOGSparseMatrixClazz_getColPtr());
   }
-  catch (convert_error e)
+  catch (convert_error& e)
   {
     cerr << "Warning (~JOGComplexSparseMatrix): convert_error thrown when unbinding Java array data" << endl;
   }
@@ -432,7 +432,7 @@ JOGRealDiagonalMatrix::~JOGRealDiagonalMatrix()
   try {
     unbindOGArrayData<real8, jdoubleArray>(this->getData(), _backingObject);
   }
-  catch (convert_error e)
+  catch (convert_error& e)
   {
     cerr << "Warning (~JOGRealDiagonalMatrix): convert_error thrown when unbinding Java array data" << endl;
   }
@@ -471,7 +471,7 @@ JOGComplexDiagonalMatrix::~JOGComplexDiagonalMatrix()
   try {
     unbindOGArrayData<complex16, jdoubleArray>(this->getData(), _backingObject);
   }
-  catch (convert_error e)
+  catch (convert_error& e)
   {
     cerr << "Warning (~JOGRealDiagonalMatrix): convert_error thrown when unbinding Java array data" << endl;
   }

--- a/src/jshim/jvmmanager.cc
+++ b/src/jshim/jvmmanager.cc
@@ -44,7 +44,7 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *jvm, void __attribute__ ((unused)) *re
   try {
     JVMManager::initialize(jvm);
   }
-  catch (convert_error e)
+  catch (convert_error& e)
   {
     DEBUG_PRINT("Exception in JNI_OnLoad: %s\n.", e.what());
     return JNI_ERR;


### PR DESCRIPTION
Testing [MAT-474](https://opengamma.atlassian.net/browse/MAT-474) (assemble license docs into jar) highlighted that the OSX build is suffering from a problem where libraries linked with GCC's `-static-libc++` are still being dynamic linked to `libstdc++`. This ended up being a massive trudge through GCC and OSX system internals, the eventual fix is a return to dynamic linking on OSX only.

This changeset:
- Updates the GCC location on the OSX syslib builder as GCC 4.9.1 is now the version unified across the entire build system.
- Fixes up some instances of catching by value opposed to reference.
- Adds a missing `toString()` to `ComplexArrayContainer` that was needed during debugging.
- Switches OSX to use dynamic linking for `libstdc++` and to link using the 2 layer namespace.

A more thorough explanation for the last item is given in the commit message of e2e97ba. Basically, GCC bug, a few possible visibility bugs, a leaky system library and a raft of unknowns makes dynamic linking for `libstdc++` the sensible option on OSX at the present time.

Coverage:
No change worth reporting.
