### PR TITLE
MAT-474 add licenses into jar build

### DIFF
--- a/combine/combine.py
+++ b/combine/combine.py
@@ -221,7 +221,7 @@ def create_main_jar(newverinfo, verinfos):
 
     # Copy the platform-independent files into the main jar from the linux main jar
     nl = mainjar.namelist()
-    files = [ n for n in nl if (n[:3] == 'com' or n[:6] == 'config' or n[:8] == 'META-INF') and n[-1] != '/' ]
+    files = [ n for n in nl if (n[:3] == 'com' or n[:6] == 'config' or n[:8] == 'META-INF' or n[:8] == 'licenses') and n[-1] != '/' ]
     for f in files:
         if DEBUG:
             print "Adding %s to main jar" % f

--- a/src/java/src/main/CMakeLists.txt
+++ b/src/java/src/main/CMakeLists.txt
@@ -113,7 +113,10 @@ endforeach()
 include(${IZY_BUILDINFO})
 include(${LAPACK_BUILDINFO})
 
-# This sort out the licensing directory that gets bundled into the jar root
+# This cache is used to trigger dependencies in add_jar
+set(jar_licenses ${licensing_dirs} CACHE INTERNAL "The jar licenses")
+
+# This sorts out the licensing directory that gets bundled into the jar root
 add_custom_target (licensing_dirs
 # root level license dir (license_root_dir)
 COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/licenses
@@ -135,14 +138,21 @@ COMMAND ${CMAKE_COMMAND} -E copy_directory ${IZY_SRC_DIR}/licenses/ ${CMAKE_BINA
 
 # the OG-Lapack licenses go into (license_root_dir/licenses/OG-Lapack)
 COMMAND ${CMAKE_COMMAND} -E copy ${LAPACK_SRC_DIR}/LICENSE.txt ${CMAKE_BINARY_DIR}/licenses/OG-Lapack/LICENSE.txt
-
 COMMENT "Creating licensing directories"
 )
 
+# make it impossible to create native libs without also creating licenses
+# jar_native_libraries comes from the cache established by NativeLibraryBuilder
+foreach(item ${jar_native_libraries})
+  add_dependencies(${item} licensing_dirs)
+endforeach()
+set(jar_licenses ${licensing_dirs} CACHE INTERNAL "The jar licenses")
+
 add_jar(${JAR_NAME_NO_EXTN} ${JAR_SOURCES}
-        RESOURCES ${CMAKE_CURRENT_SOURCE_DIR}/config ${CMAKE_BINARY_DIR}/verinfo.yaml ${CMAKE_BINARY_DIR}/licenses
+        RESOURCES ${CMAKE_CURRENT_SOURCE_DIR}/config ${CMAKE_BINARY_DIR}/verinfo.yaml
         INCLUDE_NATIVE TRUE
-        DEPENDS verinfo licensing_dirs
+        INCLUDE_LICENSES TRUE
+        DEPENDS verinfo
         ENTRY_POINT com/opengamma/maths/nativeloader/NativeLibrariesSelfTest
         OUTPUT_DIR ${JARDIR})
 

--- a/src/java/src/main/CMakeLists.txt
+++ b/src/java/src/main/CMakeLists.txt
@@ -108,10 +108,41 @@ foreach(JFILE ${JAVA_FILES})
   set(JAR_SOURCES ${JAR_SOURCES} ${CMAKE_CURRENT_SOURCE_DIR}/java/${JPACKAGEDIR}/${JFILE})
 endforeach()
 
+
+#need these to get the external repo root dir locations
+include(${IZY_BUILDINFO})
+include(${LAPACK_BUILDINFO})
+
+# This sort out the licensing directory that gets bundled into the jar root
+add_custom_target (licensing_dirs
+# root level license dir (license_root_dir)
+COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/licenses
+# where OG-Maths licenses will live (license_root_dir/licenses)
+COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/licenses/licenses
+# where OG-Izy licenses will live (license_root_dir/licenses/OG-Izy)
+COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/licenses/OG-Izy
+# where OG-Lapack licenses will live (license_root_dir/licenses/OG-Izy)
+COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/licenses/OG-Lapack
+
+# the OG-Maths license goes into the license_root_dir
+COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/LICENSE.txt ${CMAKE_BINARY_DIR}/licenses/LICENSE.txt
+# the OG-Maths licenses directory goes into the license_root_dir/licenses
+COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/licenses/ ${CMAKE_BINARY_DIR}/licenses/licenses/
+
+# the OG-Izy licenses go into (license_root_dir/licenses/OG-Izy)
+COMMAND ${CMAKE_COMMAND} -E copy ${IZY_SRC_DIR}/LICENSE.txt ${CMAKE_BINARY_DIR}/licenses/OG-Izy/LICENSE.txt
+COMMAND ${CMAKE_COMMAND} -E copy_directory ${IZY_SRC_DIR}/licenses/ ${CMAKE_BINARY_DIR}/licenses/OG-Izy
+
+# the OG-Lapack licenses go into (license_root_dir/licenses/OG-Lapack)
+COMMAND ${CMAKE_COMMAND} -E copy ${LAPACK_SRC_DIR}/LICENSE.txt ${CMAKE_BINARY_DIR}/licenses/OG-Lapack/LICENSE.txt
+
+COMMENT "Creating licensing directories"
+)
+
 add_jar(${JAR_NAME_NO_EXTN} ${JAR_SOURCES}
-        RESOURCES ${CMAKE_CURRENT_SOURCE_DIR}/config ${CMAKE_BINARY_DIR}/verinfo.yaml
+        RESOURCES ${CMAKE_CURRENT_SOURCE_DIR}/config ${CMAKE_BINARY_DIR}/verinfo.yaml ${CMAKE_BINARY_DIR}/licenses
         INCLUDE_NATIVE TRUE
-        DEPENDS verinfo
+        DEPENDS verinfo licensing_dirs
         ENTRY_POINT com/opengamma/maths/nativeloader/NativeLibrariesSelfTest
         OUTPUT_DIR ${JARDIR})
 

--- a/src/java/src/main/java/com/opengamma/maths/DOGMA.java
+++ b/src/java/src/main/java/com/opengamma/maths/DOGMA.java
@@ -92,8 +92,8 @@ public final class DOGMA {
    * Instantiates a new OGComplexScalar with the real part taken from the numerical
    * value extracted from an object of the java Number class. The imaginary part is
    * set to zero.
-   * @param num the number from which to create the real part of the complex scalar.
-   * @return an OGComplexScalar representing {@code num}.
+   * @param real the number from which to create the real part of the complex scalar.
+   * @return an OGComplexScalar representing {@code real}.
    */
 
   public static OGTerminal C(Number real) {
@@ -113,7 +113,7 @@ public final class DOGMA {
    * the numerical value extracted from objects of the java Number class. 
    * @param real the number from which to create the real part of the complex scalar.
    * @param imag the number from which to create the imaginary part of the complex scalar.
-   * @return an OGComplexScalar representing {@code num}.
+   * @return an OGComplexScalar representing {@code real+i*imag}.
    */
   public static OGTerminal C(Number real, Number imag) {
     return new OGComplexScalar(real, imag);
@@ -597,8 +597,7 @@ public final class DOGMA {
    * is a single number it is applied as a scaling, whereas if both arguments 
    * are the same dimension element wise multiplication takes place.
    * <p>
-   * @param arg0 The first argument to multiply.
-   * @param arg1 The second argument to multiply
+   * @param args the arguments to times.
    *
    * @return The element wise multiplication of the first argument by all subsequent arguments.
    */

--- a/src/java/src/main/java/com/opengamma/maths/datacontainers/other/ComplexArrayContainer.java
+++ b/src/java/src/main/java/com/opengamma/maths/datacontainers/other/ComplexArrayContainer.java
@@ -67,7 +67,7 @@ public class ComplexArrayContainer {
 
   /**
    * Returns true if any part of the imaginary data is nonzero
-   * @return
+   * @return true if any part of the imaginary data is nonzero
    */
   public boolean anyImaginary() {
     return _anyImag;

--- a/src/java/src/main/java/com/opengamma/maths/fuzzer/FixedSizeFIFO.java
+++ b/src/java/src/main/java/com/opengamma/maths/fuzzer/FixedSizeFIFO.java
@@ -29,7 +29,7 @@ public class FixedSizeFIFO<T> {
    * The capacity of this container
    */
   private int _capacity;
-  
+
   /**
    * The list that acts as backing storage for this container.
    */
@@ -55,7 +55,7 @@ public class FixedSizeFIFO<T> {
   /**
    * Add an element to the container, if the container is at capacity then the oldest
    * element in the container is dropped and the new added.
-   * @param element
+   * @param element the element to add.
    */
   public void add(T element) {
     if (_backing.size() == _capacity) {

--- a/src/java/src/main/java/com/opengamma/maths/fuzzer/FuzzerMain.java
+++ b/src/java/src/main/java/com/opengamma/maths/fuzzer/FuzzerMain.java
@@ -35,6 +35,7 @@ public class FuzzerMain {
 
   /**
    * Gets the singleton instance of this class.
+   * @return the instance of FuzzerMain.
    */
   public static FuzzerMain getInstance() {
     return FuzzerMainRefHolder.s_ref;

--- a/src/java/src/main/java/com/opengamma/maths/fuzzer/ThreadedTreeFuzzer.java
+++ b/src/java/src/main/java/com/opengamma/maths/fuzzer/ThreadedTreeFuzzer.java
@@ -72,8 +72,11 @@ public class ThreadedTreeFuzzer implements Fuzzer {
   /**
    * Sets up internal state of dogma methods via reflection.
    * @param startSeed the start seed for the RNG
-   * @param maxTreeRefs
-   * @param maxDataSize
+   * @param maxTreeRefs the maximum number of references permitted in a tree.
+   * @param maxDataSize the maximum data size permitted in an element of the tree.
+   * @param nthreads the number of threads, each will contain it's own fuzzing instance.
+   * @param logging true to log, false to not.
+   * @param logDir the directory for logs, applicable if {@code logging} is true.
    */
   public ThreadedTreeFuzzer(long startSeed, int maxTreeRefs, int maxDataSize, int nthreads, boolean logging, File logDir) {
     _startSeed = startSeed;


### PR DESCRIPTION
This PR, to be read in conjunction with https://github.com/OpenGamma/OG-Izy/pull/12 and https://github.com/OpenGamma/OG-Lapack/pull/15:
- Adds the approved license directory structure into all jars and then from the linux jar into the combined jar.
- Forces the build dependencies such that items created by the `NativeLibraryBuilder` cannot be built without assembling the licenses correctly.
- Adds code to import licenses from OG-Izy and OG-Lapack.
- Fixes some minor javadoc issues that were causing compilation failure locally.

Coverage:
No change.
