### PR TITLE
[MAT-479] Add requirement for finite system to mldivide.

### DIFF
--- a/src/librdag/runners/mldividerunner.cc
+++ b/src/librdag/runners/mldividerunner.cc
@@ -481,7 +481,12 @@ mldivide_dense_runner(RegContainer& reg0, shared_ptr<const OGMatrix<T>> arg0, sh
   {
     stringstream msg;
     msg << "System does not commute. Rows in arg0: " << rows1 << ". Rows in arg1 " << rows2 << std::endl;
-    throw rdag_error(msg.str());
+    throw rdag_unrecoverable_error(msg.str());
+  }
+  // and that system matrix is finite
+  if(!isfinite(data1, rows1*cols1))
+  {
+    throw rdag_unrecoverable_error("System matrix contains data which is not finite. Solution(s) can only be obtained using finite data.");
   }
 
   // check for all zeros system matrix, quick return if so

--- a/src/librdag/test/nodes/check_mldivide.cc
+++ b/src/librdag/test/nodes/check_mldivide.cc
@@ -585,6 +585,15 @@ TEST(MLDIVIDETests, CheckBadCommuteThrows) {
   OGExpr::Ptr node = MLDIVIDE::create(m1, m2);
   ASSERT_THROW(
   runtree(node),
-  rdag_error);
+  rdag_unrecoverable_error);
+}
+
+TEST(MLDIVIDETests, CheckNonFiniteSystemMatrixThrows) {
+  OGNumeric::Ptr m1 = OGRealDenseMatrix::create(new real8[6]{std::numeric_limits<real8>::signaling_NaN(),3,5,2,4,6},3,2,OWNER);
+  OGNumeric::Ptr m2 = OGRealDenseMatrix::create(new real8[7]{10,30,20,40,50,60},3,2,OWNER);
+  OGExpr::Ptr node = MLDIVIDE::create(m1, m2);
+  ASSERT_THROW(
+  runtree(node),
+  rdag_unrecoverable_error);
 }
 


### PR DESCRIPTION
This adds a scan of the system matrix to the mldivide function.
This scan will cause an exception to be raised if the matrix
contains non-finite data. The reason for this behavior is to
prevent LAPACK solvers receiving data containing inf/NaN as it
makes them do rightly bizarre things.

Coverage:
Java: 82% (no change)
build/src/jshim 0.8% (no change)
build/src/librdag 40.8% (no change)
src/jshim 53.1% (no change)
src/librdag 85.9%  (no change)
src/librdag/runners 96.1% (up 0.3%).
