### PR TITLE
Mat 476 adding deploy target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,6 +293,18 @@ add_custom_target(maven_install
                           -Dsources=${JAR_SOURCES_NAME}
                   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/jars)
 
+# Test deploy to local maven repository
+add_custom_target(maven_test_deploy
+                  COMMAND mvn -X deploy:deploy-file
+                          -Durl=file:///${CMAKE_BINARY_DIR}/deploy_test
+                          -DrepositoryId=release
+                          -DpomFile=${CMAKE_SOURCE_DIR}/src/java/pom.xml
+                          -Dfile=${JAR_NAME}
+                          -Djavadoc=${JAR_JAVADOC_NAME}
+                          -Dsources=${JAR_SOURCES_NAME}
+                  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/jars
+)
+
 message("Build type: " ${CMAKE_BUILD_TYPE})
 
 message("

--- a/src/java/pom.xml
+++ b/src/java/pom.xml
@@ -39,6 +39,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
+      <version>1.7.7</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
This PR:
- Adds a custom maven deployment test target. This is now called by the build system as the final step to check that the provided `pom.xml` is at least parseable!
- Specifies a version of slf4j required for the OG-Maths jar.

Coverage:
No change.
