### PR TITLE
[MAT-483] Adds testng and bumps version to 0.2.0-SNAPSHOT

### DIFF
--- a/src/java/pom.xml
+++ b/src/java/pom.xml
@@ -14,7 +14,7 @@
 
   <groupId>com.opengamma.maths</groupId>
   <artifactId>og-maths</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>OpenGamma Maths Library</name>
@@ -40,6 +40,10 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>1.7.7</version>
+    </dependency>
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
This updates the `pom.xml` with the new release version and adds a dependency to TestNG for the compiled test jar.

Coverage:
No change, patch is to infrastructure only.
